### PR TITLE
Improve ResidencyManager error checks.

### DIFF
--- a/src/d3d12/ResidencyManagerD3D12.h
+++ b/src/d3d12/ResidencyManagerD3D12.h
@@ -45,7 +45,7 @@ namespace gpgmm { namespace d3d12 {
         ~ResidencyManager();
 
         HRESULT LockHeap(Heap* heap);
-        void UnlockHeap(Heap* heap);
+        HRESULT UnlockHeap(Heap* heap);
 
         HRESULT Evict(uint64_t allocationSize,
                       const DXGI_MEMORY_SEGMENT_GROUP& memorySegmentGroup,


### PR DESCRIPTION
Return hr error if heap does not exist so client can decide to handle it (ignore or ASSERT).