### PR TITLE
Add shared library build targets.

### DIFF
--- a/.github/workflows/win_msvc_dbg_x64.yaml
+++ b/.github/workflows/win_msvc_dbg_x64.yaml
@@ -47,6 +47,22 @@ jobs:
         copy scripts\standalone.gclient .gclient
         gclient sync
 
+    - name: Generate shared library for main branch (with patch)
+      shell: cmd
+      run: |
+        set "PATH=%CD%\..\depot_tools;%PATH%"
+        set "DEPOT_TOOLS_WIN_TOOLCHAIN=0"
+        cd test
+        gn gen out\Debug --args="is_debug=true is_clang=false gpgmm_shared_library=true"
+
+    - name: Build shared library for main branch (with patch)
+      shell: cmd
+      run: |
+        set "PATH=%CD%\..\depot_tools;%PATH%"
+        set "DEPOT_TOOLS_WIN_TOOLCHAIN=0"
+        cd test
+        ninja -C out\Debug gpgmm
+
     - name: Generate project for main branch (with patch)
       shell: cmd
       run: |

--- a/.github/workflows/win_msvc_rel_x64.yaml
+++ b/.github/workflows/win_msvc_rel_x64.yaml
@@ -47,6 +47,22 @@ jobs:
         copy scripts\standalone.gclient .gclient
         gclient sync
 
+    - name: Generate shared library for main branch (with patch)
+      shell: cmd
+      run: |
+        set "PATH=%CD%\..\depot_tools;%PATH%"
+        set "DEPOT_TOOLS_WIN_TOOLCHAIN=0"
+        cd test
+        gn gen out\Release --args="is_debug=false is_clang=false gpgmm_shared_library=true"
+
+    - name: Build shared library for main branch (with patch)
+      shell: cmd
+      run: |
+        set "PATH=%CD%\..\depot_tools;%PATH%"
+        set "DEPOT_TOOLS_WIN_TOOLCHAIN=0"
+        cd test
+        ninja -C out\Release gpgmm
+
     - name: Generate project for main branch (with patch)
       shell: cmd
       run: |

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -34,13 +34,3 @@ group("default") {
   testonly = true
   deps = [ ":all" ]
 }
-
-# Shared and static library build targets are used to re-distributable GPGMM as a linkable binary.
-static_library("gpgmm_static") {
-  complete_static_lib = true
-  deps = [ "src:gpgmm" ]
-}
-
-shared_library("gpgmm_shared") {
-  deps = [ "src:gpgmm" ]
-}

--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ Get the source code as follows:
 ### Setting up the build
 Generate build files using `gn args out/Debug` or `gn args out/Release`.
 
-A text editor will appear asking build options, the most common option is `is_debug=true/false`; otherwise `gn args out/Release --list` shows all the possible options.
+A text editor will appear asking build arguments, the most common argument is `is_debug=true/false`; otherwise `gn args out/Release --list` shows all the possible options.
 
-To build with a backend, please set the corresponding option from following table.
+To build with a backend, please set the corresponding argument from following table.
 
-| Backend | Option |
+| Backend | Build argument |
 |---------|--------------|
-| D3D12 | `gpgmm_enable_d3d12=true` (default on winos) |
+| DirectX 12 | `gpgmm_enable_d3d12=true` (default on winos) |
 | Vulkan | `gpgmm_enable_vulkan=true` |
 
 ### Build
@@ -58,12 +58,12 @@ Run unit tests:
 
 Run end2end tests:
 ```sh
-> out/Release/gpgmm_end2end_tests
+> out/Debug/gpgmm_end2end_tests
 ```
 
 Run capture replay tests:
 ```sh
-> out/Release/gpgmm_capture_replay_tests
+> out/Debug/gpgmm_capture_replay_tests
 ```
 
 ## How do I use it?
@@ -140,14 +140,16 @@ target_link_libraries(proj PRIVATE gpgmm ...)
 
 ### Visual Studio (MSVC)
 
