### PR TITLE
Rename Dawn prefixed macros with GPGMM ones.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ target_link_libraries(gpgmm_common_config INTERFACE gpgmm_public_config)
 # Compile definitions for the common config
 if (GPGMM_ALWAYS_ASSERT OR $<CONFIG:Debug>)
     # TODO: rename definition
-    target_compile_definitions(gpgmm_common_config INTERFACE "DAWN_ENABLE_ASSERTS")
+    target_compile_definitions(gpgmm_common_config INTERFACE "GPGMM_ENABLE_ASSERTS")
 endif()
 if (GPGMM_ENABLE_D3D12)
     target_compile_definitions(gpgmm_common_config INTERFACE "GPGMM_ENABLE_D3D12")

--- a/src/common/Assert.cpp
+++ b/src/common/Assert.cpp
@@ -24,9 +24,9 @@ void HandleAssertionFailure(const char* file,
                             const char* condition) {
     gpgmm::ErrorLog() << "Assertion failure at " << file << ":" << line << " (" << function
                       << "): " << condition;
-#if defined(DAWN_ABORT_ON_ASSERT)
+#if defined(GPGMM_ABORT_ON_ASSERT)
     abort();
 #else
-    DAWN_BREAKPOINT();
+    GPGMM_BREAKPOINT();
 #endif
 }

--- a/src/common/Assert.h
+++ b/src/common/Assert.h
@@ -22,8 +22,6 @@
 // yet, you should start now!). In debug ASSERT(condition) will trigger an error, otherwise in
 // release it does nothing at runtime.
 //
-// In case of name clashes (with for example a testing library), you can define the
-// DAWN_SKIP_ASSERT_SHORTHANDS to only define the DAWN_ prefixed macros.
 //
 // These asserts feature:
 //     - Logging of the error with file, line and function information.
@@ -33,44 +31,51 @@
 // MSVC triggers a warning in /W4 for do {} while(0). SDL worked around this by using (0,0) and
 // points out that it looks like an owl face.
 #if defined(GPGMM_COMPILER_MSVC)
-#    define DAWN_ASSERT_LOOP_CONDITION (0, 0)
+#    define GPGMM_ASSERT_LOOP_CONDITION (0, 0)
 #else
-#    define DAWN_ASSERT_LOOP_CONDITION (0)
+#    define GPGMM_ASSERT_LOOP_CONDITION (0)
 #endif
 
-// DAWN_ASSERT_CALLSITE_HELPER generates the actual assert code. In Debug it does what you would
+// GPGMM_ASSERT_CALLSITE_HELPER generates the actual assert code. In Debug it does what you would
 // expect of an assert and in release it tries to give hints to make the compiler generate better
 // code.
-#if defined(DAWN_ENABLE_ASSERTS)
-#    define DAWN_ASSERT_CALLSITE_HELPER(file, func, line, condition)  \
+#if defined(GPGMM_ENABLE_ASSERTS)
+#    define GPGMM_ASSERT_CALLSITE_HELPER(file, func, line, condition) \
         do {                                                          \
             if (!(condition)) {                                       \
                 HandleAssertionFailure(file, func, line, #condition); \
             }                                                         \
-        } while (DAWN_ASSERT_LOOP_CONDITION)
+        } while (GPGMM_ASSERT_LOOP_CONDITION)
 #else
 #    if defined(GPGMM_COMPILER_MSVC)
-#        define DAWN_ASSERT_CALLSITE_HELPER(file, func, line, condition) __assume(condition)
+#        define GPGMM_ASSERT_CALLSITE_HELPER(file, func, line, condition) __assume(condition)
 #    elif defined(GPGMM_COMPILER_CLANG) && defined(__builtin_assume)
-#        define DAWN_ASSERT_CALLSITE_HELPER(file, func, line, condition) __builtin_assume(condition)
+#        define GPGMM_ASSERT_CALLSITE_HELPER(file, func, line, condition) \
+            __builtin_assume(condition)
 #    else
-#        define DAWN_ASSERT_CALLSITE_HELPER(file, func, line, condition) \
-            do {                                                         \
-                DAWN_UNUSED(sizeof(condition));                          \
-            } while (DAWN_ASSERT_LOOP_CONDITION)
+#        define GPGMM_ASSERT_CALLSITE_HELPER(file, func, line, condition) \
+            do {                                                          \
+                GPGMM_UNUSED(sizeof(condition));                          \
+            } while (GPGMM_ASSERT_LOOP_CONDITION)
 #    endif
 #endif
 
