### PR TITLE
Remove default user-defined destructors.

### DIFF
--- a/src/gpgmm/TraceEvent.h
+++ b/src/gpgmm/TraceEvent.h
@@ -144,7 +144,6 @@ namespace gpgmm {
                    double timestamp,
                    uint32_t flags,
                    std::string args);
-        ~TraceEvent() = default;
 
       private:
         friend FileEventTracer;

--- a/src/gpgmm/common/RefCount.h
+++ b/src/gpgmm/common/RefCount.h
@@ -23,7 +23,6 @@ namespace gpgmm {
     class RefCounted {
       public:
         RefCounted(int_fast32_t initialRefCount);
-        ~RefCounted() = default;
 
         // Increments ref by one.
         void Ref();

--- a/src/gpgmm/d3d12/ResidencySetD3D12.h
+++ b/src/gpgmm/d3d12/ResidencySetD3D12.h
@@ -31,7 +31,6 @@ namespace gpgmm { namespace d3d12 {
     class GPGMM_EXPORT ResidencySet {
       public:
         ResidencySet() = default;
-        ~ResidencySet() = default;
 
         HRESULT Insert(Heap* heap);
         HRESULT Reset();


### PR DESCRIPTION

Clang will error when an implicitly generated copy is needed and ONLY an explicit default destructor is defined (has no explicit copy dtor AND copy assignment operator). This rule is enforced as of C++11.