### PR TITLE
Prefer using the D3D12 resource heap enum type.

### DIFF
--- a/patches/gpgmm_dawn.diff
+++ b/patches/gpgmm_dawn.diff
@@ -411,7 +411,7 @@ index 3b96092e..5ef2c02d 100644
 +        allocatorDesc.Adapter = adapter->GetHardwareAdapter();
 +        allocatorDesc.Device = mD3d12Device;
 +        allocatorDesc.IsUMA = adapter->GetDeviceInfo().isUMA;
-+        allocatorDesc.ResourceHeapTier = adapter->GetDeviceInfo().resourceHeapTier;
++        allocatorDesc.ResourceHeapTier =  static_cast<D3D12_RESOURCE_HEAP_TIER>(adapter->GetDeviceInfo().resourceHeapTier);
 +        allocatorDesc.PreferredResourceHeapSize = 4ll * 1024ll * 1024ll;      // 4MB
 +        allocatorDesc.MaxResourceHeapSize = 32ll * 1024ll * 1024ll * 1024ll;  // 32GB
 +        allocatorDesc.MaxResourceSizeForPooling = 0;                          // Always pool heaps

--- a/src/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/d3d12/ResourceAllocatorD3D12.cpp
@@ -149,8 +149,8 @@ namespace gpgmm { namespace d3d12 {
         RESOURCE_HEAP_TYPE GetResourceHeapType(D3D12_RESOURCE_DIMENSION dimension,
                                                D3D12_HEAP_TYPE heapType,
                                                D3D12_RESOURCE_FLAGS flags,
-                                               uint32_t resourceHeapTier) {
-            if (resourceHeapTier >= 2) {
+                                               D3D12_RESOURCE_HEAP_TIER resourceHeapTier) {
+            if (resourceHeapTier >= D3D12_RESOURCE_HEAP_TIER_2) {
                 switch (heapType) {
                     case D3D12_HEAP_TYPE_UPLOAD:
                         return RESOURCE_HEAP_TYPE_UPLOAD_ALLOW_ALL_BUFFERS_AND_TEXTURES;

--- a/src/d3d12/ResourceAllocatorD3D12.h
+++ b/src/d3d12/ResourceAllocatorD3D12.h
@@ -85,7 +85,7 @@ namespace gpgmm { namespace d3d12 {
 
         // Determines if resource heaps can mix resource categories (both texture and
         // buffers). Use CheckFeatureSupport to get supported tier. Required parameter.
-        uint32_t ResourceHeapTier;
+        D3D12_RESOURCE_HEAP_TIER ResourceHeapTier;
 
         // Preferred size of the resource heap.
         // The preferred size of the resource heap is the minimum heap size to sub-allocate
@@ -234,7 +234,7 @@ namespace gpgmm { namespace d3d12 {
         std::unique_ptr<ResidencyManager> mResidencyManager;
 
         const bool mIsUMA;
-        const uint32_t mResourceHeapTier;
+        const D3D12_RESOURCE_HEAP_TIER mResourceHeapTier;
         const bool mIsAlwaysCommitted;
         const bool mIsAlwaysInBudget;
         const uint64_t mMaxResourceHeapSize;

--- a/src/tests/D3D12Test.h
+++ b/src/tests/D3D12Test.h
@@ -37,7 +37,7 @@ namespace gpgmm { namespace d3d12 {
         ComPtr<ID3D12Device> mDevice;
 
         bool mIsUMA = false;
-        uint32_t mResourceHeapTier = 1;
+        D3D12_RESOURCE_HEAP_TIER mResourceHeapTier = D3D12_RESOURCE_HEAP_TIER_1;
     };
 
 }}  // namespace gpgmm::d3d12


### PR DESCRIPTION

Using the D3D12 enum type ensures only valid tiers can be specified and prevents programmer error.