### PR TITLE
Prevent ending Dawn-GPGMM workflow prematurely.

### DIFF
--- a/.github/workflows/win_dawn_rel.yaml
+++ b/.github/workflows/win_dawn_rel.yaml
@@ -70,6 +70,7 @@ jobs:
 
     - name: Run dawn_end2end_tests
       shell: cmd
+      continue-on-error: true
       run: |
         cd base
         out\Release\dawn_end2end_tests.exe --backend=d3d12 --exclusive-device-type-preference=discrete,integrated,cpu --enable-backend-validation=partial --gtest_output=json:${{ github.workspace }}\..\baseline_end2end_tests.json
@@ -111,6 +112,7 @@ jobs:
 
     - name: Run dawn_end2end_tests (with patch)
       shell: cmd
+      continue-on-error: true
       run: |
         cd test
         out\Release\dawn_end2end_tests.exe --backend=d3d12 --exclusive-device-type-preference=discrete,integrated,cpu --enable-backend-validation=partial --gtest_output=json:${{ github.workspace }}\..\test_end2end_tests.json || true


### PR DESCRIPTION
Unhandled Dawn E2E failures with WARP are prematurely ending the workflow. Since the workflow is only testing for regressions, they can be safely ignored.