### PR TITLE
Allow allocator creation to return a managed residency manager.

### DIFF
--- a/src/d3d12/ResidencyManagerD3D12.h
+++ b/src/d3d12/ResidencyManagerD3D12.h
@@ -17,14 +17,9 @@
 #define GPGMM_D3D12_RESIDENCYMANAGERD3D12_H_
 
 #include "../common/LinkedList.h"
+#include "src/d3d12/IUnknownImplD3D12.h"
 
-#include "src/d3d12/d3d12_platform.h"
-
-#include <cstdint>
 #include <memory>
-
-struct ID3D12CommandList;
-struct ID3D12CommandQueue;
 
 namespace gpgmm { namespace d3d12 {
 
@@ -33,7 +28,7 @@ namespace gpgmm { namespace d3d12 {
     class ResidencySet;
     class ResourceAllocator;
 
-    class ResidencyManager {
+    class ResidencyManager : public IUnknownImpl {
       public:
         ~ResidencyManager();
 

--- a/src/d3d12/ResourceAllocatorD3D12.h
+++ b/src/d3d12/ResourceAllocatorD3D12.h
@@ -159,10 +159,12 @@ namespace gpgmm { namespace d3d12 {
 
     class ResourceAllocator final : public AllocatorBase, public IUnknownImpl {
       public:
-        // Creates the main instance used to help manage video memory for the
-        // specified D3D12 device and adapter in the |descriptor|.
+        // Creates the allocator and residency manager instance used to manage video memory for the
+        // App specified device and adapter. Residency manager only exists if this adapter at-least
+        // supports DXGI 1.4 and cannot outlive the resource allocator used to create it.
         static HRESULT CreateAllocator(const ALLOCATOR_DESC& descriptor,
-                                       ResourceAllocator** resourceAllocationOut);
+                                       ResourceAllocator** resourceAllocatorOut,
+                                       ResidencyManager** residencyManagerOut = nullptr);
 
         ~ResourceAllocator() override;
 
@@ -198,7 +200,7 @@ namespace gpgmm { namespace d3d12 {
         friend ResourceAllocation;
 
         ResourceAllocator(const ALLOCATOR_DESC& descriptor,
-                          std::unique_ptr<ResidencyManager> residencyManager);
+                          ComPtr<ResidencyManager> residencyManager);
 
         HRESULT CreatePlacedResourceHeap(const MemoryAllocation& subAllocation,
                                          const D3D12_RESOURCE_ALLOCATION_INFO resourceInfo,
@@ -226,7 +228,7 @@ namespace gpgmm { namespace d3d12 {
         void FreeResourceHeap(Heap* resourceHeap);
 
         ComPtr<ID3D12Device> mDevice;
-        std::unique_ptr<ResidencyManager> mResidencyManager;
+        ComPtr<ResidencyManager> mResidencyManager;
 
         const bool mIsUMA;
         const D3D12_RESOURCE_HEAP_TIER mResourceHeapTier;


### PR DESCRIPTION

Avoids the need to call GetResidencyManager immediately after CreateAllocator upon device initialization.