### PR TITLE
Plumb VideoMemoryEvictSize allocator parameter to residency manager.

### DIFF
--- a/src/d3d12/DefaultsD3D12.h
+++ b/src/d3d12/DefaultsD3D12.h
@@ -20,10 +20,10 @@
 namespace gpgmm { namespace d3d12 {
 
     static constexpr uint64_t kDefaultMaxResourceHeapSize =
-        32ll * 1024ll * 1024ll * 1024ll;                                                   // 32GB
-    static constexpr uint64_t kDefaultPreferredResourceHeapSize = 4ll * 1024ll * 1024ll;   // 4MB
-    static constexpr uint32_t kDefaultResidentResourceEvictSize = 50ll * 1024ll * 1024ll;  // 50MB
-    static constexpr float kDefaultMaxVideoMemoryBudget = 0.95f;                           // 95%
+        32ll * 1024ll * 1024ll * 1024ll;                                                  // 32GB
+    static constexpr uint64_t kDefaultPreferredResourceHeapSize = 4ll * 1024ll * 1024ll;  // 4MB
+    static constexpr uint32_t kDefaultVideoMemoryEvictSize = 50ll * 1024ll * 1024ll;      // 50MB
+    static constexpr float kDefaultMaxVideoMemoryBudget = 0.95f;                          // 95%
 
 }}  // namespace gpgmm::d3d12
 

--- a/src/d3d12/ResidencyManagerD3D12.h
+++ b/src/d3d12/ResidencyManagerD3D12.h
@@ -63,6 +63,7 @@ namespace gpgmm { namespace d3d12 {
                                               bool isUMA,
                                               float videoMemoryBudget,
                                               uint64_t availableForResourceBudget,
+                                              uint64_t videoMemoryEvictSize,
                                               ResidencyManager** residencyManagerOut);
 
         ResidencyManager(ComPtr<ID3D12Device> device,
@@ -70,7 +71,8 @@ namespace gpgmm { namespace d3d12 {
                          std::unique_ptr<Fence> fence,
                          bool isUMA,
                          float memorySegmentBudgetLimit,
-                         uint64_t totalResourceBudgetLimit);
+                         uint64_t totalResourceBudgetLimit,
+                         uint64_t videoMemoryEvictSize);
 
         using Cache = LinkedList<Heap>;
 
@@ -100,6 +102,7 @@ namespace gpgmm { namespace d3d12 {
         const bool mIsUMA;
         const float mVideoMemoryBudgetLimit;
         const uint64_t mAvailableForResourcesBudget;
+        const uint64_t mVideoMemoryEvictSize;
 
         VideoMemorySegment mLocalVideoMemorySegment;
         VideoMemorySegment mNonLocalVideoMemorySegment;

--- a/src/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/d3d12/ResourceAllocatorD3D12.cpp
@@ -304,7 +304,7 @@ namespace gpgmm { namespace d3d12 {
         if (SUCCEEDED(ResidencyManager::CreateResidencyManager(
                 newDescriptor.Device, newDescriptor.Adapter, newDescriptor.IsUMA,
                 newDescriptor.MaxVideoMemoryBudget, newDescriptor.TotalResourceBudgetLimit,
-                &residencyManagerPtr))) {
+                newDescriptor.VideoMemoryEvictSize, &residencyManagerPtr))) {
             residencyManager = std::unique_ptr<ResidencyManager>(residencyManagerPtr);
         }
 

--- a/src/d3d12/ResourceAllocatorD3D12.h
+++ b/src/d3d12/ResourceAllocatorD3D12.h
@@ -121,11 +121,11 @@ namespace gpgmm { namespace d3d12 {
         // Optional parameter. When 0 is used, the API will not restrict the resource budget.
         uint64_t TotalResourceBudgetLimit;
 
-        // Total memory Size of resident resources that could be evicted, should there not be enough
-        // residency budget available.
-        // Optional parameter. When 0 is used, the API will try to evict 50MB worth of resource
-        // memory before re-attempting to make them resident.
-        uint64_t ResidentResourceEvictSize;
+        // Video memory to evict from residency in order to make more resource resident, should
+        // there not be enough budget available.
+        // Optional parameter. When 0 is used, the API will automatically set the video memory
+        // evict size to 50MB.
+        uint64_t VideoMemoryEvictSize;
     };
 
     typedef enum ALLOCATION_FLAGS {


### PR DESCRIPTION

Allows the eviction size to be optionally specified upon allocator creation.