### PR TITLE
Validate mapping of suballocation within resources.

### DIFF
--- a/src/BuddyMemoryAllocator.cpp
+++ b/src/BuddyMemoryAllocator.cpp
@@ -101,9 +101,6 @@ namespace gpgmm {
         ASSERT(subAllocation != nullptr);
 
         const AllocationInfo info = subAllocation->GetInfo();
-
-        ASSERT(info.Method == AllocationMethod::kSubAllocated);
-
         const uint64_t memoryIndex = GetMemoryIndex(info.Block->Offset);
 
         mBuddyBlockAllocator.DeallocateBlock(info.Block);

--- a/src/MemoryAllocation.h
+++ b/src/MemoryAllocation.h
@@ -30,8 +30,11 @@ namespace gpgmm {
         // Not sub-divided.
         kStandalone,
 
-        // Sub-divided using one or more blocks.
+        // Sub-divided using one or more memory allocations.
         kSubAllocated,
+
+        // Sub-divided within a single memory allocation.
+        kSubAllocatedWithin,
 
         // Not yet allocated or invalid.
         kUndefined

--- a/src/d3d12/ResourceAllocationD3D12.h
+++ b/src/d3d12/ResourceAllocationD3D12.h
@@ -50,8 +50,11 @@ namespace gpgmm { namespace d3d12 {
         // Gets the CPU pointer to the specificed subresource of the resource allocation.
         // If sub-allocated within the resource, the read or write range and
         // pointer value will start from the allocation instead of the resource.
-        HRESULT Map(uint32_t subresource, const D3D12_RANGE* readRange, void** dataOut);
-        void Unmap(uint32_t subresource, const D3D12_RANGE* writtenRange);
+        HRESULT Map(uint32_t subresource = 0,
+                    const D3D12_RANGE* readRange = nullptr,
+                    void** dataOut = nullptr);
+
+        void Unmap(uint32_t subresource = 0, const D3D12_RANGE* writtenRange = nullptr);
 
         // Returns the resource owned by this allocation.
         ID3D12Resource* GetResource() const;

--- a/src/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/d3d12/ResourceAllocatorD3D12.cpp
@@ -428,6 +428,9 @@ namespace gpgmm { namespace d3d12 {
                     Heap* resourceHeap = static_cast<Heap*>(subAllocation.GetMemory());
                     ReturnIfFailed(resourceHeap->GetPageable().As(&committedResource));
 
+                    AllocationInfo info = subAllocation.GetInfo();
+                    info.Method = AllocationMethod::kSubAllocatedWithin;
+
                     *resourceAllocationOut = new ResourceAllocation{
                         mResidencyManager.get(),      subAllocator,
                         subAllocation.GetInfo(),      subAllocation.GetInfo().Offset,


### PR DESCRIPTION

ResourceAllocation::Map now verifies if subresource-relative coordinates were specified and errors if the resource was suballocated within.