-#define DAWN_ASSERT(condition) DAWN_ASSERT_CALLSITE_HELPER(__FILE__, __func__, __LINE__, condition)
-#define DAWN_UNREACHABLE()                                                 \
-    do {                                                                   \
-        DAWN_ASSERT(DAWN_ASSERT_LOOP_CONDITION && "Unreachable code hit"); \
-        DAWN_BUILTIN_UNREACHABLE();                                        \
-    } while (DAWN_ASSERT_LOOP_CONDITION)
+#define GPGMM_ASSERT(condition) \
+    GPGMM_ASSERT_CALLSITE_HELPER(__FILE__, __func__, __LINE__, condition)
+#define GPGMM_UNREACHABLE()                                                  \
+    do {                                                                     \
+        GPGMM_ASSERT(GPGMM_ASSERT_LOOP_CONDITION && "Unreachable code hit"); \
+        GPGMM_BUILTIN_UNREACHABLE();                                         \
+    } while (GPGMM_ASSERT_LOOP_CONDITION)
 
-#if !defined(DAWN_SKIP_ASSERT_SHORTHANDS)
-#    define ASSERT DAWN_ASSERT
-#    define UNREACHABLE DAWN_UNREACHABLE
+// Disable short-hand defined macros due to possible name clash.
+// Instead, GPGMM will always use the already defined one.
+#if !defined(ASSERT)
+#    define ASSERT GPGMM_ASSERT
+#endif
+
+#if !defined(UNREACHABLE)
+#    define UNREACHABLE GPGMM_UNREACHABLE
 #endif
 
 void HandleAssertionFailure(const char* file,

--- a/src/common/BUILD.gn
+++ b/src/common/BUILD.gn
@@ -47,12 +47,12 @@ config("gpgmm_common_config") {
   defines = []
   if (gpgmm_always_assert || dcheck_always_on || is_debug ||
       use_fuzzing_engine) {
-    defines += [ "DAWN_ENABLE_ASSERTS" ]
+    defines += [ "GPGMM_ENABLE_ASSERTS" ]
   }
 
   if (use_fuzzing_engine) {
     # Does a hard abort when an assertion fails so that fuzzers catch and parse the failure.
-    defines += [ "DAWN_ABORT_ON_ASSERT" ]
+    defines += [ "GPGMM_ABORT_ON_ASSERT" ]
   }
 
   # Only internal build targets can use this config, this means only targets in

--- a/src/common/Compiler.h
+++ b/src/common/Compiler.h
@@ -17,16 +17,16 @@
 #define GPGMM_COMMON_COMPILER_H_
 
 // Defines macros for compiler-specific functionality
-//  - DAWN_COMPILER_[CLANG|GCC|MSVC]: Compiler detection
-//  - DAWN_BREAKPOINT(): Raises an exception and breaks in the debugger
-//  - DAWN_BUILTIN_UNREACHABLE(): Hints the compiler that a code path is unreachable
-//  - DAWN_NO_DISCARD: An attribute that is C++17 [[nodiscard]] where available
-//  - DAWN_(UN)?LIKELY(EXPR): Where available, hints the compiler that the expression will be true
+//  - GPGMM_COMPILER_[CLANG|GCC|MSVC]: Compiler detection
+//  - GPGMM_BREAKPOINT(): Raises an exception and breaks in the debugger
+//  - GPGMM_BUILTIN_UNREACHABLE(): Hints the compiler that a code path is unreachable
+//  - GPGMM_NO_DISCARD: An attribute that is C++17 [[nodiscard]] where available
+//  - GPGMM_(UN)?LIKELY(EXPR): Where available, hints the compiler that the expression will be true
 //      (resp. false) to help it generate code that leads to better branch prediction.
-//  - DAWN_UNUSED(EXPR): Prevents unused variable/expression warnings on EXPR.
-//  - DAWN_UNUSED_FUNC(FUNC): Prevents unused function warnings on FUNC.
-//  - DAWN_DECLARE_UNUSED:    Prevents unused function warnings a subsequent declaration.
-//  Both DAWN_UNUSED_FUNC and DAWN_DECLARE_UNUSED may be necessary, e.g. to suppress clang's
+//  - GPGMM_UNUSED(EXPR): Prevents unused variable/expression warnings on EXPR.
+//  - GPGMM_UNUSED_FUNC(FUNC): Prevents unused function warnings on FUNC.
+//  - GPGMM_DECLARE_UNUSED:    Prevents unused function warnings a subsequent declaration.
+//  Both GPGMM_UNUSED_FUNC and GPGMM_DECLARE_UNUSED may be necessary, e.g. to suppress clang's
 //  unneeded-internal-declaration warning.
 
 // Clang and GCC, check for __clang__ too to catch clang-cl masquarading as MSVC
@@ -34,19 +34,19 @@
 #    if defined(__clang__)
 #        define GPGMM_COMPILER_CLANG
 #    else
-#        define DAWN_COMPILER_GCC
+#        define GPGMM_COMPILER_GCC
 #    endif
 
 #    if defined(__i386__) || defined(__x86_64__)
-#        define DAWN_BREAKPOINT() __asm__ __volatile__("int $3\n\t")
+#        define GPGMM_BREAKPOINT() __asm__ __volatile__("int $3\n\t")
 #    else
 // TODO(cwallez@chromium.org): Implement breakpoint on all supported architectures
-#        define DAWN_BREAKPOINT()
+#        define GPGMM_BREAKPOINT()
 #    endif
 
-#    define DAWN_BUILTIN_UNREACHABLE() __builtin_unreachable()
-#    define DAWN_LIKELY(x) __builtin_expect(!!(x), 1)
-#    define DAWN_UNLIKELY(x) __builtin_expect(!!(x), 0)
+#    define GPGMM_BUILTIN_UNREACHABLE() __builtin_unreachable()
+#    define GPGMM_LIKELY(x) __builtin_expect(!!(x), 1)
+#    define GPGMM_UNLIKELY(x) __builtin_expect(!!(x), 0)
 
 #    if !defined(__has_cpp_attribute)
 #        define __has_cpp_attribute(name) 0
@@ -56,14 +56,14 @@
 // Also avoid warn_unused_result with GCC because it is only a function attribute and not a type
 // attribute.
 #    if __has_cpp_attribute(warn_unused_result) && defined(__clang__)
-#        define DAWN_NO_DISCARD __attribute__((warn_unused_result))
+#        define GPGMM_NO_DISCARD __attribute__((warn_unused_result))
 #    elif DAWN_CPP_VERSION >= 17 && __has_cpp_attribute(nodiscard)
-#        define DAWN_NO_DISCARD [[nodiscard]]
+#        define GPGMM_NO_DISCARD [[nodiscard]]
 #    endif
 
-#    define DAWN_DECLARE_UNUSED __attribute__((unused))
+#    define GPGMM_DECLARE_UNUSED __attribute__((unused))
 #    if defined(NDEBUG)
-#        define DAWN_FORCE_INLINE inline __attribute__((always_inline))
+#        define GPGMM_FORCE_INLINE inline __attribute__((always_inline))
 #    endif
 
 // MSVC
@@ -71,18 +71,18 @@
 #    define GPGMM_COMPILER_MSVC
 
 extern void __cdecl __debugbreak(void);
-#    define DAWN_BREAKPOINT() __debugbreak()
+#    define GPGMM_BREAKPOINT() __debugbreak()
 
-#    define DAWN_BUILTIN_UNREACHABLE() __assume(false)
+#    define GPGMM_BUILTIN_UNREACHABLE() __assume(false)
 
 // Visual Studio 2017 15.3 adds support for [[nodiscard]]
 #    if _MSC_VER >= 1911 && DAWN_CPP_VERSION >= 17
-#        define DAWN_NO_DISCARD [[nodiscard]]
+#        define GPGMM_NO_DISCARD [[nodiscard]]
 #    endif
 
-#    define DAWN_DECLARE_UNUSED
+#    define GPGMM_DECLARE_UNUSED
 #    if defined(NDEBUG)
-#        define DAWN_FORCE_INLINE __forceinline
+#        define GPGMM_FORCE_INLINE __forceinline
 #    endif
 
 #else
@@ -90,28 +90,28 @@ extern void __cdecl __debugbreak(void);
 #endif
 
 // It seems that (void) EXPR works on all compilers to silence the unused variable warning.
-#define DAWN_UNUSED(EXPR) (void)EXPR
+#define GPGMM_UNUSED(EXPR) (void)EXPR
 // Likewise using static asserting on sizeof(&FUNC) seems to make it tagged as used
-#define DAWN_UNUSED_FUNC(FUNC) static_assert(sizeof(&FUNC) == sizeof(void (*)()), "")
+#define GPGMM_UNUSED_FUNC(FUNC) static_assert(sizeof(&FUNC) == sizeof(void (*)()), "")
 
 // Add noop replacements for macros for features that aren't supported by the compiler.
-#if !defined(DAWN_LIKELY)
-#    define DAWN_LIKELY(X) X
+#if !defined(GPGMM_LIKELY)
+#    define GPGMM_LIKELY(X) X
 #endif
-#if !defined(DAWN_UNLIKELY)
-#    define DAWN_UNLIKELY(X) X
+#if !defined(GPGMM_UNLIKELY)
+#    define GPGMM_UNLIKELY(X) X
 #endif
-#if !defined(DAWN_NO_DISCARD)
-#    define DAWN_NO_DISCARD
+#if !defined(GPGMM_NO_DISCARD)
+#    define GPGMM_NO_DISCARD
 #endif
-#if !defined(DAWN_FORCE_INLINE)
-#    define DAWN_FORCE_INLINE inline
+#if !defined(GPGMM_FORCE_INLINE)
+#    define GPGMM_FORCE_INLINE inline
 #endif
 
 #if defined(__clang__)
-#    define DAWN_FALLTHROUGH [[clang::fallthrough]]
+#    define GPGMM_FALLTHROUGH [[clang::fallthrough]]
 #else
-#    define DAWN_FALLTHROUGH
+#    define GPGMM_FALLTHROUGH
 #endif
 
 #endif  // GPGMM_COMMON_COMPILER_H_


### PR DESCRIPTION

This is to avoid name clashes since both the Assert and Compiler macros originate from Dawn.