### PR TITLE
Do not leak failed memory allocations.

### DIFF
--- a/src/MemoryAllocator.cpp
+++ b/src/MemoryAllocator.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "src/MemoryAllocator.h"
-#include "common/Assert.h"
 
 namespace gpgmm {
 


### PR DESCRIPTION

Implements TrySubAllocateMemory so memory allocations do not leak when they fail.