### PR TITLE
Fix access violation when destroying IUnknownImpl.

### DIFF
--- a/src/common/RefCount.h
+++ b/src/common/RefCount.h
@@ -29,7 +29,7 @@ namespace gpgmm {
         void Ref();
 
         // Decrements ref by one. If count is positive, returns false.
-        // Otherwise, when it reaches zero, returns true and deletes this.
+        // Otherwise, when it reaches zero, returns true.
         bool Unref();
 
         // Get the reference count.

--- a/src/d3d12/IUnknownImplD3D12.cpp
+++ b/src/d3d12/IUnknownImplD3D12.cpp
@@ -41,10 +41,11 @@ namespace gpgmm { namespace d3d12 {
     }
 
     ULONG IUnknownImpl::Release() {
-        if (Unref()) {
+        const ULONG refCount = Unref() ? 0 : RefCount();
+        if (refCount == 0) {
             DeleteThis();
         }
-        return RefCount();
+        return refCount;
     }
 
     void IUnknownImpl::DeleteThis() {


### PR DESCRIPTION

IUnknownImpl::Release would read its refcount after it was destroyed which randomly caused an access exception to occur.