-```sh
-> gn gen out/gpgmm_static --args='is_clang=false'
-> ninja -C out/gpgmm_static gpgmm_static
-> xcopy out/gpgmm_static/obj/gpgmm_static.lib $(ProjectDir)
-```
-1. Right click solution project ("Property pages") > Configuration Properties.
-2. Add `gpgmm_static.lib` to Linker > Additional Dependencies.
-3. Add path(s) 1. `gpgmm` and 2. `gpgmm\src\include` to Include Directories.
+Dynamic Linked Library (DLL)
+
+Use `is_clang=false gpgmm_shared_library=true` when [Setting up the build](#Setting-up-the-build).
+Then use `ninja -C out/Release gpgmm` or `ninja -C out/Debug gpgmm` to build the shared library (DLL).
+
+Copy the DLL into the `$(OutputPath)` folder and configure the VS build:
+1. Highlight project in the **Solution Explorer**, and then select **Project > Properties**.
+2. Under **Configuration Properties > C/C++ > General**, add `gpgmm` and `gpgmm\src\include` to **Additional Include Directories**.
+3. Under **Configuration Properties > Linker > Input**, add ``gpgmm.dll.lib`` to **Additional Dependencies**.
+4. Under **Configuration Properties > Linker > General**, add the folder path to `out\Release` to **Additional Library Directories**.
 
 Then import:
 ```cpp

--- a/build_overrides/gpgmm_features.gni
+++ b/build_overrides/gpgmm_features.gni
@@ -43,4 +43,7 @@ declare_args() {
 
   # Enables compilation of WebNN's end2end tests.
   gpgmm_enable_webnn = checkout_webnn
+
+  # Build GPGMM as a shared library.
+  gpgmm_shared_library = false
 }

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -88,7 +88,12 @@ source_set("gpgmm_sources") {
     ":gpgmm_headers",
     "${gpgmm_root_dir}/src/common:gpgmm_common_sources",
   ]
-  defines = []
+
+  defines = [ "GPGMM_IMPLEMENTATION" ]
+
+  if (gpgmm_shared_library) {
+    defines += [ "GPGMM_SHARED_LIBRARY" ]
+  }
 
   if (gpgmm_always_record) {
     defines += [ "GPGMM_ALWAYS_RECORD" ]
@@ -199,7 +204,18 @@ source_set("gpgmm_sources") {
   }
 }
 
-source_set("gpgmm") {
+# Defines the type of target for GN to build.
+# GN source set acts as a stand-in replacement for a static library.
+# Unlike a static library, GN source set generates no intermediate object file
+# and all compiled object files are linked into the final target.
+# The GN style guide recommends source set over a static library to avoid
+# generating this extra lib (docs/style_guide.md).
+target_type = "source_set"
+if (gpgmm_shared_library) {
+  target_type = "shared_library"
+}
+
+target(target_type, "gpgmm") {
   public_deps = [ ":gpgmm_headers" ]
   deps = [ ":gpgmm_sources" ]
 }

--- a/src/MemoryAllocation.h
+++ b/src/MemoryAllocation.h
@@ -17,6 +17,7 @@
 #define GPGMM_MEMORYALLOCATION_H_
 
 #include "common/Limits.h"
+#include "include/gpgmm_export.h"
 
 #include <cstdint>
 
@@ -44,7 +45,7 @@ namespace gpgmm {
     class MemoryAllocator;
 
     // Represents a location in memory.
-    class MemoryAllocation {
+    class GPGMM_EXPORT MemoryAllocation {
       public:
         MemoryAllocation();
 

--- a/src/common/BUILD.gn
+++ b/src/common/BUILD.gn
@@ -121,6 +121,16 @@ config("gpgmm_common_config") {
         "/EHsc",
       ]
     }
+
+    # MSVC requires a dynamically linked library (.dll) to use a multi-thread
+    # dynamic runtime.
+    if (gpgmm_shared_library) {
+      if (is_debug) {
+        cflags += [ "/MDd" ]
+      } else {
+        cflags += [ "/MD" ]
+      }
+    }
   }
 }
 

--- a/src/d3d12/HeapD3D12.h
+++ b/src/d3d12/HeapD3D12.h
@@ -18,6 +18,7 @@
 
 #include "../common/LinkedList.h"
 #include "../common/RefCount.h"
+#include "../include/gpgmm_export.h"
 #include "src/Memory.h"
 #include "src/d3d12/d3d12_platform.h"
 
@@ -43,7 +44,7 @@ namespace gpgmm { namespace d3d12 {
     // allocated, and any time it is scheduled to be used by the GPU. This node is removed from the
     // LRU cache when it is evicted from resident memory due to budget constraints, or when the
     // pageable allocation is released.
-    class Heap : public MemoryBase, public LinkNode<Heap> {
+    class GPGMM_EXPORT Heap : public MemoryBase, public LinkNode<Heap> {
       public:
         Heap(ComPtr<ID3D12Pageable> pageable,
              const DXGI_MEMORY_SEGMENT_GROUP& memorySegmentGroup,

--- a/src/d3d12/IUnknownImplD3D12.h
+++ b/src/d3d12/IUnknownImplD3D12.h
@@ -16,12 +16,13 @@
 #define GPGMM_D3D12_IUNKNOWNIMPLD3D12_H_
 
 #include "src/d3d12/d3d12_platform.h"
+#include "src/include/gpgmm_export.h"
 
 #include "../common/RefCount.h"
 
 namespace gpgmm { namespace d3d12 {
 
-    class IUnknownImpl : public IUnknown, public RefCounted {
+    class GPGMM_EXPORT IUnknownImpl : public IUnknown, public RefCounted {
       public:
         IUnknownImpl();
         virtual ~IUnknownImpl() = default;

--- a/src/d3d12/ResidencyManagerD3D12.h
+++ b/src/d3d12/ResidencyManagerD3D12.h
@@ -17,6 +17,7 @@
 #define GPGMM_D3D12_RESIDENCYMANAGERD3D12_H_
 
 #include "../common/LinkedList.h"
+#include "../include/gpgmm_export.h"
 #include "src/d3d12/IUnknownImplD3D12.h"
 
 #include <memory>
@@ -28,7 +29,7 @@ namespace gpgmm { namespace d3d12 {
     class ResidencySet;
     class ResourceAllocator;
 
-    class ResidencyManager : public IUnknownImpl {
+    class GPGMM_EXPORT ResidencyManager : public IUnknownImpl {
       public:
         ~ResidencyManager();
 

--- a/src/d3d12/ResidencySetD3D12.h
+++ b/src/d3d12/ResidencySetD3D12.h
@@ -16,6 +16,7 @@
 #define GPGMM_D3D12_RESIDENCYSETD3D12_H_
 
 #include "src/d3d12/d3d12_platform.h"
+#include "src/include/gpgmm_export.h"
 
 #include <set>
 #include <vector>
@@ -27,7 +28,7 @@ namespace gpgmm { namespace d3d12 {
 
     // Represents a set of resource allocations which are referenced by a command list.
     // The set must be updated to ensure each allocations is resident for execution.
-    class ResidencySet {
+    class GPGMM_EXPORT ResidencySet {
       public:
         ResidencySet() = default;
         ~ResidencySet() = default;

--- a/src/d3d12/ResourceAllocationD3D12.h
+++ b/src/d3d12/ResourceAllocationD3D12.h
@@ -17,6 +17,7 @@
 #define GPGMM_D3D12_RESOURCEALLOCATIOND3D12_H_
 
 #include "../common/NonCopyable.h"
+#include "../include/gpgmm_export.h"
 #include "src/MemoryAllocation.h"
 #include "src/d3d12/IUnknownImplD3D12.h"
 #include "src/d3d12/d3d12_platform.h"
@@ -36,9 +37,9 @@ namespace gpgmm { namespace d3d12 {
         Heap* ResourceHeap;
     };
 
-    class ResourceAllocation final : public MemoryAllocation,
-                                     public NonCopyable,
-                                     public IUnknownImpl {
+    class GPGMM_EXPORT ResourceAllocation final : public MemoryAllocation,
+                                                  public NonCopyable,
+                                                  public IUnknownImpl {
       public:
         // Constructs a sub-allocated resource allocation.
         ResourceAllocation(ResidencyManager* residencyManager,

--- a/src/d3d12/ResourceAllocatorD3D12.h
+++ b/src/d3d12/ResourceAllocatorD3D12.h
@@ -18,6 +18,7 @@
 
 #include "src/Allocator.h"
 #include "src/d3d12/IUnknownImplD3D12.h"
+#include "src/include/gpgmm_export.h"
 
 #include <array>
 #include <memory>
@@ -224,7 +225,7 @@ namespace gpgmm { namespace d3d12 {
         ALLOCATOR_MESSAGE_ID ID;
     };
 
-    class ResourceAllocator final : public AllocatorBase, public IUnknownImpl {
+    class GPGMM_EXPORT ResourceAllocator final : public AllocatorBase, public IUnknownImpl {
       public:
         // Creates the allocator and residency manager instance used to manage video memory for the
         // App specified device and adapter. Residency manager only exists if this adapter at-least

--- a/src/include/gpgmm_export.h
+++ b/src/include/gpgmm_export.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// export.h : Defines GPGMM_EXPORT, a macro for exporting functions from the DLL
+
 #ifndef GPGMM_EXPORT_H_
 #define GPGMM_EXPORT_H_
 


### PR DESCRIPTION
Adds a new build feature, `gpgmm_shared_library` which allows gpgmm.dll to be built then linked in a 3rd party project.