### PR TITLE
Move residency cache into own type.

### DIFF
--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -173,6 +173,8 @@ source_set("gpgmm_sources") {
       "d3d12/IUnknownImplD3D12.h",
       "d3d12/JSONSerializerD3D12.cpp",
       "d3d12/JSONSerializerD3D12.h",
+      "d3d12/ResidencyCacheD3D12.cpp",
+      "d3d12/ResidencyCacheD3D12.h",
       "d3d12/ResidencyManagerD3D12.cpp",
       "d3d12/ResidencyManagerD3D12.h",
       "d3d12/ResidencySetD3D12.cpp",

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,6 +76,8 @@ if (GPGMM_ENABLE_D3D12)
         "d3d12/JSONSerializerD3D12.h"
         "d3d12/ResidencyManagerD3D12.cpp"
         "d3d12/ResidencyManagerD3D12.h"
+        "d3d12/ResidencyCacheD3D12.cpp"
+        "d3d12/ResidencyCacheD3D12.h"
         "d3d12/ResidencySetD3D12.cpp"
         "d3d12/ResidencySetD3D12.h"
         "d3d12/ResourceAllocationD3D12.cpp"

--- a/src/d3d12/ResidencyCacheD3D12.cpp
+++ b/src/d3d12/ResidencyCacheD3D12.cpp
@@ -1,0 +1,41 @@
+// Copyright 2021 The GPGMM Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/d3d12/ResidencyCacheD3D12.h"
+#include "src/d3d12/HeapD3D12.h"
+
+namespace gpgmm { namespace d3d12 {
+
+    bool ResidencyCache::Insert(Heap* heap) {
+        if (heap->IsInList()) {
+            return false;
+        }
+
+        mCache.Append(heap);
+        return true;
+    }
+
+    Heap* ResidencyCache::GetNext() const {
+        if (mCache.empty()) {
+            return nullptr;
+        }
+
+        return mCache.head()->value();
+    }
+
+    void ResidencyCache::Remove(Heap* heap) {
+        heap->RemoveFromList();
+    }
+
+}}  // namespace gpgmm::d3d12

--- a/src/d3d12/ResidencyCacheD3D12.h
+++ b/src/d3d12/ResidencyCacheD3D12.h
@@ -1,0 +1,38 @@
+// Copyright 2021 The GPGMM Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GPGMM_D3D12_RESIDENCYCACHED3D12_H_
+#define GPGMM_D3D12_RESIDENCYCACHED3D12_H_
+
+#include "../common/LinkedList.h"
+
+namespace gpgmm { namespace d3d12 {
+
+    class Heap;
+
+    class ResidencyCache {
+      public:
+        bool Insert(Heap* heap);
+        void Remove(Heap* heap);
+        Heap* GetNext() const;
+
+      private:
+        using Cache = LinkedList<Heap>;
+
+        Cache mCache;
+    };
+
+}}  // namespace gpgmm::d3d12
+
+#endif  // GPGMM_D3D12_RESIDENCYCACHED3D12_H_

--- a/src/d3d12/ResidencyManagerD3D12.cpp
+++ b/src/d3d12/ResidencyManagerD3D12.cpp
@@ -194,40 +194,6 @@ namespace gpgmm { namespace d3d12 {
         return S_OK;
     }
 
-    // Removes a heap from the LRU and returns the least recently used heap when possible. Returns
-    // nullptr when nothing further can be evicted.
-    HRESULT ResidencyManager::EvictHeap(const Cache& cache, Heap** heapOut) {
-        // If the LRU is empty, return nullptr to allow execution to continue. Note that fully
-        // emptying the LRU is undesirable, because it can mean either 1) the LRU is not accurately
-        // accounting for Dawn's GPU allocations, or 2) a component external to Dawn is using all of
-        // the process budget and starving Dawn, which will cause thrash.
-        if (cache.empty()) {
-            return S_OK;
-        }
-
-        Heap* heap = cache.head()->value();
-
-        const uint64_t lastUsedFenceValue = heap->GetLastUsedFenceValue();
-
-        // If the next candidate for eviction was inserted into the LRU during the pending
-        // submission, it is because more memory is being used in a single command list than is
-        // available. In this scenario, we cannot make any more resources resident and thrashing
-        // must occur.
-        if (lastUsedFenceValue == mFence->GetCurrentFence()) {
-            return S_OK;
-        }
-
-        // We must ensure that any previous use of a resource has completed before the resource can
-        // be evicted.
-        ReturnIfFailed(mFence->WaitFor(lastUsedFenceValue));
-
-        heap->RemoveFromList();
-
-        *heapOut = heap;
-
-        return S_OK;
-    }
-
     // Any time we need to make something resident, we must check that we have enough free memory to
     // make the new object resident while also staying within budget. If there isn't enough
     // memory, we should evict until there is. Returns the number of bytes evicted.
@@ -251,13 +217,24 @@ namespace gpgmm { namespace d3d12 {
             currentUsageAfterMakeResident - memorySegmentInfo->budget;
         uint64_t sizeEvicted = 0;
         while (sizeEvicted < sizeNeededToBeUnderBudget) {
-            Heap* heap = nullptr;
-            ReturnIfFailed(EvictHeap(memorySegmentInfo->lruCache, &heap));
-
+            Heap* heap = memorySegmentInfo->cache.GetNext();
             // If no heap was returned, then nothing more can be evicted.
             if (heap == nullptr) {
                 break;
             }
+
+            // If the heap being evicted was inserted into the cache during the pending
+            // submission, it is because more memory is being used in a single command list than is
+            // available. In this scenario, we cannot make any more resources resident and thrashing
+            // must occur.
+            const uint64_t lastUsedFenceValue = heap->GetLastUsedFenceValue();
+            if (lastUsedFenceValue == mFence->GetCurrentFence()) {
+                break;
+            }
+
+            // Remove the heap from the cache once the GPU is done with it.
+            ReturnIfFailed(mFence->WaitFor(lastUsedFenceValue));
+            memorySegmentInfo->cache.Remove(heap);
 
             sizeEvicted += heap->GetSize();
             resourcesToEvict.push_back(heap->GetPageable());
@@ -389,16 +366,12 @@ namespace gpgmm { namespace d3d12 {
             return E_INVALIDARG;
         }
 
-        // Heap already exists in the cache.
-        if (heap->IsInList()) {
-            return E_INVALIDARG;
-        }
-
         MemorySegmentInfo* memorySegment = GetMemorySegmentInfo(heap->GetMemorySegmentGroup());
         ASSERT(memorySegment != nullptr);
 
-        memorySegment->lruCache.Append(heap);
-        ASSERT(heap->IsInList());
+        if (!memorySegment->cache.Insert(heap)) {
+            return E_INVALIDARG;
+        }
 
         return S_OK;
     }

--- a/src/d3d12/ResidencyManagerD3D12.h
+++ b/src/d3d12/ResidencyManagerD3D12.h
@@ -16,7 +16,7 @@
 #ifndef GPGMM_D3D12_RESIDENCYMANAGERD3D12_H_
 #define GPGMM_D3D12_RESIDENCYMANAGERD3D12_H_
 
-#include "../common/LinkedList.h"
+#include "src/d3d12/ResidencyCacheD3D12.h"
 
 #include "src/d3d12/d3d12_platform.h"
 
@@ -71,18 +71,14 @@ namespace gpgmm { namespace d3d12 {
                          float memorySegmentBudgetLimit,
                          uint64_t totalResourceBudgetLimit);
 
-        using Cache = LinkedList<Heap>;
-
         struct MemorySegmentInfo {
             const DXGI_MEMORY_SEGMENT_GROUP group;
-            Cache lruCache = {};
+            ResidencyCache cache = {};
             uint64_t budget = 0;
             uint64_t currentUsage = 0;
             uint64_t currentReservation = 0;
             uint64_t reservation = 0;
         };
-
-        HRESULT EvictHeap(const Cache& cache, Heap** heapOut);
 
         HRESULT MakeResident(const DXGI_MEMORY_SEGMENT_GROUP memorySegmentGroup,
                              uint64_t sizeToMakeResident,


### PR DESCRIPTION
Moves residency cache functions into dedicated type so non-cache functions can be better inlined where used.