### PR TITLE
Replace backend type casts with ToBackendType.

### DIFF
--- a/src/gpgmm/Backend.h
+++ b/src/gpgmm/Backend.h
@@ -1,0 +1,47 @@
+// Copyright 2021 The GPGMM Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GPGMM_BACKEND_H_
+#define GPGMM_BACKEND_H_
+
+namespace gpgmm {
+
+    // Forward declare common types.
+    class MemoryBase;
+
+    template <typename CommonType, typename BackendTrait>
+    struct CommonTrait;
+
+    template <typename BackendTrait>
+    struct CommonTrait<MemoryBase, BackendTrait> {
+        using CommonType = typename BackendTrait::MemoryType;
+    };
+
+    // Converts common to backend type.
+
+    template <typename BackendTrait, typename CommonT>
+    typename CommonTrait<CommonT, BackendTrait>::CommonType* ToBackendType(CommonT* obj) {
+        return reinterpret_cast<typename CommonTrait<CommonT, BackendTrait>::CommonType*>(obj);
+    }
+
+    template <typename BackendTrait, typename CommonT>
+    const typename CommonTrait<CommonT, BackendTrait>::CommonType* ToBackendType(
+        const CommonT* obj) {
+        return reinterpret_cast<const typename CommonTrait<CommonT, BackendTrait>::CommonType*>(
+            obj);
+    }
+
+}  // namespace gpgmm
+
+#endif  // GPGMM_TOBACKEND_H_

--- a/src/gpgmm/d3d12/BackendD3D12.h
+++ b/src/gpgmm/d3d12/BackendD3D12.h
@@ -1,0 +1,35 @@
+// Copyright 2021 The GPGMM Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GPGMM_D3D12_BACKEND3D12_H_
+#define GPGMM_D3D12_BACKEND3D12_H_
+
+#include "gpgmm/Backend.h"
+
+namespace gpgmm { namespace d3d12 {
+
+    class Heap;
+
+    struct BackendTrait {
+        using MemoryType = Heap;
+    };
+
+    template <typename T>
+    auto ToBackendType(T&& obj) -> decltype(gpgmm::ToBackendType<BackendTrait>(obj)) {
+        return gpgmm::ToBackendType<BackendTrait>(obj);
+    }
+
+}}  // namespace gpgmm::d3d12
+
+#endif

--- a/src/gpgmm/d3d12/BufferAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/BufferAllocatorD3D12.cpp
@@ -14,6 +14,7 @@
 
 #include "gpgmm/d3d12/BufferAllocatorD3D12.h"
 
+#include "gpgmm/d3d12/BackendD3D12.h"
 #include "gpgmm/d3d12/HeapD3D12.h"
 #include "gpgmm/d3d12/ResourceAllocationD3D12.h"
 #include "gpgmm/d3d12/ResourceAllocatorD3D12.h"
