### PR TITLE
ResourceAllocator implements AllocatorBase.

### DIFF
--- a/src/d3d12/ResourceAllocationD3D12.h
+++ b/src/d3d12/ResourceAllocationD3D12.h
@@ -36,6 +36,14 @@ namespace gpgmm { namespace d3d12 {
                            uint64_t offset,
                            ComPtr<ID3D12Resource> resource,
                            Heap* heap);
+
+        ResourceAllocation(ResidencyManager* residencyManager,
+                           ResourceAllocator* resourceAllocator,
+                           const AllocationInfo& info,
+                           uint64_t offset,
+                           ComPtr<ID3D12Resource> resource,
+                           Heap* heap);
+
         ~ResourceAllocation() override = default;
         ResourceAllocation(const ResourceAllocation&) = default;
         ResourceAllocation& operator=(const ResourceAllocation&) = default;
@@ -51,6 +59,7 @@ namespace gpgmm { namespace d3d12 {
         void ReleaseThis() override;
 
       private:
+        ResourceAllocator* mResourceAllocator;
         ResidencyManager* mResidencyManager;
         ComPtr<ID3D12Resource> mResource;
     };

--- a/src/d3d12/ResourceAllocatorD3D12.h
+++ b/src/d3d12/ResourceAllocatorD3D12.h
@@ -16,7 +16,7 @@
 #ifndef GPGMM_D3D12_RESOURCEALLOCATORD3D12_H_
 #define GPGMM_D3D12_RESOURCEALLOCATORD3D12_H_
 
-#include "src/MemoryAllocator.h"
+#include "src/Allocator.h"
 #include "src/d3d12/ResourceAllocationD3D12.h"
 
 #include <array>
@@ -136,7 +136,7 @@ namespace gpgmm {
 
         // Manages a list of resource allocators used by the device to create resources using
         // multiple allocation methods.
-        class ResourceAllocator : public MemoryAllocator {
+        class ResourceAllocator : public AllocatorBase {
           public:
             ResourceAllocator(const ALLOCATOR_DESC& descriptor);
             ~ResourceAllocator() override;
@@ -156,12 +156,6 @@ namespace gpgmm {
             friend ResourceHeapAllocator;
             friend ResourceAllocation;
 
-            // MemoryAllocator interface
-            std::unique_ptr<MemoryAllocation> AllocateMemory(uint64_t size,
-                                                             uint64_t alignment) override;
-            void DeallocateMemory(MemoryAllocation* allocation) override;
-            void ReleaseMemory() override;
-
             HRESULT CreatePlacedResource(const MemoryAllocation& subAllocation,
                                          const D3D12_RESOURCE_ALLOCATION_INFO resourceInfo,
                                          const D3D12_RESOURCE_DESC* resourceDescriptor,
@@ -169,8 +163,7 @@ namespace gpgmm {
                                          D3D12_RESOURCE_STATES initialUsage,
                                          ResourceAllocation** ppResourceAllocation);
 
-            HRESULT CreateCommittedResource(const MemoryAllocation& subAllocation,
-                                            D3D12_HEAP_TYPE heapType,
+            HRESULT CreateCommittedResource(D3D12_HEAP_TYPE heapType,
                                             D3D12_HEAP_FLAGS heapFlags,
                                             const D3D12_RESOURCE_ALLOCATION_INFO& resourceInfo,
                                             const D3D12_RESOURCE_DESC* resourceDescriptor,
@@ -184,6 +177,8 @@ namespace gpgmm {
                                        DXGI_MEMORY_SEGMENT_GROUP memorySegment,
                                        uint64_t heapAlignment,
                                        Heap** ppResourceHeap);
+
+            void FreeResourceHeap(Heap* resourceHeap);
 
             ComPtr<ID3D12Device> mDevice;
 

--- a/src/d3d12/ResourceHeapAllocatorD3D12.cpp
+++ b/src/d3d12/ResourceHeapAllocatorD3D12.cpp
@@ -45,7 +45,9 @@ namespace gpgmm { namespace d3d12 {
     }
 
     void ResourceHeapAllocator::DeallocateMemory(MemoryAllocation* allocation) {
-        mResourceAllocator->DeallocateMemory(allocation);
+        ASSERT(allocation != nullptr);
+        Heap* heap = static_cast<Heap*>(allocation->GetMemory());
+        mResourceAllocator->FreeResourceHeap(heap);
     }
 
 }}  // namespace gpgmm::d3d12


### PR DESCRIPTION

Avoids mixing memory and resource allocator interfaces.