### PR TITLE
Rename gpgmm::d3d12::ALLOCATOR_FLAGS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 New
-- `gpgmm::d3d12::ALLOCATOR_FLAGS::ALLOCATOR_ALWAYS_COMMITED` flag to help troubleshoot problems from using placed resource based sub-allocation.
-- `gpgmm::d3d12::ALLOCATOR_FLAGS::ALLOCATOR_ALWAYS_IN_BUDGET` flag to help troubleshoot
+- `gpgmm::d3d12::ALLOCATOR_FLAGS::ALLOCATOR_FLAG_ALWAYS_COMMITED` flag to help troubleshoot problems from using placed resource based sub-allocation.
+- `gpgmm::d3d12::ALLOCATOR_FLAGS::ALLOCATOR_FLAG_ALWAYS_IN_BUDGET` flag to help troubleshoot
 problems from over committing when using residency.
 
 - `gpgmm::d3d12::ALLOCATOR_DESC::[PreferredResourceHeapSize|MaxResourceHeapSize]` option(s) to specify the (preferred) min and/or max heap sizes, respectively (vs hard coded).

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ allocation.Release();
 ```
 
 To use basic residency:
-1. Create a `d3d12::ResourceAllocator` with `ALLOCATOR_ALWAYS_IN_BUDGET` flag.
+1. Create a `d3d12::ResourceAllocator` with `ALLOCATOR_FLAG_ALWAYS_IN_BUDGET` flag.
 2. Use `d3d12::ResourceAllocator::CreateResource` for every resource you want residency managed.
 3. Create a `d3d12::ResidencySet` to track a collection of allocations that should be resident for a given command-list (1:1 relationship).
 4. `d3d12::ResourceAllocation::UpdateResidency` tracks the underlying heap for the resident set.

--- a/patches/gpgmm_dawn.diff
+++ b/patches/gpgmm_dawn.diff
@@ -417,7 +417,7 @@ index 3b96092e..5ef2c02d 100644
 +        allocatorDesc.MaxResourceSizeForPooling = 0;                          // Always pool heaps
 +
 +        if (IsToggleEnabled(Toggle::UseD3D12ResidencyManagement)) {
-+            allocatorDesc.Flags = gpgmm::d3d12::ALLOCATOR_ALWAYS_IN_BUDGET;
++            allocatorDesc.Flags = gpgmm::d3d12::ALLOCATOR_FLAG_ALWAYS_IN_BUDGET;
 +            allocatorDesc.MaxVideoMemoryBudget = 0.95;  // Use up to 95%.
 +        }
 +

--- a/src/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/d3d12/ResourceAllocatorD3D12.cpp
@@ -248,7 +248,8 @@ namespace gpgmm { namespace d3d12 {
             return E_INVALIDARG;
         }
 
-        bool enableEventTracer = descriptor.RecordOptions.Flags & ALLOCATOR_RECORD_TRACE_EVENTS;
+        bool enableEventTracer =
+            descriptor.RecordOptions.Flags & ALLOCATOR_RECORD_FLAG_TRACE_EVENTS;
 #ifdef GPGMM_ALWAYS_RECORD_EVENT_TRACE
         enableEventTracer = true;
 #endif
@@ -280,8 +281,8 @@ namespace gpgmm { namespace d3d12 {
           mResidencyManager(std::move(residencyManager)),
           mIsUMA(descriptor.IsUMA),
           mResourceHeapTier(descriptor.ResourceHeapTier),
-          mIsAlwaysCommitted(descriptor.Flags & ALLOCATOR_ALWAYS_COMMITED),
-          mIsAlwaysInBudget(descriptor.Flags & ALLOCATOR_ALWAYS_IN_BUDGET),
+          mIsAlwaysCommitted(descriptor.Flags & ALLOCATOR_FLAG_ALWAYS_COMMITED),
+          mIsAlwaysInBudget(descriptor.Flags & ALLOCATOR_FLAG_ALWAYS_IN_BUDGET),
           mMaxResourceHeapSize((descriptor.MaxResourceHeapSize > 0) ? descriptor.MaxResourceHeapSize
                                                                     : kDefaultMaxResourceHeapSize) {
         GPGMM_OBJECT_NEW_INSTANCE("ResourceAllocator", this);

--- a/src/d3d12/ResourceAllocatorD3D12.h
+++ b/src/d3d12/ResourceAllocatorD3D12.h
@@ -43,26 +43,26 @@ namespace gpgmm { namespace d3d12 {
 
         // Forces standalone committed resource creation. Useful to debug problems with
         // suballocation or needing to create very big resources.
-        ALLOCATOR_ALWAYS_COMMITED = 0x1,
+        ALLOCATOR_FLAG_ALWAYS_COMMITED = 0x1,
 
         // Ensures resources are always within the resource budget at creation time. Mostly used
         // to debug with residency being over committed.
-        ALLOCATOR_ALWAYS_IN_BUDGET = 0x2,
+        ALLOCATOR_FLAG_ALWAYS_IN_BUDGET = 0x2,
 
     } ALLOCATOR_FLAGS;
 
     typedef enum ALLOCATOR_RECORD_FLAGS {
 
         // Disables all recording flags. Enabled by default.
-        ALLOCATOR_RECORD_FLAGS_NONE = 0x0,
+        ALLOCATOR_RECORD_FLAG_NONE = 0x0,
 
         // Configures event-based tracing using the Trace Event API.
-        ALLOCATOR_RECORD_TRACE_EVENTS = 0x1,
+        ALLOCATOR_RECORD_FLAG_TRACE_EVENTS = 0x1,
 
     } ALLOCATOR_RECORD_FLAGS;
 
     struct ALLOCATOR_RECORD_OPTIONS {
-        ALLOCATOR_RECORD_FLAGS Flags = ALLOCATOR_RECORD_FLAGS_NONE;
+        ALLOCATOR_RECORD_FLAGS Flags = ALLOCATOR_RECORD_FLAG_NONE;
 
         // Path to trace file. Default is trace.json.
         const char* TraceFile = nullptr;

--- a/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
+++ b/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
@@ -142,7 +142,7 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferInvalidDesc) {
 
 TEST_F(D3D12ResourceAllocatorTests, CreateBufferAlwaysCommittedFlag) {
     ALLOCATOR_DESC desc = CreateBasicAllocatorDesc();
-    desc.Flags = ALLOCATOR_ALWAYS_COMMITED;
+    desc.Flags = ALLOCATOR_FLAG_ALWAYS_COMMITED;
 
     ComPtr<ResourceAllocator> allocator;
     ASSERT_SUCCEEDED(ResourceAllocator::CreateAllocator(desc, &allocator));


### PR DESCRIPTION

Changes the named prefix "ALLOCATOR_" to "ALLOCATOR_FLAG_" for consistency.