### PR TITLE
Check alignment when tightly placing resoures.

### DIFF
--- a/src/CombinedMemoryAllocator.h
+++ b/src/CombinedMemoryAllocator.h
@@ -29,11 +29,11 @@ namespace gpgmm {
 
         MemoryAllocator* PushAllocator(std::unique_ptr<MemoryAllocator> allocator);
 
+        // MemoryAllocator interface.
         std::unique_ptr<MemoryAllocation> TryAllocateMemory(uint64_t size,
                                                             uint64_t alignment,
                                                             bool neverAllocate) override;
         void DeallocateMemory(MemoryAllocation* allocation) override;
-
         void ReleaseMemory() override;
 
         MEMORY_ALLOCATOR_INFO QueryInfo() const override;

--- a/src/d3d12/ResourceAllocatorD3D12.h
+++ b/src/d3d12/ResourceAllocatorD3D12.h
@@ -213,6 +213,10 @@ namespace gpgmm { namespace d3d12 {
         // size.
         ALLOCATOR_MESSAGE_ID_RESOURCE_ALLOCATION_SUBOPTIONAL_ALIGNMENT = 0x4,
 
+        // Resource allocation was unable to be pool-allocated. This introduces OS VidMM overhead
+        // because non-pool allocated memory cannot be reused by the allocator.
+        ALLOCATOR_MESSAGE_ID_RESOURCE_ALLOCATION_NON_POOLED = 0x5,
+
     } ALLOCATOR_MESSAGE_ID;
 
     struct ALLOCATOR_MESSAGE {
@@ -276,7 +280,6 @@ namespace gpgmm { namespace d3d12 {
 
         HRESULT CreatePlacedResource(Heap* const resourceHeap,
                                      uint64_t resourceOffset,
-                                     const D3D12_RESOURCE_ALLOCATION_INFO resourceInfo,
                                      const D3D12_RESOURCE_DESC* resourceDescriptor,
                                      const D3D12_CLEAR_VALUE* clearValue,
                                      D3D12_RESOURCE_STATES initialResourceState,


### PR DESCRIPTION

Ensures resource heap size is a multiple of the resource size so small aligned resources or textures do not consume 4x more memory by default (4KB vs 64KB).