@@ -70,7 +71,7 @@ namespace gpgmm { namespace d3d12 {
 
     void BufferAllocator::DeallocateMemory(MemoryAllocation* allocation) {
         ASSERT(allocation != nullptr);
-        Heap* heap = static_cast<Heap*>(allocation->GetMemory());
+        Heap* heap = ToBackendType(allocation->GetMemory());
 
         mStats.UsedMemoryCount--;
         mStats.UsedMemoryUsage -= heap->GetSize();

--- a/src/gpgmm/d3d12/ResourceAllocationD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocationD3D12.cpp
@@ -17,6 +17,7 @@
 
 #include "gpgmm/MemoryAllocator.h"
 #include "gpgmm/TraceEvent.h"
+#include "gpgmm/d3d12/BackendD3D12.h"
 #include "gpgmm/d3d12/HeapD3D12.h"
 #include "gpgmm/d3d12/JSONSerializerD3D12.h"
 #include "gpgmm/d3d12/ResidencyManagerD3D12.h"
@@ -123,7 +124,7 @@ namespace gpgmm { namespace d3d12 {
         } else {
             ASSERT(GetMethod() == AllocationMethod::kStandalone);
             ASSERT(mResourceAllocator != nullptr);
-            Heap* resourceHeap = static_cast<Heap*>(GetMemory());
+            Heap* resourceHeap = ToBackendType(GetMemory());
             mResourceAllocator->FreeResourceHeap(resourceHeap);
         }
 
@@ -140,7 +141,7 @@ namespace gpgmm { namespace d3d12 {
     HRESULT ResourceAllocation::Map(uint32_t subresource,
                                     const D3D12_RANGE* readRange,
                                     void** dataOut) {
-        Heap* resourceHeap = static_cast<Heap*>(GetMemory());
+        Heap* resourceHeap = ToBackendType(GetMemory());
         if (resourceHeap == nullptr) {
             return E_INVALIDARG;
         }
@@ -177,7 +178,7 @@ namespace gpgmm { namespace d3d12 {
     }
 
     void ResourceAllocation::Unmap(uint32_t subresource, const D3D12_RANGE* writtenRange) {
-        Heap* resourceHeap = static_cast<Heap*>(GetMemory());
+        Heap* resourceHeap = ToBackendType(GetMemory());
         if (resourceHeap == nullptr) {
             return;
         }
@@ -202,7 +203,7 @@ namespace gpgmm { namespace d3d12 {
     }
 
     HRESULT ResourceAllocation::UpdateResidency(ResidencySet* residencySet) {
-        Heap* resourceHeap = static_cast<Heap*>(GetMemory());
+        Heap* resourceHeap = ToBackendType(GetMemory());
         if (resourceHeap == nullptr) {
             return E_INVALIDARG;
         }
@@ -224,7 +225,7 @@ namespace gpgmm { namespace d3d12 {
     }
 
     RESOURCE_ALLOCATION_DESC ResourceAllocation::GetDesc() const {
-        Heap* resourceHeap = static_cast<Heap*>(GetMemory());
+        Heap* resourceHeap = ToBackendType(GetMemory());
         ASSERT(resourceHeap != nullptr);
 
         return {GetSize(), GetOffset(), mOffsetFromResource, GetMethod(), resourceHeap};

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -21,6 +21,7 @@
 #include "gpgmm/SegmentedMemoryAllocator.h"
 #include "gpgmm/common/Log.h"
 #include "gpgmm/common/Math.h"
+#include "gpgmm/d3d12/BackendD3D12.h"
 #include "gpgmm/d3d12/BufferAllocatorD3D12.h"
 #include "gpgmm/d3d12/DefaultsD3D12.h"
 #include "gpgmm/d3d12/HeapD3D12.h"
@@ -474,7 +475,7 @@ namespace gpgmm { namespace d3d12 {
                     // Committed resource implicitly creates a resource heap which can be
                     // used for sub-allocation.
                     ComPtr<ID3D12Resource> committedResource;
-                    Heap* resourceHeap = static_cast<Heap*>(subAllocation.GetMemory());
+                    Heap* resourceHeap = ToBackendType(subAllocation.GetMemory());
                     ReturnIfFailed(resourceHeap->GetPageable().As(&committedResource));
 
                     *resourceAllocationOut = new ResourceAllocation{
@@ -508,7 +509,7 @@ namespace gpgmm { namespace d3d12 {
                     // Each allocation maps to a disjoint (physical) address range so no physical
                     // memory is can be aliased or will overlap.
                     ComPtr<ID3D12Resource> placedResource;
-                    Heap* resourceHeap = static_cast<Heap*>(subAllocation.GetMemory());
+                    Heap* resourceHeap = ToBackendType(subAllocation.GetMemory());
                     ReturnIfFailed(CreatePlacedResource(resourceHeap, subAllocation.GetOffset(),
                                                         &newResourceDesc, clearValue,
                                                         initialResourceState, &placedResource));
@@ -556,7 +557,7 @@ namespace gpgmm { namespace d3d12 {
                 [&](const auto& allocation) -> HRESULT {
                     // If the resource's heap cannot be pooled then it is no better then
                     // calling CreateCommittedResource if the allocation is not fully contained.
-                    Heap* resourceHeap = static_cast<Heap*>(allocation.GetMemory());
+                    Heap* resourceHeap = ToBackendType(allocation.GetMemory());
                     if (resourceHeap->GetPool() == nullptr &&
                         allocation.GetSize() % heapSize != 0) {
                         return E_FAIL;

--- a/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.cpp
@@ -16,6 +16,7 @@
 #include "gpgmm/d3d12/ResourceHeapAllocatorD3D12.h"
 
 #include "gpgmm/common/Limits.h"
+#include "gpgmm/d3d12/BackendD3D12.h"
 #include "gpgmm/d3d12/HeapD3D12.h"
 #include "gpgmm/d3d12/ResourceAllocatorD3D12.h"
 
@@ -48,7 +49,7 @@ namespace gpgmm { namespace d3d12 {
 
     void ResourceHeapAllocator::DeallocateMemory(MemoryAllocation* allocation) {
         ASSERT(allocation != nullptr);
-        Heap* heap = static_cast<Heap*>(allocation->GetMemory());
+        Heap* heap = ToBackendType(allocation->GetMemory());
 
         mStats.UsedMemoryCount--;
         mStats.UsedMemoryUsage -= heap->GetSize();

--- a/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
+++ b/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "gpgmm/common/Math.h"
+#include "gpgmm/d3d12/BackendD3D12.h"
 #include "gpgmm/d3d12/DefaultsD3D12.h"
 #include "gpgmm/d3d12/UtilsD3D12.h"
 #include "tests/D3D12Test.h"
@@ -327,7 +328,7 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferAlwaysCommitted) {
     EXPECT_EQ(allocation->GetSize(), kDefaultPreferredResourceHeapSize);
 
     // Commmitted resources cannot be backed by a D3D12 heap.
-    Heap* resourceHeap = static_cast<Heap*>(allocation->GetMemory());
+    Heap* resourceHeap = ToBackendType(allocation->GetMemory());
     ASSERT_NE(resourceHeap, nullptr);
     ASSERT_EQ(resourceHeap->GetHeap(), nullptr);
 }


### PR DESCRIPTION

Replaces use of static_cast which avoids runtime checks with a safer trait based helper which checks types at compile-type.