### PR TITLE
Eliminate indirection to use pool with segments.

### DIFF
--- a/src/gpgmm/BuddyMemoryAllocator.cpp
+++ b/src/gpgmm/BuddyMemoryAllocator.cpp
@@ -28,7 +28,8 @@ namespace gpgmm {
         : MemoryAllocator(std::move(memoryAllocator)),
           mMemorySize(memorySize),
           mMemoryAlignment(memoryAlignment),
-          mBuddyBlockAllocator(systemSize) {
+          mBuddyBlockAllocator(systemSize),
+          mPool(mMemorySize) {
         ASSERT(mMemorySize <= systemSize);
         ASSERT(IsPowerOfTwo(mMemorySize));
         ASSERT(IsAligned(systemSize, mMemorySize));

--- a/src/gpgmm/IndexedMemoryPool.cpp
+++ b/src/gpgmm/IndexedMemoryPool.cpp
@@ -19,6 +19,9 @@
 
 namespace gpgmm {
 
+    IndexedMemoryPool::IndexedMemoryPool(uint64_t memorySize) : MemoryPool(memorySize) {
+    }
+
     std::unique_ptr<MemoryAllocation> IndexedMemoryPool::AcquireFromPool(uint64_t memoryIndex) {
         if (memoryIndex >= mPool.size()) {
             mPool.resize(memoryIndex + 1);

--- a/src/gpgmm/IndexedMemoryPool.h
+++ b/src/gpgmm/IndexedMemoryPool.h
@@ -23,7 +23,7 @@ namespace gpgmm {
 
     class IndexedMemoryPool : public MemoryPool {
       public:
-        IndexedMemoryPool() = default;
+        explicit IndexedMemoryPool(uint64_t memorySize);
         ~IndexedMemoryPool() override = default;
 
         // MemoryPool interface

--- a/src/gpgmm/LIFOMemoryPool.cpp
+++ b/src/gpgmm/LIFOMemoryPool.cpp
@@ -21,6 +21,9 @@
 
 namespace gpgmm {
 
+    LIFOMemoryPool::LIFOMemoryPool(uint64_t memorySize) : MemoryPool(memorySize) {
+    }
+
     std::unique_ptr<MemoryAllocation> LIFOMemoryPool::AcquireFromPool(uint64_t memoryIndex) {
         ASSERT(memoryIndex == kInvalidIndex);
 

--- a/src/gpgmm/LIFOMemoryPool.h
+++ b/src/gpgmm/LIFOMemoryPool.h
@@ -21,10 +21,10 @@
 
 namespace gpgmm {
 
-    // Pools memory using LIFO queue (newest are recycled first).
+    // Pool using LIFO (newest are recycled first).
     class LIFOMemoryPool : public MemoryPool {
       public:
-        LIFOMemoryPool() = default;
+        explicit LIFOMemoryPool(uint64_t memorySize);
         ~LIFOMemoryPool() override = default;
 
         // MemoryPool interface

--- a/src/gpgmm/MemoryPool.cpp
+++ b/src/gpgmm/MemoryPool.cpp
@@ -18,7 +18,7 @@
 
 namespace gpgmm {
 
-    MemoryPool::MemoryPool() {
+    MemoryPool::MemoryPool(uint64_t memorySize) : mMemorySize(memorySize) {
         TRACE_EVENT_OBJECT_CREATED_WITH_ID("GPUMemoryPool", this);
     }
 
@@ -26,8 +26,12 @@ namespace gpgmm {
         TRACE_EVENT_OBJECT_DELETED_WITH_ID("GPUMemoryPool", this);
     }
 
+    uint64_t MemoryPool::GetMemorySize() const {
+        return mMemorySize;
+    }
+
     POOL_DESC MemoryPool::GetDesc() const {
-        return {GetPoolSize()};
+        return {GetPoolSize() * mMemorySize};
     }
 
 }  // namespace gpgmm

--- a/src/gpgmm/MemoryPool.h
+++ b/src/gpgmm/MemoryPool.h
@@ -30,7 +30,7 @@ namespace gpgmm {
     // Stores a collection of fixed-size memory blocks.
     class MemoryPool {
       public:
-        MemoryPool();
+        explicit MemoryPool(uint64_t memorySize);
         virtual ~MemoryPool();
 
         // Retrieves a memory allocation from the pool using an optional index.
@@ -47,7 +47,13 @@ namespace gpgmm {
         // Returns number of memory allocations in the pool.
         virtual uint64_t GetPoolSize() const = 0;
 
+        /// Returns the size of the memory blocks being pooled.
+        virtual uint64_t GetMemorySize() const;
+
         POOL_DESC GetDesc() const;
+
+      private:
+        uint64_t mMemorySize;
     };
 
 }  // namespace gpgmm

--- a/src/gpgmm/SegmentedMemoryAllocator.h
+++ b/src/gpgmm/SegmentedMemoryAllocator.h
@@ -15,6 +15,7 @@
 #ifndef GPGMM_SEGMENTEDMEMORYALLOCATOR_H_
 #define GPGMM_SEGMENTEDMEMORYALLOCATOR_H_
 
+#include "gpgmm/LIFOMemoryPool.h"
 #include "gpgmm/MemoryAllocator.h"
 #include "gpgmm/common/LinkedList.h"
 
@@ -25,21 +26,10 @@ namespace gpgmm {
     // Represents one or more memory blocks managed in a pool.
     // A memory segment is a node in a linked-list so it may be cached and reuse by the segmented
     // allocator.
-    class MemorySegment : public LinkNode<MemorySegment> {
+    class MemorySegment : public LIFOMemoryPool, public LinkNode<MemorySegment> {
       public:
-        MemorySegment(uint64_t memorySize, std::unique_ptr<MemoryPool> pool);
+        explicit MemorySegment(uint64_t memorySize);
         virtual ~MemorySegment();
-
-        // Return the size of the memory segment which is defined as the size of any memory block in
-        // the pool. The size is used to lookup a free memory block in a segment.
-        uint64_t GetSize() const;
-
-        // Return the pool managed by this segment.
-        MemoryPool* GetPool() const;
-
-      private:
-        const uint64_t mMemorySize;
-        std::unique_ptr<MemoryPool> mPool;
     };
 
     // SegmentedMemoryAllocator maintains a sorted segmented list of memory pools to allocate

--- a/src/tests/capture_replay_tests/traces/dawn_end2end_queuewritebuffertests_manywritebuffer.json
+++ b/src/tests/capture_replay_tests/traces/dawn_end2end_queuewritebuffertests_manywritebuffer.json
@@ -5,7 +5,7 @@
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
+      "tid": 16852,
       "ts": 0,
       "pid": "GPGMM",
       "args": {
@@ -26,35 +26,26 @@
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f7442b0",
-      "tid": 43696,
-      "ts": 4,
+      "id": "0x1743c061e80",
+      "tid": 16852,
+      "ts": 6,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d9c9c30",
-      "tid": 43696,
-      "ts": 23,
+      "id": "0x1743de43a98",
+      "tid": 16852,
+      "ts": 16,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d9c9e10",
-      "tid": 43696,
-      "ts": 29,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90d9c9870",
-      "tid": 43696,
+      "id": "0x1743de44c98",
+      "tid": 16852,
       "ts": 33,
       "pid": "GPGMM"
     },
@@ -62,8 +53,8 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d9ca590",
-      "tid": 43696,
+      "id": "0x1743de44798",
+      "tid": 16852,
       "ts": 38,
       "pid": "GPGMM"
     },
@@ -71,53 +62,35 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d9ca3b0",
-      "tid": 43696,
-      "ts": 42,
+      "id": "0x1743de44898",
+      "tid": 16852,
+      "ts": 45,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d9caef0",
-      "tid": 43696,
-      "ts": 46,
+      "id": "0x1743de44398",
+      "tid": 16852,
+      "ts": 50,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d9ca860",
-      "tid": 43696,
-      "ts": 49,
+      "id": "0x1743de45398",
+      "tid": 16852,
+      "ts": 55,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d9ca950",
-      "tid": 43696,
-      "ts": 53,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90d9c9960",
-      "tid": 43696,
-      "ts": 56,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90d9cab30",
-      "tid": 43696,
+      "id": "0x1743de44f98",
+      "tid": 16852,
       "ts": 60,
       "pid": "GPGMM"
     },
@@ -125,62 +98,17 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d9ca680",
-      "tid": 43696,
-      "ts": 65,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90d9ca4a0",
-      "tid": 43696,
-      "ts": 68,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90d9c9a50",
-      "tid": 43696,
-      "ts": 71,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90d9c9f00",
-      "tid": 43696,
-      "ts": 74,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90d9caa40",
-      "tid": 43696,
-      "ts": 77,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90d9ca770",
-      "tid": 43696,
-      "ts": 82,
+      "id": "0x1743de44298",
+      "tid": 16852,
+      "ts": 67,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 173,
+      "tid": 16852,
+      "ts": 154,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -210,91 +138,38 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 175,
+      "tid": 16852,
+      "ts": 156,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "ResourceAllocator.CreateCommittedResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 181,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d9ca680",
-      "tid": 43696,
-      "ts": 202,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 209,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f751950",
-      "tid": 43696,
-      "ts": 210,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f751950",
-      "tid": 43696,
-      "ts": 218,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 224,
+      "tid": 16852,
+      "ts": 163,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d97a3f0",
-      "tid": 43696,
-      "ts": 1187,
+      "id": "0x1743c091b10",
+      "tid": 16852,
+      "ts": 1093,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d97a3f0",
-      "tid": 43696,
-      "ts": 1208,
+      "id": "0x1743c091b10",
+      "tid": 16852,
+      "ts": 1114,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "Size": 4194304,
+          "Size": 4063232,
           "IsResident": 0,
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0
@@ -305,13 +180,13 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d97a3f0",
-      "tid": 43696,
-      "ts": 1234,
+      "id": "0x1743c091b10",
+      "tid": 16852,
+      "ts": 1178,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "Size": 4194304,
+          "Size": 4063232,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0
@@ -319,108 +194,38 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
+      "name": "ResourceAllocator.CreateCommittedResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 1236,
+      "tid": 16852,
+      "ts": 1194,
       "pid": "GPGMM"
-    },
-    {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 1237,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d9ca680",
-      "tid": 43696,
-      "ts": 1244,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 1247,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d97a3f0",
-      "tid": 43696,
-      "ts": 1268,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 1,
-          "MemoryPool": {
-            "id_ref": "0x1a90f751950"
-          }
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d97a3f0",
-      "tid": 43696,
-      "ts": 1382,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 1,
-          "MemoryPool": {
-            "id_ref": "0x1a90f751950"
-          }
-        }
-      }
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f82beb0",
-      "tid": 43696,
-      "ts": 1385,
+      "id": "0x1743df13920",
+      "tid": 16852,
+      "ts": 1201,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f82beb0",
-      "tid": 43696,
-      "ts": 1401,
+      "id": "0x1743df13920",
+      "tid": 16852,
+      "ts": 1228,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "Size": 4194304,
-          "HeapOffset": 0,
+          "Size": 4063232,
+          "HeapOffset": 18446744073709551615,
           "OffsetFromResource": 0,
-          "Method": 2,
+          "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x1a90d97a3f0"
+            "id_ref": "0x1743c091b10"
           }
         }
       }
@@ -429,16 +234,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 1404,
+      "tid": 16852,
+      "ts": 1231,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 1519,
+      "tid": 16852,
+      "ts": 1356,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -468,87 +273,34 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 1521,
+      "tid": 16852,
+      "ts": 1358,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "ResourceAllocator.CreateCommittedResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 1522,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d9c9960",
-      "tid": 43696,
-      "ts": 1535,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 1537,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f751e50",
-      "tid": 43696,
-      "ts": 1538,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f751e50",
-      "tid": 43696,
-      "ts": 1545,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 1547,
+      "tid": 16852,
+      "ts": 1359,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d97a750",
-      "tid": 43696,
-      "ts": 3325,
+      "id": "0x1743df16960",
+      "tid": 16852,
+      "ts": 3098,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d97a750",
-      "tid": 43696,
-      "ts": 3346,
+      "id": "0x1743df16960",
+      "tid": 16852,
+      "ts": 3136,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -563,9 +315,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d97a750",
-      "tid": 43696,
-      "ts": 3363,
+      "id": "0x1743df16960",
+      "tid": 16852,
+      "ts": 3164,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -577,108 +329,38 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
+      "name": "ResourceAllocator.CreateCommittedResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 3365,
+      "tid": 16852,
+      "ts": 3166,
       "pid": "GPGMM"
-    },
-    {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 3366,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d9c9960",
-      "tid": 43696,
-      "ts": 3373,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 3376,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d97a750",
-      "tid": 43696,
-      "ts": 3392,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 1,
-          "MemoryPool": {
-            "id_ref": "0x1a90f751e50"
-          }
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d97a750",
-      "tid": 43696,
-      "ts": 3425,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 1,
-          "MemoryPool": {
-            "id_ref": "0x1a90f751e50"
-          }
-        }
-      }
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f82c7a0",
-      "tid": 43696,
-      "ts": 3427,
+      "id": "0x1743df140b0",
+      "tid": 16852,
+      "ts": 3167,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f82c7a0",
-      "tid": 43696,
-      "ts": 3443,
+      "id": "0x1743df140b0",
+      "tid": 16852,
+      "ts": 3182,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
-          "HeapOffset": 0,
+          "HeapOffset": 18446744073709551615,
           "OffsetFromResource": 0,
-          "Method": 2,
+          "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x1a90d97a750"
+            "id_ref": "0x1743df16960"
           }
         }
       }
@@ -687,16 +369,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 3445,
+      "tid": 16852,
+      "ts": 3184,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 3534,
+      "tid": 16852,
+      "ts": 3314,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -726,78 +408,34 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 3536,
+      "tid": 16852,
+      "ts": 3316,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "ResourceAllocator.CreateCommittedResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 3537,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d9c9960",
-      "tid": 43696,
-      "ts": 3546,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 3548,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f751e50",
-      "tid": 43696,
-      "ts": 3555,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 3557,
+      "tid": 16852,
+      "ts": 3317,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d97b5f0",
-      "tid": 43696,
-      "ts": 5277,
+      "id": "0x1743df16b10",
+      "tid": 16852,
+      "ts": 6204,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d97b5f0",
-      "tid": 43696,
-      "ts": 5313,
+      "id": "0x1743df16b10",
+      "tid": 16852,
+      "ts": 6226,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -812,9 +450,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d97b5f0",
-      "tid": 43696,
-      "ts": 5330,
+      "id": "0x1743df16b10",
+      "tid": 16852,
+      "ts": 6243,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -826,108 +464,38 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
+      "name": "ResourceAllocator.CreateCommittedResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 5332,
+      "tid": 16852,
+      "ts": 6245,
       "pid": "GPGMM"
-    },
-    {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 5333,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d9c9960",
-      "tid": 43696,
-      "ts": 5340,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 2
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 5342,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d97b5f0",
-      "tid": 43696,
-      "ts": 5358,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 1,
-          "MemoryPool": {
-            "id_ref": "0x1a90f751e50"
-          }
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d97b5f0",
-      "tid": 43696,
-      "ts": 5390,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 1,
-          "MemoryPool": {
-            "id_ref": "0x1a90f751e50"
-          }
-        }
-      }
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f82bf60",
-      "tid": 43696,
-      "ts": 5392,
+      "id": "0x1743df139d0",
+      "tid": 16852,
+      "ts": 6246,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f82bf60",
-      "tid": 43696,
-      "ts": 5408,
+      "id": "0x1743df139d0",
+      "tid": 16852,
+      "ts": 6260,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
-          "HeapOffset": 0,
+          "HeapOffset": 18446744073709551615,
           "OffsetFromResource": 0,
-          "Method": 2,
+          "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x1a90d97b5f0"
+            "id_ref": "0x1743df16b10"
           }
         }
       }
@@ -936,16 +504,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 5410,
+      "tid": 16852,
+      "ts": 6262,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 5511,
+      "tid": 16852,
+      "ts": 6361,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -975,91 +543,38 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 5512,
+      "tid": 16852,
+      "ts": 6363,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "ResourceAllocator.CreateCommittedResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 5513,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d9ca860",
-      "tid": 43696,
-      "ts": 5533,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 5535,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f837d10",
-      "tid": 43696,
-      "ts": 5536,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f837d10",
-      "tid": 43696,
-      "ts": 5543,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 5545,
+      "tid": 16852,
+      "ts": 6364,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f8343f0",
-      "tid": 43696,
-      "ts": 6397,
+      "id": "0x1743df17800",
+      "tid": 16852,
+      "ts": 6644,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f8343f0",
-      "tid": 43696,
-      "ts": 6433,
+      "id": "0x1743df17800",
+      "tid": 16852,
+      "ts": 6665,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "Size": 4194304,
+          "Size": 262144,
           "IsResident": 0,
           "MemorySegmentGroup": 1,
           "SubAllocatedRefs": 0
@@ -1070,13 +585,13 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f8343f0",
-      "tid": 43696,
-      "ts": 6451,
+      "id": "0x1743df17800",
+      "tid": 16852,
+      "ts": 6680,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "Size": 4194304,
+          "Size": 262144,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
           "SubAllocatedRefs": 0
@@ -1084,108 +599,38 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
+      "name": "ResourceAllocator.CreateCommittedResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 6453,
+      "tid": 16852,
+      "ts": 6682,
       "pid": "GPGMM"
-    },
-    {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 6454,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d9ca860",
-      "tid": 43696,
-      "ts": 6461,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 6463,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f8343f0",
-      "tid": 43696,
-      "ts": 6479,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 1,
-          "MemoryPool": {
-            "id_ref": "0x1a90f837d10"
-          }
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f8343f0",
-      "tid": 43696,
-      "ts": 6514,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 1,
-          "MemoryPool": {
-            "id_ref": "0x1a90f837d10"
-          }
-        }
-      }
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f82c430",
-      "tid": 43696,
-      "ts": 6516,
+      "id": "0x1743df14210",
+      "tid": 16852,
+      "ts": 6683,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f82c430",
-      "tid": 43696,
-      "ts": 6532,
+      "id": "0x1743df14210",
+      "tid": 16852,
+      "ts": 6698,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 262144,
-          "HeapOffset": 0,
+          "HeapOffset": 18446744073709551615,
           "OffsetFromResource": 0,
-          "Method": 2,
+          "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x1a90f8343f0"
+            "id_ref": "0x1743df17800"
           }
         }
       }
@@ -1194,564 +639,225 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 6534,
+      "tid": 16852,
+      "ts": 6700,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 6603,
+      "tid": 16852,
+      "ts": 6776,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "GPUMemoryBlock",
       "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 6604,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d9ca680",
-      "tid": 43696,
-      "ts": 6616,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 6618,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f751950",
-      "tid": 43696,
-      "ts": 6643,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 6644,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 6645,
+      "ph": "D",
+      "id": "0x1743c091b10",
+      "tid": 16852,
+      "ts": 6776,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f82beb0",
-      "tid": 43696,
-      "ts": 6651,
+      "id": "0x1743df13920",
+      "tid": 16852,
+      "ts": 6955,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 6652,
+      "tid": 16852,
+      "ts": 6957,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 6690,
+      "tid": 16852,
+      "ts": 6987,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "GPUMemoryBlock",
       "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 6690,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d9ca860",
-      "tid": 43696,
-      "ts": 6702,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 6704,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f837d10",
-      "tid": 43696,
-      "ts": 6730,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 6732,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 6733,
+      "ph": "D",
+      "id": "0x1743df17800",
+      "tid": 16852,
+      "ts": 6987,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f82c430",
-      "tid": 43696,
-      "ts": 6736,
+      "id": "0x1743df14210",
+      "tid": 16852,
+      "ts": 7105,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 6736,
+      "tid": 16852,
+      "ts": 7107,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 6762,
+      "tid": 16852,
+      "ts": 7137,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "GPUMemoryBlock",
       "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 6762,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d9c9960",
-      "tid": 43696,
-      "ts": 6770,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 2
-        }
-      }
-    },
-    {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 6772,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f751e50",
-      "tid": 43696,
-      "ts": 6780,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 6789,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 6790,
+      "ph": "D",
+      "id": "0x1743df16960",
+      "tid": 16852,
+      "ts": 7137,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f82c7a0",
-      "tid": 43696,
-      "ts": 6793,
+      "id": "0x1743df140b0",
+      "tid": 16852,
+      "ts": 7320,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 6793,
+      "tid": 16852,
+      "ts": 7322,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 6819,
+      "tid": 16852,
+      "ts": 7352,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "GPUMemoryBlock",
       "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 6819,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d9c9960",
-      "tid": 43696,
-      "ts": 6829,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 6831,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f751e50",
-      "tid": 43696,
-      "ts": 6838,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 2
-        }
-      }
-    },
-    {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 6863,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 6863,
+      "ph": "D",
+      "id": "0x1743df16b10",
+      "tid": 16852,
+      "ts": 7352,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f82bf60",
-      "tid": 43696,
-      "ts": 6866,
+      "id": "0x1743df139d0",
+      "tid": 16852,
+      "ts": 7492,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 6867,
+      "tid": 16852,
+      "ts": 7501,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f7442b0",
-      "tid": 43696,
-      "ts": 6878,
+      "id": "0x1743c061e80",
+      "tid": 16852,
+      "ts": 7512,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90d9c9e10",
-      "tid": 43696,
-      "ts": 6879,
+      "id": "0x1743de43a98",
+      "tid": 16852,
+      "ts": 7525,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90d9ca590",
-      "tid": 43696,
-      "ts": 6882,
+      "id": "0x1743de44c98",
+      "tid": 16852,
+      "ts": 7530,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90d9caef0",
-      "tid": 43696,
-      "ts": 6883,
+      "id": "0x1743de44798",
+      "tid": 16852,
+      "ts": 7533,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90d9ca950",
-      "tid": 43696,
-      "ts": 6885,
+      "id": "0x1743de44898",
+      "tid": 16852,
+      "ts": 7535,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90d9cab30",
-      "tid": 43696,
-      "ts": 6887,
+      "id": "0x1743de44398",
+      "tid": 16852,
+      "ts": 7537,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90d9ca4a0",
-      "tid": 43696,
-      "ts": 6888,
+      "id": "0x1743de45398",
+      "tid": 16852,
+      "ts": 7540,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90d9c9f00",
-      "tid": 43696,
-      "ts": 6890,
+      "id": "0x1743de44f98",
+      "tid": 16852,
+      "ts": 7542,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90d9ca770",
-      "tid": 43696,
-      "ts": 6892,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90d9c9c30",
-      "tid": 43696,
-      "ts": 6893,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90d9c9870",
-      "tid": 43696,
-      "ts": 6896,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90d9ca3b0",
-      "tid": 43696,
-      "ts": 6898,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90d9ca860",
-      "tid": 43696,
-      "ts": 6901,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f8343f0",
-      "tid": 43696,
-      "ts": 6903,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f837d10",
-      "tid": 43696,
-      "ts": 7106,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90d9c9960",
-      "tid": 43696,
-      "ts": 7109,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90d97b5f0",
-      "tid": 43696,
-      "ts": 7111,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90d97a750",
-      "tid": 43696,
-      "ts": 7295,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f751e50",
-      "tid": 43696,
-      "ts": 7581,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90d9ca680",
-      "tid": 43696,
-      "ts": 7585,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90d97a3f0",
-      "tid": 43696,
-      "ts": 7587,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f751950",
-      "tid": 43696,
-      "ts": 7785,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90d9c9a50",
-      "tid": 43696,
-      "ts": 7799,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90d9caa40",
-      "tid": 43696,
-      "ts": 7802,
+      "id": "0x1743de44298",
+      "tid": 16852,
+      "ts": 7545,
       "pid": "GPGMM"
     }
   ]

--- a/src/tests/capture_replay_tests/traces/directml_samples_directmlxsuperresolution.json
+++ b/src/tests/capture_replay_tests/traces/directml_samples_directmlxsuperresolution.json
@@ -5,8 +5,8 @@
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 182863,
+      "tid": 16852,
+      "ts": 185190,
       "pid": "GPGMM",
       "args": {
         "Flags": 0,
@@ -26,161 +26,89 @@
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f79e410",
-      "tid": 43696,
-      "ts": 182870,
+      "id": "0x1743e0f9ed0",
+      "tid": 16852,
+      "ts": 185194,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f6f1d60",
-      "tid": 43696,
-      "ts": 182887,
+      "id": "0x1743de44698",
+      "tid": 16852,
+      "ts": 185214,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f6f1c70",
-      "tid": 43696,
-      "ts": 182899,
+      "id": "0x1743de44298",
+      "tid": 16852,
+      "ts": 185243,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f6f1220",
-      "tid": 43696,
-      "ts": 182905,
+      "id": "0x1743de44998",
+      "tid": 16852,
+      "ts": 185264,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f6f1130",
-      "tid": 43696,
-      "ts": 182915,
+      "id": "0x1743de44a98",
+      "tid": 16852,
+      "ts": 185271,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f6f1310",
-      "tid": 43696,
-      "ts": 182927,
+      "id": "0x1743de44098",
+      "tid": 16852,
+      "ts": 185288,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f6f1f40",
-      "tid": 43696,
-      "ts": 182937,
+      "id": "0x1743de44d98",
+      "tid": 16852,
+      "ts": 185294,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f6f24e0",
-      "tid": 43696,
-      "ts": 182944,
+      "id": "0x1743de43598",
+      "tid": 16852,
+      "ts": 185299,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f6f27b0",
-      "tid": 43696,
-      "ts": 182954,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 182960,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f6f2a80",
-      "tid": 43696,
-      "ts": 182966,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 182972,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f6f18b0",
-      "tid": 43696,
-      "ts": 182980,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f6f2b70",
-      "tid": 43696,
-      "ts": 182984,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f6f2c60",
-      "tid": 43696,
-      "ts": 182987,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f6f0e60",
-      "tid": 43696,
-      "ts": 182990,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f6f15e0",
-      "tid": 43696,
-      "ts": 182997,
+      "id": "0x1743de43698",
+      "tid": 16852,
+      "ts": 185309,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 183089,
+      "tid": 16852,
+      "ts": 185394,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -210,25 +138,41 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 183090,
+      "tid": 16852,
+      "ts": 185396,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 185397,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 185408,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 183092,
+      "tid": 16852,
+      "ts": 185414,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 183110,
+      "id": "0x1743de44098",
+      "tid": 16852,
+      "ts": 185432,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -240,26 +184,26 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 183113,
+      "tid": 16852,
+      "ts": 185435,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 183820,
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 186061,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 183844,
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 186085,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -274,9 +218,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 183864,
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 186114,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -291,21 +235,21 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 183866,
+      "tid": 16852,
+      "ts": 186115,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 183874,
+      "id": "0x1743de44098",
+      "tid": 16852,
+      "ts": 186123,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 4194304
         }
       }
     },
@@ -313,24 +257,40 @@
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 183877,
+      "tid": 16852,
+      "ts": 186126,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 186127,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 186128,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 183891,
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 186141,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 1
+          "SubAllocatedRefs": 2
         }
       }
     },
@@ -338,16 +298,16 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 183939,
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 186187,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 1
+          "SubAllocatedRefs": 2
         }
       }
     },
@@ -355,18 +315,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90fadcc60",
-      "tid": 43696,
-      "ts": 183942,
+      "id": "0x1743e24ae80",
+      "tid": 16852,
+      "ts": 186190,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90fadcc60",
-      "tid": 43696,
-      "ts": 183958,
+      "id": "0x1743e24ae80",
+      "tid": 16852,
+      "ts": 186205,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -375,7 +335,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90d9e8230"
+            "id_ref": "0x1743c092260"
           }
         }
       }
@@ -384,16 +344,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 183965,
+      "tid": 16852,
+      "ts": 186207,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 184070,
+      "tid": 16852,
+      "ts": 186326,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -423,68 +383,56 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 184072,
+      "tid": 16852,
+      "ts": 186328,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 184073,
+      "tid": 16852,
+      "ts": 186329,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 184081,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 186335,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 184089,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 184091,
+      "tid": 16852,
+      "ts": 186337,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 186338,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 184105,
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 186351,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 2
+          "SubAllocatedRefs": 3
         }
       }
     },
@@ -492,16 +440,16 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 184135,
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 186381,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 2
+          "SubAllocatedRefs": 3
         }
       }
     },
@@ -509,18 +457,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90fadce70",
-      "tid": 43696,
-      "ts": 184137,
+      "id": "0x1743e24b090",
+      "tid": 16852,
+      "ts": 186383,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90fadce70",
-      "tid": 43696,
-      "ts": 184153,
+      "id": "0x1743e24b090",
+      "tid": 16852,
+      "ts": 186397,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -529,7 +477,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90d9e8230"
+            "id_ref": "0x1743c092260"
           }
         }
       }
@@ -538,16 +486,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 184155,
+      "tid": 16852,
+      "ts": 186399,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 184229,
+      "tid": 16852,
+      "ts": 186467,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -577,68 +525,56 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 184230,
+      "tid": 16852,
+      "ts": 186469,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 184231,
+      "tid": 16852,
+      "ts": 186469,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 184239,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 186470,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 184247,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 184250,
+      "tid": 16852,
+      "ts": 186472,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 186473,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 184264,
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 186486,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 3
+          "SubAllocatedRefs": 4
         }
       }
     },
@@ -646,16 +582,16 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 184291,
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 186512,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 3
+          "SubAllocatedRefs": 4
         }
       }
     },
@@ -663,18 +599,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90faddc30",
-      "tid": 43696,
-      "ts": 184293,
+      "id": "0x1743e24a2d0",
+      "tid": 16852,
+      "ts": 186514,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90faddc30",
-      "tid": 43696,
-      "ts": 184309,
+      "id": "0x1743e24a2d0",
+      "tid": 16852,
+      "ts": 186527,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -683,7 +619,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90d9e8230"
+            "id_ref": "0x1743c092260"
           }
         }
       }
@@ -692,16 +628,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 184311,
+      "tid": 16852,
+      "ts": 186529,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 184403,
+      "tid": 16852,
+      "ts": 186615,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -739,50 +675,50 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 184406,
+      "tid": 16852,
+      "ts": 186618,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 184426,
+      "tid": 16852,
+      "ts": 186648,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 184427,
+      "tid": 16852,
+      "ts": 186659,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 184429,
+      "tid": 16852,
+      "ts": 186662,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d9e8500",
-      "tid": 43696,
-      "ts": 185981,
+      "id": "0x1743e24f6d0",
+      "tid": 16852,
+      "ts": 188325,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8500",
-      "tid": 43696,
-      "ts": 186002,
+      "id": "0x1743e24f6d0",
+      "tid": 16852,
+      "ts": 188346,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -797,9 +733,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8500",
-      "tid": 43696,
-      "ts": 186020,
+      "id": "0x1743e24f6d0",
+      "tid": 16852,
+      "ts": 188362,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -814,17 +750,17 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 186022,
+      "tid": 16852,
+      "ts": 188364,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8500",
-      "tid": 43696,
-      "ts": 186043,
+      "id": "0x1743e24f6d0",
+      "tid": 16852,
+      "ts": 188376,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -839,9 +775,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8500",
-      "tid": 43696,
-      "ts": 186433,
+      "id": "0x1743e24f6d0",
+      "tid": 16852,
+      "ts": 188767,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -856,18 +792,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90faddfa0",
-      "tid": 43696,
-      "ts": 186435,
+      "id": "0x1743e24bda0",
+      "tid": 16852,
+      "ts": 188769,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90faddfa0",
-      "tid": 43696,
-      "ts": 186451,
+      "id": "0x1743e24bda0",
+      "tid": 16852,
+      "ts": 188784,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -876,7 +812,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x1a90d9e8500"
+            "id_ref": "0x1743e24f6d0"
           }
         }
       }
@@ -885,16 +821,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 186454,
+      "tid": 16852,
+      "ts": 188793,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 186543,
+      "tid": 16852,
+      "ts": 188879,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -924,25 +860,41 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 186545,
+      "tid": 16852,
+      "ts": 188881,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 188882,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 188886,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 186546,
+      "tid": 16852,
+      "ts": 188889,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 186561,
+      "id": "0x1743de44d98",
+      "tid": 16852,
+      "ts": 188902,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -954,26 +906,26 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 186563,
+      "tid": 16852,
+      "ts": 188904,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 187767,
+      "id": "0x1743e24e290",
+      "tid": 16852,
+      "ts": 189989,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 187803,
+      "id": "0x1743e24e290",
+      "tid": 16852,
+      "ts": 190020,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -988,9 +940,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 187822,
+      "id": "0x1743e24e290",
+      "tid": 16852,
+      "ts": 190035,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1005,21 +957,21 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 187824,
+      "tid": 16852,
+      "ts": 190037,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 187832,
+      "id": "0x1743de44d98",
+      "tid": 16852,
+      "ts": 190043,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 4194304
         }
       }
     },
@@ -1027,24 +979,40 @@
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 187834,
+      "tid": 16852,
+      "ts": 190046,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 190047,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 190048,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 187848,
+      "id": "0x1743e24e290",
+      "tid": 16852,
+      "ts": 190060,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 1
+          "SubAllocatedRefs": 2
         }
       }
     },
@@ -1052,16 +1020,16 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 187889,
+      "id": "0x1743e24e290",
+      "tid": 16852,
+      "ts": 190089,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 1
+          "SubAllocatedRefs": 2
         }
       }
     },
@@ -1069,18 +1037,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f846e50",
-      "tid": 43696,
-      "ts": 187893,
+      "id": "0x1743e24add0",
+      "tid": 16852,
+      "ts": 190091,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f846e50",
-      "tid": 43696,
-      "ts": 187910,
+      "id": "0x1743e24add0",
+      "tid": 16852,
+      "ts": 190105,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1089,7 +1057,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90f843b40"
+            "id_ref": "0x1743e24e290"
           }
         }
       }
@@ -1098,16 +1066,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 187912,
+      "tid": 16852,
+      "ts": 190107,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 188018,
+      "tid": 16852,
+      "ts": 190196,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1137,68 +1105,56 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 188019,
+      "tid": 16852,
+      "ts": 190197,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 188021,
+      "tid": 16852,
+      "ts": 190198,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 188029,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 190199,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 188037,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 188039,
+      "tid": 16852,
+      "ts": 190202,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 190202,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 188053,
+      "id": "0x1743e24e290",
+      "tid": 16852,
+      "ts": 190215,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 2
+          "SubAllocatedRefs": 3
         }
       }
     },
@@ -1206,16 +1162,16 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 188083,
+      "id": "0x1743e24e290",
+      "tid": 16852,
+      "ts": 190241,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 2
+          "SubAllocatedRefs": 3
         }
       }
     },
@@ -1223,18 +1179,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f847c10",
-      "tid": 43696,
-      "ts": 188086,
+      "id": "0x1743e24b980",
+      "tid": 16852,
+      "ts": 190243,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f847c10",
-      "tid": 43696,
-      "ts": 188101,
+      "id": "0x1743e24b980",
+      "tid": 16852,
+      "ts": 190256,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1243,7 +1199,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90f843b40"
+            "id_ref": "0x1743e24e290"
           }
         }
       }
@@ -1252,16 +1208,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 188104,
+      "tid": 16852,
+      "ts": 190258,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 188181,
+      "tid": 16852,
+      "ts": 190324,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1291,68 +1247,56 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 188182,
+      "tid": 16852,
+      "ts": 190325,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 188183,
+      "tid": 16852,
+      "ts": 190326,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 188191,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 190327,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 188198,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 188201,
+      "tid": 16852,
+      "ts": 190329,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 190330,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 188215,
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 190342,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 4
+          "SubAllocatedRefs": 5
         }
       }
     },
@@ -1360,16 +1304,16 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 188244,
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 190366,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 4
+          "SubAllocatedRefs": 5
         }
       }
     },
@@ -1377,18 +1321,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f8461f0",
-      "tid": 43696,
-      "ts": 188247,
+      "id": "0x1743e24af30",
+      "tid": 16852,
+      "ts": 190368,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f8461f0",
-      "tid": 43696,
-      "ts": 188262,
+      "id": "0x1743e24af30",
+      "tid": 16852,
+      "ts": 190382,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1397,7 +1341,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90d9e8230"
+            "id_ref": "0x1743c092260"
           }
         }
       }
@@ -1406,16 +1350,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 188264,
+      "tid": 16852,
+      "ts": 190384,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 188334,
+      "tid": 16852,
+      "ts": 190446,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1445,68 +1389,56 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 188335,
+      "tid": 16852,
+      "ts": 190447,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 188336,
+      "tid": 16852,
+      "ts": 190448,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 188344,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 190449,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 188352,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 188355,
+      "tid": 16852,
+      "ts": 190451,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 190452,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 188369,
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 190463,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 5
+          "SubAllocatedRefs": 6
         }
       }
     },
@@ -1514,16 +1446,16 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 188398,
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 190490,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 5
+          "SubAllocatedRefs": 6
         }
       }
     },
@@ -1531,18 +1463,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f847690",
-      "tid": 43696,
-      "ts": 188401,
+      "id": "0x1743e24b770",
+      "tid": 16852,
+      "ts": 190492,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f847690",
-      "tid": 43696,
-      "ts": 188416,
+      "id": "0x1743e24b770",
+      "tid": 16852,
+      "ts": 190505,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1551,7 +1483,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90d9e8230"
+            "id_ref": "0x1743c092260"
           }
         }
       }
@@ -1560,16 +1492,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 188418,
+      "tid": 16852,
+      "ts": 190507,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 188487,
+      "tid": 16852,
+      "ts": 190570,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1599,68 +1531,56 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 188489,
+      "tid": 16852,
+      "ts": 190571,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 188489,
+      "tid": 16852,
+      "ts": 190572,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 188497,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 190573,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 188505,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 188507,
+      "tid": 16852,
+      "ts": 190575,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 190576,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 188521,
+      "id": "0x1743e24e290",
+      "tid": 16852,
+      "ts": 190587,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 3
+          "SubAllocatedRefs": 4
         }
       }
     },
@@ -1668,16 +1588,16 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 188548,
+      "id": "0x1743e24e290",
+      "tid": 16852,
+      "ts": 190612,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 3
+          "SubAllocatedRefs": 4
         }
       }
     },
@@ -1685,18 +1605,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f846820",
-      "tid": 43696,
-      "ts": 188551,
+      "id": "0x1743df98430",
+      "tid": 16852,
+      "ts": 190614,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f846820",
-      "tid": 43696,
-      "ts": 188566,
+      "id": "0x1743df98430",
+      "tid": 16852,
+      "ts": 190628,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1705,7 +1625,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90f843b40"
+            "id_ref": "0x1743e24e290"
           }
         }
       }
@@ -1714,16 +1634,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 188581,
+      "tid": 16852,
+      "ts": 190641,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 188655,
+      "tid": 16852,
+      "ts": 190704,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1753,68 +1673,56 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 188657,
+      "tid": 16852,
+      "ts": 190706,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 188658,
+      "tid": 16852,
+      "ts": 190707,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 188665,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 190708,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 188673,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 188675,
+      "tid": 16852,
+      "ts": 190710,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 190710,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 188689,
+      "id": "0x1743e24e290",
+      "tid": 16852,
+      "ts": 190722,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 4
+          "SubAllocatedRefs": 5
         }
       }
     },
@@ -1822,16 +1730,16 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 188717,
+      "id": "0x1743e24e290",
+      "tid": 16852,
+      "ts": 190746,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 4
+          "SubAllocatedRefs": 5
         }
       }
     },
@@ -1839,18 +1747,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f8475e0",
-      "tid": 43696,
-      "ts": 188719,
+      "id": "0x1743df975c0",
+      "tid": 16852,
+      "ts": 190748,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f8475e0",
-      "tid": 43696,
-      "ts": 188734,
+      "id": "0x1743df975c0",
+      "tid": 16852,
+      "ts": 190761,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1859,7 +1767,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90f843b40"
+            "id_ref": "0x1743e24e290"
           }
         }
       }
@@ -1868,16 +1776,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 188736,
+      "tid": 16852,
+      "ts": 190763,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 188808,
+      "tid": 16852,
+      "ts": 190825,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1907,68 +1815,56 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 188809,
+      "tid": 16852,
+      "ts": 190827,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 188810,
+      "tid": 16852,
+      "ts": 190828,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 188817,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 190829,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 188825,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 188830,
+      "tid": 16852,
+      "ts": 190831,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 190831,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 188843,
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 190843,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 6
+          "SubAllocatedRefs": 7
         }
       }
     },
@@ -1976,16 +1872,16 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 188871,
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 190866,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 6
+          "SubAllocatedRefs": 7
         }
       }
     },
@@ -1993,18 +1889,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f847a00",
-      "tid": 43696,
-      "ts": 188873,
+      "id": "0x1743df97e00",
+      "tid": 16852,
+      "ts": 190868,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f847a00",
-      "tid": 43696,
-      "ts": 188889,
+      "id": "0x1743df97e00",
+      "tid": 16852,
+      "ts": 190881,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2013,7 +1909,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90d9e8230"
+            "id_ref": "0x1743c092260"
           }
         }
       }
@@ -2022,16 +1918,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 188891,
+      "tid": 16852,
+      "ts": 190883,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 188960,
+      "tid": 16852,
+      "ts": 190945,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -2061,68 +1957,56 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 188961,
+      "tid": 16852,
+      "ts": 190947,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 188962,
+      "tid": 16852,
+      "ts": 190948,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 188970,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 190949,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 188978,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 188980,
+      "tid": 16852,
+      "ts": 190950,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 190951,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 188994,
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 190965,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 7
+          "SubAllocatedRefs": 8
         }
       }
     },
@@ -2130,16 +2014,16 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 189023,
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 190988,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 7
+          "SubAllocatedRefs": 8
         }
       }
     },
@@ -2147,18 +2031,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f847ab0",
-      "tid": 43696,
-      "ts": 189025,
+      "id": "0x1743df977d0",
+      "tid": 16852,
+      "ts": 190990,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f847ab0",
-      "tid": 43696,
-      "ts": 189041,
+      "id": "0x1743df977d0",
+      "tid": 16852,
+      "ts": 191003,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2167,7 +2051,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90d9e8230"
+            "id_ref": "0x1743c092260"
           }
         }
       }
@@ -2176,16 +2060,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 189043,
+      "tid": 16852,
+      "ts": 191005,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 189113,
+      "tid": 16852,
+      "ts": 191070,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -2215,43 +2099,118 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 189114,
+      "tid": 16852,
+      "ts": 191072,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 191073,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 191076,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 189115,
+      "tid": 16852,
+      "ts": 191079,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 189123,
+      "id": "0x1743de44d98",
+      "tid": 16852,
+      "ts": 191087,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 4194304
         }
       }
+    },
+    {
+      "name": "ResourceAllocator.CreateResourceHeap",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 191089,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x1743e24f400",
+      "tid": 16852,
+      "ts": 191781,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743e24f400",
+      "tid": 16852,
+      "ts": 191814,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 0,
+          "MemorySegmentGroup": 0,
+          "SubAllocatedRefs": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743e24f400",
+      "tid": 16852,
+      "ts": 191829,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 0,
+          "SubAllocatedRefs": 0
+        }
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResourceHeap",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 191830,
+      "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 189131,
+      "id": "0x1743de44d98",
+      "tid": 16852,
+      "ts": 191837,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 8388608
         }
       }
     },
@@ -2259,24 +2218,40 @@
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 189134,
+      "tid": 16852,
+      "ts": 191839,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 191841,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 191842,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 189148,
+      "id": "0x1743e24f400",
+      "tid": 16852,
+      "ts": 191853,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 5
+          "SubAllocatedRefs": 2
         }
       }
     },
@@ -2284,16 +2259,16 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 189176,
+      "id": "0x1743e24f400",
+      "tid": 16852,
+      "ts": 191880,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 5
+          "SubAllocatedRefs": 2
         }
       }
     },
@@ -2301,27 +2276,169 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f847530",
-      "tid": 43696,
-      "ts": 189179,
+      "id": "0x1743df97f60",
+      "tid": 16852,
+      "ts": 191883,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f847530",
-      "tid": 43696,
-      "ts": 189194,
+      "id": "0x1743df97f60",
+      "tid": 16852,
+      "ts": 191896,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 131072,
+          "HeapOffset": 0,
+          "OffsetFromResource": 0,
+          "Method": 2,
+          "ResourceHeap": {
+            "id_ref": "0x1743e24f400"
+          }
+        }
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 191898,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16852,
+      "ts": 191963,
+      "pid": "GPGMM",
+      "args": {
+        "allocationDescriptor": {
+          "Flags": 0,
+          "HeapType": 1
+        },
+        "resourceDescriptor": {
+          "Dimension": 1,
+          "Alignment": 0,
+          "Width": 128,
+          "Height": 1,
+          "DepthOrArraySize": 1,
+          "MipLevels": 1,
+          "Format": 0,
+          "Layout": 1,
+          "SampleDesc": {
+            "Count": 1,
+            "Quality": 0
+          },
+          "Flags": 4
+        },
+        "initialResourceState": 0,
+        "clearValue": {}
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 191965,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 191966,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 191967,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 191969,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 191970,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743e24e290",
+      "tid": 16852,
+      "ts": 191982,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 0,
+          "SubAllocatedRefs": 6
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743e24e290",
+      "tid": 16852,
+      "ts": 192010,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 0,
+          "SubAllocatedRefs": 6
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x1743df984e0",
+      "tid": 16852,
+      "ts": 192012,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743df984e0",
+      "tid": 16852,
+      "ts": 192025,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 65536,
           "HeapOffset": 262144,
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90f843b40"
+            "id_ref": "0x1743e24e290"
           }
         }
       }
@@ -2330,170 +2447,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 189196,
+      "tid": 16852,
+      "ts": 192027,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 189266,
-      "pid": "GPGMM",
-      "args": {
-        "allocationDescriptor": {
-          "Flags": 0,
-          "HeapType": 1
-        },
-        "resourceDescriptor": {
-          "Dimension": 1,
-          "Alignment": 0,
-          "Width": 128,
-          "Height": 1,
-          "DepthOrArraySize": 1,
-          "MipLevels": 1,
-          "Format": 0,
-          "Layout": 1,
-          "SampleDesc": {
-            "Count": 1,
-            "Quality": 0
-          },
-          "Flags": 4
-        },
-        "initialResourceState": 0,
-        "clearValue": {}
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 189269,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 189270,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 189278,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 189286,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 189288,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 189302,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 6
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 189329,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 6
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f8478a0",
-      "tid": 43696,
-      "ts": 189331,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f8478a0",
-      "tid": 43696,
-      "ts": 189346,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 65536,
-          "HeapOffset": 393216,
-          "OffsetFromResource": 0,
-          "Method": 2,
-          "ResourceHeap": {
-            "id_ref": "0x1a90f843b40"
-          }
-        }
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 189350,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "i",
-      "tid": 43696,
-      "ts": 189422,
+      "tid": 16852,
+      "ts": 192090,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -2523,43 +2486,118 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 189424,
+      "tid": 16852,
+      "ts": 192092,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 192092,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 192096,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 189424,
+      "tid": 16852,
+      "ts": 192098,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 189433,
+      "id": "0x1743de44098",
+      "tid": 16852,
+      "ts": 192107,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 4194304
         }
       }
+    },
+    {
+      "name": "ResourceAllocator.CreateResourceHeap",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 192109,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x1743e24e320",
+      "tid": 16852,
+      "ts": 195151,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743e24e320",
+      "tid": 16852,
+      "ts": 195184,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 0,
+          "MemorySegmentGroup": 1,
+          "SubAllocatedRefs": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743e24e320",
+      "tid": 16852,
+      "ts": 195199,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 1,
+          "SubAllocatedRefs": 0
+        }
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResourceHeap",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 195201,
+      "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 189441,
+      "id": "0x1743de44098",
+      "tid": 16852,
+      "ts": 195207,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 8388608
         }
       }
     },
@@ -2567,24 +2605,40 @@
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 189443,
+      "tid": 16852,
+      "ts": 195210,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 195211,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 195212,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 189457,
+      "id": "0x1743e24e320",
+      "tid": 16852,
+      "ts": 195224,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 8
+          "SubAllocatedRefs": 2
         }
       }
     },
@@ -2592,16 +2646,16 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 189485,
+      "id": "0x1743e24e320",
+      "tid": 16852,
+      "ts": 195249,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 8
+          "SubAllocatedRefs": 2
         }
       }
     },
@@ -2609,27 +2663,27 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f847110",
-      "tid": 43696,
-      "ts": 189487,
+      "id": "0x1743df97040",
+      "tid": 16852,
+      "ts": 195251,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f847110",
-      "tid": 43696,
-      "ts": 189503,
+      "id": "0x1743df97040",
+      "tid": 16852,
+      "ts": 195265,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 131072,
-          "HeapOffset": 524288,
+          "HeapOffset": 0,
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90d9e8230"
+            "id_ref": "0x1743e24e320"
           }
         }
       }
@@ -2638,16 +2692,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 189505,
+      "tid": 16852,
+      "ts": 195267,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 189574,
+      "tid": 16852,
+      "ts": 195334,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -2677,61 +2731,49 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 189576,
+      "tid": 16852,
+      "ts": 195335,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 189576,
+      "tid": 16852,
+      "ts": 195336,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 189583,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 195337,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 189591,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 189594,
+      "tid": 16852,
+      "ts": 195339,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 195340,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 189607,
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 195352,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2746,9 +2788,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 189633,
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 195375,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2763,18 +2805,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f846560",
-      "tid": 43696,
-      "ts": 189636,
+      "id": "0x1743df97a90",
+      "tid": 16852,
+      "ts": 195377,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f846560",
-      "tid": 43696,
-      "ts": 189651,
+      "id": "0x1743df97a90",
+      "tid": 16852,
+      "ts": 195390,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2783,7 +2825,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90d9e8230"
+            "id_ref": "0x1743c092260"
           }
         }
       }
@@ -2792,16 +2834,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 189653,
+      "tid": 16852,
+      "ts": 195392,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 189772,
+      "tid": 16852,
+      "ts": 195455,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -2831,61 +2873,191 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 189774,
+      "tid": 16852,
+      "ts": 195457,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 189775,
+      "tid": 16852,
+      "ts": 195458,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 189784,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 195459,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 189792,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 189795,
+      "tid": 16852,
+      "ts": 195460,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 195461,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 189810,
+      "id": "0x1743e24f400",
+      "tid": 16852,
+      "ts": 195473,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 0,
+          "SubAllocatedRefs": 3
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743e24f400",
+      "tid": 16852,
+      "ts": 195496,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 0,
+          "SubAllocatedRefs": 3
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x1743df98170",
+      "tid": 16852,
+      "ts": 195498,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743df98170",
+      "tid": 16852,
+      "ts": 195511,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 131072,
+          "HeapOffset": 131072,
+          "OffsetFromResource": 0,
+          "Method": 2,
+          "ResourceHeap": {
+            "id_ref": "0x1743e24f400"
+          }
+        }
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 195513,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16852,
+      "ts": 195575,
+      "pid": "GPGMM",
+      "args": {
+        "allocationDescriptor": {
+          "Flags": 0,
+          "HeapType": 1
+        },
+        "resourceDescriptor": {
+          "Dimension": 1,
+          "Alignment": 0,
+          "Width": 64,
+          "Height": 1,
+          "DepthOrArraySize": 1,
+          "MipLevels": 1,
+          "Format": 0,
+          "Layout": 1,
+          "SampleDesc": {
+            "Count": 1,
+            "Quality": 0
+          },
+          "Flags": 4
+        },
+        "initialResourceState": 0,
+        "clearValue": {}
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 195576,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 195577,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 195578,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 195580,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 195581,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743e24e290",
+      "tid": 16852,
+      "ts": 195593,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2900,9 +3072,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 189841,
+      "id": "0x1743e24e290",
+      "tid": 16852,
+      "ts": 195615,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2917,27 +3089,311 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f846980",
-      "tid": 43696,
-      "ts": 189843,
+      "id": "0x1743df97510",
+      "tid": 16852,
+      "ts": 195617,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f846980",
-      "tid": 43696,
-      "ts": 189860,
+      "id": "0x1743df97510",
+      "tid": 16852,
+      "ts": 195630,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 65536,
+          "HeapOffset": 327680,
+          "OffsetFromResource": 0,
+          "Method": 2,
+          "ResourceHeap": {
+            "id_ref": "0x1743e24e290"
+          }
+        }
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 195632,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16852,
+      "ts": 195695,
+      "pid": "GPGMM",
+      "args": {
+        "allocationDescriptor": {
+          "Flags": 0,
+          "HeapType": 2
+        },
+        "resourceDescriptor": {
+          "Dimension": 1,
+          "Alignment": 0,
+          "Width": 102400,
+          "Height": 1,
+          "DepthOrArraySize": 1,
+          "MipLevels": 1,
+          "Format": 0,
+          "Layout": 1,
+          "SampleDesc": {
+            "Count": 1,
+            "Quality": 0
+          },
+          "Flags": 0
+        },
+        "initialResourceState": 2755,
+        "clearValue": {}
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 195696,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 195697,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 195698,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 195700,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 195701,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743e24e320",
+      "tid": 16852,
+      "ts": 195712,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 1,
+          "SubAllocatedRefs": 3
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743e24e320",
+      "tid": 16852,
+      "ts": 195734,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 1,
+          "SubAllocatedRefs": 3
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x1743df97b40",
+      "tid": 16852,
+      "ts": 195736,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743df97b40",
+      "tid": 16852,
+      "ts": 195749,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 131072,
+          "HeapOffset": 131072,
+          "OffsetFromResource": 0,
+          "Method": 2,
+          "ResourceHeap": {
+            "id_ref": "0x1743e24e320"
+          }
+        }
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 195771,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16852,
+      "ts": 195834,
+      "pid": "GPGMM",
+      "args": {
+        "allocationDescriptor": {
+          "Flags": 0,
+          "HeapType": 2
+        },
+        "resourceDescriptor": {
+          "Dimension": 1,
+          "Alignment": 0,
+          "Width": 64,
+          "Height": 1,
+          "DepthOrArraySize": 1,
+          "MipLevels": 1,
+          "Format": 0,
+          "Layout": 1,
+          "SampleDesc": {
+            "Count": 1,
+            "Quality": 0
+          },
+          "Flags": 0
+        },
+        "initialResourceState": 2755,
+        "clearValue": {}
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 195836,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 195836,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 195837,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 195839,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 195840,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 195852,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 1,
+          "SubAllocatedRefs": 10
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 195874,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 1,
+          "SubAllocatedRefs": 10
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x1743df980c0",
+      "tid": 16852,
+      "ts": 195876,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743df980c0",
+      "tid": 16852,
+      "ts": 195889,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 65536,
           "HeapOffset": 524288,
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90f843b40"
+            "id_ref": "0x1743c092260"
           }
         }
       }
@@ -2946,478 +3402,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 189862,
+      "tid": 16852,
+      "ts": 195891,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 189944,
-      "pid": "GPGMM",
-      "args": {
-        "allocationDescriptor": {
-          "Flags": 0,
-          "HeapType": 1
-        },
-        "resourceDescriptor": {
-          "Dimension": 1,
-          "Alignment": 0,
-          "Width": 64,
-          "Height": 1,
-          "DepthOrArraySize": 1,
-          "MipLevels": 1,
-          "Format": 0,
-          "Layout": 1,
-          "SampleDesc": {
-            "Count": 1,
-            "Quality": 0
-          },
-          "Flags": 4
-        },
-        "initialResourceState": 0,
-        "clearValue": {}
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 189946,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 189946,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 189954,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 189962,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 189964,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 189978,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 8
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 190004,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 8
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f847e20",
-      "tid": 43696,
-      "ts": 190007,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f847e20",
-      "tid": 43696,
-      "ts": 190023,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 65536,
-          "HeapOffset": 458752,
-          "OffsetFromResource": 0,
-          "Method": 2,
-          "ResourceHeap": {
-            "id_ref": "0x1a90f843b40"
-          }
-        }
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 190025,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "i",
-      "tid": 43696,
-      "ts": 190095,
-      "pid": "GPGMM",
-      "args": {
-        "allocationDescriptor": {
-          "Flags": 0,
-          "HeapType": 2
-        },
-        "resourceDescriptor": {
-          "Dimension": 1,
-          "Alignment": 0,
-          "Width": 102400,
-          "Height": 1,
-          "DepthOrArraySize": 1,
-          "MipLevels": 1,
-          "Format": 0,
-          "Layout": 1,
-          "SampleDesc": {
-            "Count": 1,
-            "Quality": 0
-          },
-          "Flags": 0
-        },
-        "initialResourceState": 2755,
-        "clearValue": {}
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 190096,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 190097,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 190104,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 190112,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 190115,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 190128,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 10
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 190165,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 10
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f846ae0",
-      "tid": 43696,
-      "ts": 190167,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f846ae0",
-      "tid": 43696,
-      "ts": 190183,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 131072,
-          "HeapOffset": 655360,
-          "OffsetFromResource": 0,
-          "Method": 2,
-          "ResourceHeap": {
-            "id_ref": "0x1a90d9e8230"
-          }
-        }
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 190185,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "i",
-      "tid": 43696,
-      "ts": 190248,
-      "pid": "GPGMM",
-      "args": {
-        "allocationDescriptor": {
-          "Flags": 0,
-          "HeapType": 2
-        },
-        "resourceDescriptor": {
-          "Dimension": 1,
-          "Alignment": 0,
-          "Width": 64,
-          "Height": 1,
-          "DepthOrArraySize": 1,
-          "MipLevels": 1,
-          "Format": 0,
-          "Layout": 1,
-          "SampleDesc": {
-            "Count": 1,
-            "Quality": 0
-          },
-          "Flags": 0
-        },
-        "initialResourceState": 2755,
-        "clearValue": {}
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 190250,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 190250,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 190258,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 190266,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 190269,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 190282,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 11
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 190309,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 11
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f846c40",
-      "tid": 43696,
-      "ts": 190312,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f846c40",
-      "tid": 43696,
-      "ts": 190327,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 65536,
-          "HeapOffset": 786432,
-          "OffsetFromResource": 0,
-          "Method": 2,
-          "ResourceHeap": {
-            "id_ref": "0x1a90d9e8230"
-          }
-        }
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 190329,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "i",
-      "tid": 43696,
-      "ts": 190393,
+      "tid": 16852,
+      "ts": 195953,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -3447,68 +3441,56 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 190395,
+      "tid": 16852,
+      "ts": 195955,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 190396,
+      "tid": 16852,
+      "ts": 195955,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 190403,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 195956,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 190411,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 190413,
+      "tid": 16852,
+      "ts": 195958,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 195959,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 190448,
+      "id": "0x1743e24e290",
+      "tid": 16852,
+      "ts": 195971,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 9
+          "SubAllocatedRefs": 8
         }
       }
     },
@@ -3516,16 +3498,16 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 190476,
+      "id": "0x1743e24e290",
+      "tid": 16852,
+      "ts": 195993,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 9
+          "SubAllocatedRefs": 8
         }
       }
     },
@@ -3533,27 +3515,27 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f84c940",
-      "tid": 43696,
-      "ts": 190478,
+      "id": "0x1743df96d80",
+      "tid": 16852,
+      "ts": 195995,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f84c940",
-      "tid": 43696,
-      "ts": 190493,
+      "id": "0x1743df96d80",
+      "tid": 16852,
+      "ts": 196008,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 65536,
-          "HeapOffset": 655360,
+          "HeapOffset": 393216,
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90f843b40"
+            "id_ref": "0x1743e24e290"
           }
         }
       }
@@ -3562,16 +3544,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 190495,
+      "tid": 16852,
+      "ts": 196010,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 190562,
+      "tid": 16852,
+      "ts": 196073,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -3601,61 +3583,475 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 190564,
+      "tid": 16852,
+      "ts": 196074,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 190565,
+      "tid": 16852,
+      "ts": 196075,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 190572,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 196076,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 190579,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 190582,
+      "tid": 16852,
+      "ts": 196078,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 196078,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 190595,
+      "id": "0x1743e24e290",
+      "tid": 16852,
+      "ts": 196090,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 0,
+          "SubAllocatedRefs": 9
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743e24e290",
+      "tid": 16852,
+      "ts": 196112,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 0,
+          "SubAllocatedRefs": 9
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x1743e24a590",
+      "tid": 16852,
+      "ts": 196114,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743e24a590",
+      "tid": 16852,
+      "ts": 196129,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 65536,
+          "HeapOffset": 458752,
+          "OffsetFromResource": 0,
+          "Method": 2,
+          "ResourceHeap": {
+            "id_ref": "0x1743e24e290"
+          }
+        }
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 196131,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16852,
+      "ts": 196193,
+      "pid": "GPGMM",
+      "args": {
+        "allocationDescriptor": {
+          "Flags": 0,
+          "HeapType": 2
+        },
+        "resourceDescriptor": {
+          "Dimension": 1,
+          "Alignment": 0,
+          "Width": 18432,
+          "Height": 1,
+          "DepthOrArraySize": 1,
+          "MipLevels": 1,
+          "Format": 0,
+          "Layout": 1,
+          "SampleDesc": {
+            "Count": 1,
+            "Quality": 0
+          },
+          "Flags": 0
+        },
+        "initialResourceState": 2755,
+        "clearValue": {}
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 196195,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 196195,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 196196,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 196198,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 196199,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 196211,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 1,
+          "SubAllocatedRefs": 11
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 196235,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 1,
+          "SubAllocatedRefs": 11
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x1743df9cec0",
+      "tid": 16852,
+      "ts": 196237,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743df9cec0",
+      "tid": 16852,
+      "ts": 196250,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 65536,
+          "HeapOffset": 589824,
+          "OffsetFromResource": 0,
+          "Method": 2,
+          "ResourceHeap": {
+            "id_ref": "0x1743c092260"
+          }
+        }
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 196252,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16852,
+      "ts": 196315,
+      "pid": "GPGMM",
+      "args": {
+        "allocationDescriptor": {
+          "Flags": 0,
+          "HeapType": 2
+        },
+        "resourceDescriptor": {
+          "Dimension": 1,
+          "Alignment": 0,
+          "Width": 64,
+          "Height": 1,
+          "DepthOrArraySize": 1,
+          "MipLevels": 1,
+          "Format": 0,
+          "Layout": 1,
+          "SampleDesc": {
+            "Count": 1,
+            "Quality": 0
+          },
+          "Flags": 0
+        },
+        "initialResourceState": 2755,
+        "clearValue": {}
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 196316,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 196317,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 196318,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 196320,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 196321,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 196332,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 1,
+          "SubAllocatedRefs": 12
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 196354,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 1,
+          "SubAllocatedRefs": 12
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x1743df9b810",
+      "tid": 16852,
+      "ts": 196356,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743df9b810",
+      "tid": 16852,
+      "ts": 196369,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 65536,
+          "HeapOffset": 655360,
+          "OffsetFromResource": 0,
+          "Method": 2,
+          "ResourceHeap": {
+            "id_ref": "0x1743c092260"
+          }
+        }
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 196371,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16852,
+      "ts": 196437,
+      "pid": "GPGMM",
+      "args": {
+        "allocationDescriptor": {
+          "Flags": 0,
+          "HeapType": 1
+        },
+        "resourceDescriptor": {
+          "Dimension": 1,
+          "Alignment": 0,
+          "Width": 18432,
+          "Height": 1,
+          "DepthOrArraySize": 1,
+          "MipLevels": 1,
+          "Format": 0,
+          "Layout": 1,
+          "SampleDesc": {
+            "Count": 1,
+            "Quality": 0
+          },
+          "Flags": 4
+        },
+        "initialResourceState": 0,
+        "clearValue": {}
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 196439,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 196439,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 196440,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 196442,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 196443,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743e24e290",
+      "tid": 16852,
+      "ts": 196455,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3670,9 +4066,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 190620,
+      "id": "0x1743e24e290",
+      "tid": 16852,
+      "ts": 196477,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3687,18 +4083,302 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f84c5d0",
-      "tid": 43696,
-      "ts": 190623,
+      "id": "0x1743df9bfa0",
+      "tid": 16852,
+      "ts": 196479,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f84c5d0",
-      "tid": 43696,
-      "ts": 190638,
+      "id": "0x1743df9bfa0",
+      "tid": 16852,
+      "ts": 196492,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 65536,
+          "HeapOffset": 524288,
+          "OffsetFromResource": 0,
+          "Method": 2,
+          "ResourceHeap": {
+            "id_ref": "0x1743e24e290"
+          }
+        }
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 196494,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16852,
+      "ts": 196556,
+      "pid": "GPGMM",
+      "args": {
+        "allocationDescriptor": {
+          "Flags": 0,
+          "HeapType": 1
+        },
+        "resourceDescriptor": {
+          "Dimension": 1,
+          "Alignment": 0,
+          "Width": 64,
+          "Height": 1,
+          "DepthOrArraySize": 1,
+          "MipLevels": 1,
+          "Format": 0,
+          "Layout": 1,
+          "SampleDesc": {
+            "Count": 1,
+            "Quality": 0
+          },
+          "Flags": 4
+        },
+        "initialResourceState": 0,
+        "clearValue": {}
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 196557,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 196558,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 196559,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 196561,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 196562,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743e24e290",
+      "tid": 16852,
+      "ts": 196574,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 0,
+          "SubAllocatedRefs": 11
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743e24e290",
+      "tid": 16852,
+      "ts": 196595,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 0,
+          "SubAllocatedRefs": 11
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x1743df9b550",
+      "tid": 16852,
+      "ts": 196597,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743df9b550",
+      "tid": 16852,
+      "ts": 196610,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 65536,
+          "HeapOffset": 589824,
+          "OffsetFromResource": 0,
+          "Method": 2,
+          "ResourceHeap": {
+            "id_ref": "0x1743e24e290"
+          }
+        }
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 196612,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16852,
+      "ts": 196675,
+      "pid": "GPGMM",
+      "args": {
+        "allocationDescriptor": {
+          "Flags": 0,
+          "HeapType": 2
+        },
+        "resourceDescriptor": {
+          "Dimension": 1,
+          "Alignment": 0,
+          "Width": 18432,
+          "Height": 1,
+          "DepthOrArraySize": 1,
+          "MipLevels": 1,
+          "Format": 0,
+          "Layout": 1,
+          "SampleDesc": {
+            "Count": 1,
+            "Quality": 0
+          },
+          "Flags": 0
+        },
+        "initialResourceState": 2755,
+        "clearValue": {}
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 196676,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 196677,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 196678,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 196680,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 196681,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 196693,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 1,
+          "SubAllocatedRefs": 13
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 196717,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 1,
+          "SubAllocatedRefs": 13
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x1743df9c100",
+      "tid": 16852,
+      "ts": 196719,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743df9c100",
+      "tid": 16852,
+      "ts": 196732,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3707,7 +4387,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90f843b40"
+            "id_ref": "0x1743c092260"
           }
         }
       }
@@ -3716,170 +4396,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 190640,
+      "tid": 16852,
+      "ts": 196733,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 190706,
-      "pid": "GPGMM",
-      "args": {
-        "allocationDescriptor": {
-          "Flags": 0,
-          "HeapType": 2
-        },
-        "resourceDescriptor": {
-          "Dimension": 1,
-          "Alignment": 0,
-          "Width": 18432,
-          "Height": 1,
-          "DepthOrArraySize": 1,
-          "MipLevels": 1,
-          "Format": 0,
-          "Layout": 1,
-          "SampleDesc": {
-            "Count": 1,
-            "Quality": 0
-          },
-          "Flags": 0
-        },
-        "initialResourceState": 2755,
-        "clearValue": {}
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 190708,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 190709,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 190716,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 190723,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 190726,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 190739,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 12
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 190764,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 12
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f84d020",
-      "tid": 43696,
-      "ts": 190767,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f84d020",
-      "tid": 43696,
-      "ts": 190782,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 65536,
-          "HeapOffset": 851968,
-          "OffsetFromResource": 0,
-          "Method": 2,
-          "ResourceHeap": {
-            "id_ref": "0x1a90d9e8230"
-          }
-        }
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 190784,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "i",
-      "tid": 43696,
-      "ts": 190848,
+      "tid": 16852,
+      "ts": 196798,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -3909,68 +4435,56 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 190849,
+      "tid": 16852,
+      "ts": 196799,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 190850,
+      "tid": 16852,
+      "ts": 196800,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 190857,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 196801,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 190865,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 190867,
+      "tid": 16852,
+      "ts": 196803,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 196803,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 190881,
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 196815,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 13
+          "SubAllocatedRefs": 14
         }
       }
     },
@@ -3978,16 +4492,16 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 190906,
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 196839,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 13
+          "SubAllocatedRefs": 14
         }
       }
     },
@@ -3995,172 +4509,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f84d5a0",
-      "tid": 43696,
-      "ts": 190908,
+      "id": "0x1743df9c470",
+      "tid": 16852,
+      "ts": 196841,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f84d5a0",
-      "tid": 43696,
-      "ts": 190923,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 65536,
-          "HeapOffset": 917504,
-          "OffsetFromResource": 0,
-          "Method": 2,
-          "ResourceHeap": {
-            "id_ref": "0x1a90d9e8230"
-          }
-        }
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 190925,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "i",
-      "tid": 43696,
-      "ts": 190991,
-      "pid": "GPGMM",
-      "args": {
-        "allocationDescriptor": {
-          "Flags": 0,
-          "HeapType": 1
-        },
-        "resourceDescriptor": {
-          "Dimension": 1,
-          "Alignment": 0,
-          "Width": 18432,
-          "Height": 1,
-          "DepthOrArraySize": 1,
-          "MipLevels": 1,
-          "Format": 0,
-          "Layout": 1,
-          "SampleDesc": {
-            "Count": 1,
-            "Quality": 0
-          },
-          "Flags": 4
-        },
-        "initialResourceState": 0,
-        "clearValue": {}
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 190993,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 190993,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 191001,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 191009,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 191011,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 191025,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 11
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 191050,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 11
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f84d650",
-      "tid": 43696,
-      "ts": 191053,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f84d650",
-      "tid": 43696,
-      "ts": 191068,
+      "id": "0x1743df9c470",
+      "tid": 16852,
+      "ts": 196854,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4169,7 +4529,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90f843b40"
+            "id_ref": "0x1743c092260"
           }
         }
       }
@@ -4178,16 +4538,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 191070,
+      "tid": 16852,
+      "ts": 196855,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 191136,
+      "tid": 16852,
+      "ts": 196920,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -4197,7 +4557,7 @@
         "resourceDescriptor": {
           "Dimension": 1,
           "Alignment": 0,
-          "Width": 64,
+          "Width": 1728,
           "Height": 1,
           "DepthOrArraySize": 1,
           "MipLevels": 1,
@@ -4217,61 +4577,49 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 191138,
+      "tid": 16852,
+      "ts": 196922,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 191139,
+      "tid": 16852,
+      "ts": 196923,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 191146,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 196924,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 191153,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 191156,
+      "tid": 16852,
+      "ts": 196925,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 196926,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 191170,
+      "id": "0x1743e24e290",
+      "tid": 16852,
+      "ts": 196939,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4286,9 +4634,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 191194,
+      "id": "0x1743e24e290",
+      "tid": 16852,
+      "ts": 196965,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4303,18 +4651,160 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f84c680",
-      "tid": 43696,
-      "ts": 191196,
+      "id": "0x1743df9c310",
+      "tid": 16852,
+      "ts": 196967,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f84c680",
-      "tid": 43696,
-      "ts": 191211,
+      "id": "0x1743df9c310",
+      "tid": 16852,
+      "ts": 196981,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 65536,
+          "HeapOffset": 655360,
+          "OffsetFromResource": 0,
+          "Method": 2,
+          "ResourceHeap": {
+            "id_ref": "0x1743e24e290"
+          }
+        }
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 196983,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16852,
+      "ts": 197095,
+      "pid": "GPGMM",
+      "args": {
+        "allocationDescriptor": {
+          "Flags": 0,
+          "HeapType": 2
+        },
+        "resourceDescriptor": {
+          "Dimension": 1,
+          "Alignment": 0,
+          "Width": 1728,
+          "Height": 1,
+          "DepthOrArraySize": 1,
+          "MipLevels": 1,
+          "Format": 0,
+          "Layout": 1,
+          "SampleDesc": {
+            "Count": 1,
+            "Quality": 0
+          },
+          "Flags": 0
+        },
+        "initialResourceState": 2755,
+        "clearValue": {}
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197097,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197097,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197098,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197100,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197101,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 197113,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 1,
+          "SubAllocatedRefs": 15
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 197139,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 1,
+          "SubAllocatedRefs": 15
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x1743df9ba20",
+      "tid": 16852,
+      "ts": 197141,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743df9ba20",
+      "tid": 16852,
+      "ts": 197154,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4323,7 +4813,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90f843b40"
+            "id_ref": "0x1743c092260"
           }
         }
       }
@@ -4332,1529 +4822,796 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 191213,
+      "tid": 16852,
+      "ts": 197156,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197199,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197199,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197200,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197201,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197201,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x1743e24af30",
+      "tid": 16852,
+      "ts": 197207,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197207,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197228,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197228,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197229,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197229,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197230,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x1743e24b770",
+      "tid": 16852,
+      "ts": 197232,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197232,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197252,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197252,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197252,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197253,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197253,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x1743df97e00",
+      "tid": 16852,
+      "ts": 197255,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197255,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197275,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197275,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197276,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197276,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197277,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x1743df977d0",
+      "tid": 16852,
+      "ts": 197278,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197279,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197299,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197299,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197299,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197300,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197300,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x1743df97040",
+      "tid": 16852,
+      "ts": 197302,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197303,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197322,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197322,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197323,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197323,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197324,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x1743df97a90",
+      "tid": 16852,
+      "ts": 197325,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197326,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197345,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197345,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197346,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197347,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743de44098",
+      "tid": 16852,
+      "ts": 197355,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "UnusedPoolSize": 8388608
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x1743e24e320",
+      "tid": 16852,
+      "ts": 197357,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197357,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197358,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197362,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x1743df97b40",
+      "tid": 16852,
+      "ts": 197588,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197591,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197618,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197618,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197619,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197620,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197620,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x1743df980c0",
+      "tid": 16852,
+      "ts": 197625,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197625,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197645,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197646,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197646,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197647,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197647,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x1743df9cec0",
+      "tid": 16852,
+      "ts": 197649,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197649,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197669,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197669,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197670,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197670,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197671,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x1743df9b810",
+      "tid": 16852,
+      "ts": 197672,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197673,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197692,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197692,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197693,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197693,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197694,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x1743df9c100",
+      "tid": 16852,
+      "ts": 197695,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197696,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197715,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197715,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197716,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197716,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197717,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x1743df9c470",
+      "tid": 16852,
+      "ts": 197718,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197719,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197738,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197738,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197739,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197739,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197740,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x1743df9ba20",
+      "tid": 16852,
+      "ts": 197742,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 197742,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 191279,
-      "pid": "GPGMM",
-      "args": {
-        "allocationDescriptor": {
-          "Flags": 0,
-          "HeapType": 2
-        },
-        "resourceDescriptor": {
-          "Dimension": 1,
-          "Alignment": 0,
-          "Width": 18432,
-          "Height": 1,
-          "DepthOrArraySize": 1,
-          "MipLevels": 1,
-          "Format": 0,
-          "Layout": 1,
-          "SampleDesc": {
-            "Count": 1,
-            "Quality": 0
-          },
-          "Flags": 0
-        },
-        "initialResourceState": 2755,
-        "clearValue": {}
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 191281,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 191281,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 191288,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 191296,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 191299,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 191312,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 14
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 191338,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 14
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f84da70",
-      "tid": 43696,
-      "ts": 191340,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f84da70",
-      "tid": 43696,
-      "ts": 191355,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 65536,
-          "HeapOffset": 983040,
-          "OffsetFromResource": 0,
-          "Method": 2,
-          "ResourceHeap": {
-            "id_ref": "0x1a90d9e8230"
-          }
-        }
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 191357,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "i",
-      "tid": 43696,
-      "ts": 191422,
-      "pid": "GPGMM",
-      "args": {
-        "allocationDescriptor": {
-          "Flags": 0,
-          "HeapType": 2
-        },
-        "resourceDescriptor": {
-          "Dimension": 1,
-          "Alignment": 0,
-          "Width": 64,
-          "Height": 1,
-          "DepthOrArraySize": 1,
-          "MipLevels": 1,
-          "Format": 0,
-          "Layout": 1,
-          "SampleDesc": {
-            "Count": 1,
-            "Quality": 0
-          },
-          "Flags": 0
-        },
-        "initialResourceState": 2755,
-        "clearValue": {}
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 191423,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 191424,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 191433,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 191440,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 191443,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 191457,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 15
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 191481,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 15
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f84db20",
-      "tid": 43696,
-      "ts": 191483,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f84db20",
-      "tid": 43696,
-      "ts": 191498,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 65536,
-          "HeapOffset": 1048576,
-          "OffsetFromResource": 0,
-          "Method": 2,
-          "ResourceHeap": {
-            "id_ref": "0x1a90d9e8230"
-          }
-        }
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 191500,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "i",
-      "tid": 43696,
-      "ts": 191563,
-      "pid": "GPGMM",
-      "args": {
-        "allocationDescriptor": {
-          "Flags": 0,
-          "HeapType": 1
-        },
-        "resourceDescriptor": {
-          "Dimension": 1,
-          "Alignment": 0,
-          "Width": 1728,
-          "Height": 1,
-          "DepthOrArraySize": 1,
-          "MipLevels": 1,
-          "Format": 0,
-          "Layout": 1,
-          "SampleDesc": {
-            "Count": 1,
-            "Quality": 0
-          },
-          "Flags": 4
-        },
-        "initialResourceState": 0,
-        "clearValue": {}
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 191565,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 191565,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 191573,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 191581,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 191583,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 191597,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 13
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 191624,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 13
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f84c7e0",
-      "tid": 43696,
-      "ts": 191627,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f84c7e0",
-      "tid": 43696,
-      "ts": 191642,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 65536,
-          "HeapOffset": 917504,
-          "OffsetFromResource": 0,
-          "Method": 2,
-          "ResourceHeap": {
-            "id_ref": "0x1a90f843b40"
-          }
-        }
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 191644,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "i",
-      "tid": 43696,
-      "ts": 191711,
-      "pid": "GPGMM",
-      "args": {
-        "allocationDescriptor": {
-          "Flags": 0,
-          "HeapType": 2
-        },
-        "resourceDescriptor": {
-          "Dimension": 1,
-          "Alignment": 0,
-          "Width": 1728,
-          "Height": 1,
-          "DepthOrArraySize": 1,
-          "MipLevels": 1,
-          "Format": 0,
-          "Layout": 1,
-          "SampleDesc": {
-            "Count": 1,
-            "Quality": 0
-          },
-          "Flags": 0
-        },
-        "initialResourceState": 2755,
-        "clearValue": {}
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 191712,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 191713,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 191720,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 191728,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 191730,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 191744,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 16
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 191769,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 16
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f84dbd0",
-      "tid": 43696,
-      "ts": 191771,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f84dbd0",
-      "tid": 43696,
-      "ts": 191787,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 65536,
-          "HeapOffset": 1114112,
-          "OffsetFromResource": 0,
-          "Method": 2,
-          "ResourceHeap": {
-            "id_ref": "0x1a90d9e8230"
-          }
-        }
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 191789,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 191829,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 191830,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 191837,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 191845,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 191847,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f8461f0",
-      "tid": 43696,
-      "ts": 191852,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 191853,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 191875,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 191875,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 191883,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 191890,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 191892,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f847690",
-      "tid": 43696,
-      "ts": 191895,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 191895,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 191916,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 191916,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 191924,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 191932,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 191934,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f847a00",
-      "tid": 43696,
-      "ts": 191936,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 191937,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 191957,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 191957,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 191964,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 191972,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 191974,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f847ab0",
-      "tid": 43696,
-      "ts": 191976,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 191977,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 191998,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 191998,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 192005,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 192013,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 192014,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f847110",
-      "tid": 43696,
-      "ts": 192017,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 192018,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 192038,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 192039,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 192046,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 192054,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 192056,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f846560",
-      "tid": 43696,
-      "ts": 192058,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 192058,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 192079,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 192079,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 192087,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 192094,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 192096,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f846ae0",
-      "tid": 43696,
-      "ts": 192098,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 192099,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 192119,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 192120,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 192126,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 192134,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 192136,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f846c40",
-      "tid": 43696,
-      "ts": 192138,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 192138,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 192159,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 192159,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 192166,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 192174,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 192176,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f84d020",
-      "tid": 43696,
-      "ts": 192178,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 192178,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 192199,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 192199,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 192206,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 192214,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 192216,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f84d5a0",
-      "tid": 43696,
-      "ts": 192218,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 192218,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 192238,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 192239,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 192247,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 192254,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 192256,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f84da70",
-      "tid": 43696,
-      "ts": 192258,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 192259,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 192279,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 192279,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 192286,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 192294,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 192296,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f84db20",
-      "tid": 43696,
-      "ts": 192298,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 192298,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 192319,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 192319,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 192327,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 192335,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 192338,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f84dbd0",
-      "tid": 43696,
-      "ts": 192340,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 192341,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "i",
-      "tid": 43696,
-      "ts": 192386,
+      "tid": 16852,
+      "ts": 197794,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -5884,29 +5641,45 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 192388,
+      "tid": 16852,
+      "ts": 197796,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197797,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 197801,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 192389,
+      "tid": 16852,
+      "ts": 197804,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 192398,
+      "id": "0x1743de44d98",
+      "tid": 16852,
+      "ts": 197814,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 8388608
         }
       }
     },
@@ -5914,26 +5687,26 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 192400,
+      "tid": 16852,
+      "ts": 197816,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f843750",
-      "tid": 43696,
-      "ts": 193093,
+      "id": "0x1743e24f520",
+      "tid": 16852,
+      "ts": 198681,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f843750",
-      "tid": 43696,
-      "ts": 193128,
+      "id": "0x1743e24f520",
+      "tid": 16852,
+      "ts": 198713,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5948,9 +5721,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f843750",
-      "tid": 43696,
-      "ts": 193145,
+      "id": "0x1743e24f520",
+      "tid": 16852,
+      "ts": 198727,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5965,21 +5738,21 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 193147,
+      "tid": 16852,
+      "ts": 198729,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 193155,
+      "id": "0x1743de44d98",
+      "tid": 16852,
+      "ts": 198735,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 2
+          "UnusedPoolSize": 12582912
         }
       }
     },
@@ -5987,24 +5760,40 @@
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 193157,
+      "tid": 16852,
+      "ts": 198738,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 198739,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 198740,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f843750",
-      "tid": 43696,
-      "ts": 193171,
+      "id": "0x1743e24f520",
+      "tid": 16852,
+      "ts": 198752,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 1
+          "SubAllocatedRefs": 2
         }
       }
     },
@@ -6012,16 +5801,16 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f843750",
-      "tid": 43696,
-      "ts": 193200,
+      "id": "0x1743e24f520",
+      "tid": 16852,
+      "ts": 198777,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 1
+          "SubAllocatedRefs": 2
         }
       }
     },
@@ -6029,27 +5818,27 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f84c1b0",
-      "tid": 43696,
-      "ts": 193202,
+      "id": "0x1743df9d230",
+      "tid": 16852,
+      "ts": 198779,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f84c1b0",
-      "tid": 43696,
-      "ts": 193218,
+      "id": "0x1743df9d230",
+      "tid": 16852,
+      "ts": 198792,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "Size": 4194304,
+          "Size": 3145728,
           "HeapOffset": 0,
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90f843750"
+            "id_ref": "0x1743e24f520"
           }
         }
       }
@@ -6058,16 +5847,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 193221,
+      "tid": 16852,
+      "ts": 198794,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 193310,
+      "tid": 16852,
+      "ts": 198877,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -6097,50 +5886,50 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 193312,
+      "tid": 16852,
+      "ts": 198879,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 193313,
+      "tid": 16852,
+      "ts": 198880,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 193313,
+      "tid": 16852,
+      "ts": 198884,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 193315,
+      "tid": 16852,
+      "ts": 198886,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f8437e0",
-      "tid": 43696,
-      "ts": 194603,
+      "id": "0x1743e24ee60",
+      "tid": 16852,
+      "ts": 200191,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f8437e0",
-      "tid": 43696,
-      "ts": 194638,
+      "id": "0x1743e24ee60",
+      "tid": 16852,
+      "ts": 200224,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6155,9 +5944,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f8437e0",
-      "tid": 43696,
-      "ts": 194655,
+      "id": "0x1743e24ee60",
+      "tid": 16852,
+      "ts": 200238,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6172,17 +5961,17 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 194657,
+      "tid": 16852,
+      "ts": 200240,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f8437e0",
-      "tid": 43696,
-      "ts": 194670,
+      "id": "0x1743e24ee60",
+      "tid": 16852,
+      "ts": 200252,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6197,9 +5986,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f8437e0",
-      "tid": 43696,
-      "ts": 194699,
+      "id": "0x1743e24ee60",
+      "tid": 16852,
+      "ts": 200278,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6214,18 +6003,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f84cf70",
-      "tid": 43696,
-      "ts": 194701,
+      "id": "0x1743df9bad0",
+      "tid": 16852,
+      "ts": 200280,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f84cf70",
-      "tid": 43696,
-      "ts": 194717,
+      "id": "0x1743df9bad0",
+      "tid": 16852,
+      "ts": 200293,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6234,7 +6023,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x1a90f8437e0"
+            "id_ref": "0x1743e24ee60"
           }
         }
       }
@@ -6243,16 +6032,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 194719,
+      "tid": 16852,
+      "ts": 200295,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 194803,
+      "tid": 16852,
+      "ts": 200375,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -6282,43 +6071,118 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 194805,
+      "tid": 16852,
+      "ts": 200377,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 200378,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 200381,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 194806,
+      "tid": 16852,
+      "ts": 200384,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 194814,
+      "id": "0x1743de44d98",
+      "tid": 16852,
+      "ts": 200460,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 2
+          "UnusedPoolSize": 12582912
         }
       }
+    },
+    {
+      "name": "ResourceAllocator.CreateResourceHeap",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 200462,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x1743e24fd00",
+      "tid": 16852,
+      "ts": 201101,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743e24fd00",
+      "tid": 16852,
+      "ts": 201134,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 0,
+          "MemorySegmentGroup": 0,
+          "SubAllocatedRefs": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743e24fd00",
+      "tid": 16852,
+      "ts": 201149,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 0,
+          "SubAllocatedRefs": 0
+        }
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResourceHeap",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 201150,
+      "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 194822,
+      "id": "0x1743de44d98",
+      "tid": 16852,
+      "ts": 201157,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 2
+          "UnusedPoolSize": 16777216
         }
       }
     },
@@ -6326,24 +6190,40 @@
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 194824,
+      "tid": 16852,
+      "ts": 201159,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 201161,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 201161,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 194838,
+      "id": "0x1743e24fd00",
+      "tid": 16852,
+      "ts": 201173,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 14
+          "SubAllocatedRefs": 2
         }
       }
     },
@@ -6351,16 +6231,16 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 194864,
+      "id": "0x1743e24fd00",
+      "tid": 16852,
+      "ts": 201198,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 14
+          "SubAllocatedRefs": 2
         }
       }
     },
@@ -6368,27 +6248,27 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f84db20",
-      "tid": 43696,
-      "ts": 194867,
+      "id": "0x1743df9cb50",
+      "tid": 16852,
+      "ts": 201200,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f84db20",
-      "tid": 43696,
-      "ts": 194882,
+      "id": "0x1743df9cb50",
+      "tid": 16852,
+      "ts": 201214,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "Size": 524288,
-          "HeapOffset": 1048576,
+          "Size": 327680,
+          "HeapOffset": 0,
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90f843b40"
+            "id_ref": "0x1743e24fd00"
           }
         }
       }
@@ -6397,16 +6277,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 194885,
+      "tid": 16852,
+      "ts": 201216,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 194953,
+      "tid": 16852,
+      "ts": 201282,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -6436,50 +6316,50 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 194955,
+      "tid": 16852,
+      "ts": 201283,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 194955,
+      "tid": 16852,
+      "ts": 201284,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 194956,
+      "tid": 16852,
+      "ts": 201288,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 194957,
+      "tid": 16852,
+      "ts": 201289,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f8450a0",
-      "tid": 43696,
-      "ts": 246166,
+      "id": "0x1743e24f760",
+      "tid": 16852,
+      "ts": 278187,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f8450a0",
-      "tid": 43696,
-      "ts": 246213,
+      "id": "0x1743e24f760",
+      "tid": 16852,
+      "ts": 278224,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6494,9 +6374,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f8450a0",
-      "tid": 43696,
-      "ts": 246235,
+      "id": "0x1743e24f760",
+      "tid": 16852,
+      "ts": 278244,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6511,17 +6391,17 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 246238,
+      "tid": 16852,
+      "ts": 278246,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f8450a0",
-      "tid": 43696,
-      "ts": 246254,
+      "id": "0x1743e24f760",
+      "tid": 16852,
+      "ts": 278261,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6536,9 +6416,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f8450a0",
-      "tid": 43696,
-      "ts": 246304,
+      "id": "0x1743e24f760",
+      "tid": 16852,
+      "ts": 278310,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6553,18 +6433,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f84dbd0",
-      "tid": 43696,
-      "ts": 246307,
+      "id": "0x1743df9b6b0",
+      "tid": 16852,
+      "ts": 278313,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f84dbd0",
-      "tid": 43696,
-      "ts": 246323,
+      "id": "0x1743df9b6b0",
+      "tid": 16852,
+      "ts": 278327,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6573,7 +6453,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x1a90f8450a0"
+            "id_ref": "0x1743e24f760"
           }
         }
       }
@@ -6582,913 +6462,835 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 246326,
+      "tid": 16852,
+      "ts": 278330,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 246399,
+      "tid": 16852,
+      "ts": 278404,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabCacheAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 246400,
+      "tid": 16852,
+      "ts": 278405,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 246409,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 2
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 278407,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 246418,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 2
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 246419,
+      "tid": 16852,
+      "ts": 278408,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 278408,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f846e50",
-      "tid": 43696,
-      "ts": 246427,
+      "id": "0x1743e24add0",
+      "tid": 16852,
+      "ts": 278417,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 246524,
+      "tid": 16852,
+      "ts": 278418,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 246548,
+      "tid": 16852,
+      "ts": 278440,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabCacheAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 246549,
+      "tid": 16852,
+      "ts": 278440,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 246559,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 2
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 278441,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 246566,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 2
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 246568,
+      "tid": 16852,
+      "ts": 278441,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 278442,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f847c10",
-      "tid": 43696,
-      "ts": 246573,
+      "id": "0x1743e24b980",
+      "tid": 16852,
+      "ts": 278445,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 246573,
+      "tid": 16852,
+      "ts": 278446,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 246595,
+      "tid": 16852,
+      "ts": 278466,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabCacheAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 246596,
+      "tid": 16852,
+      "ts": 278466,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 246603,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 2
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 278466,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 246611,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 2
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 246613,
+      "tid": 16852,
+      "ts": 278467,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 278467,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f846820",
-      "tid": 43696,
-      "ts": 246615,
+      "id": "0x1743df98430",
+      "tid": 16852,
+      "ts": 278470,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 246616,
+      "tid": 16852,
+      "ts": 278470,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 246637,
+      "tid": 16852,
+      "ts": 278491,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabCacheAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 246637,
+      "tid": 16852,
+      "ts": 278491,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 246645,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 2
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 278492,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 246653,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 2
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 246654,
+      "tid": 16852,
+      "ts": 278492,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 278493,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f8475e0",
-      "tid": 43696,
-      "ts": 246658,
+      "id": "0x1743df975c0",
+      "tid": 16852,
+      "ts": 278495,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 246659,
+      "tid": 16852,
+      "ts": 278496,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 246680,
+      "tid": 16852,
+      "ts": 278516,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabCacheAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 246680,
+      "tid": 16852,
+      "ts": 278516,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 246688,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 2
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 278517,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 246695,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 2
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 246697,
+      "tid": 16852,
+      "ts": 278517,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 278518,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f847530",
-      "tid": 43696,
-      "ts": 246700,
+      "id": "0x1743df97f60",
+      "tid": 16852,
+      "ts": 278520,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 246700,
+      "tid": 16852,
+      "ts": 278521,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 246722,
+      "tid": 16852,
+      "ts": 278540,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabCacheAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 246722,
+      "tid": 16852,
+      "ts": 278541,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 246729,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 2
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 278541,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 246737,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 2
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 246739,
+      "tid": 16852,
+      "ts": 278542,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 278542,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f8478a0",
-      "tid": 43696,
-      "ts": 246741,
+      "id": "0x1743df984e0",
+      "tid": 16852,
+      "ts": 278545,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 246742,
+      "tid": 16852,
+      "ts": 278545,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 246763,
+      "tid": 16852,
+      "ts": 278565,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 278566,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 278566,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 246764,
+      "tid": 16852,
+      "ts": 278567,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 246771,
+      "id": "0x1743de44d98",
+      "tid": 16852,
+      "ts": 278577,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 2
+          "UnusedPoolSize": 16777216
         }
       }
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "GPUMemoryBlock",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 246778,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 2
-        }
-      }
+      "ph": "D",
+      "id": "0x1743e24f400",
+      "tid": 16852,
+      "ts": 278579,
+      "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 246780,
+      "tid": 16852,
+      "ts": 278580,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 278581,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 278587,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f846980",
-      "tid": 43696,
-      "ts": 246783,
+      "id": "0x1743df98170",
+      "tid": 16852,
+      "ts": 278938,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 246783,
+      "tid": 16852,
+      "ts": 278940,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 246805,
+      "tid": 16852,
+      "ts": 278967,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabCacheAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 246805,
+      "tid": 16852,
+      "ts": 278968,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 246813,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 2
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 278969,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 246821,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 2
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 246823,
+      "tid": 16852,
+      "ts": 278969,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 278970,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f847e20",
-      "tid": 43696,
-      "ts": 246825,
+      "id": "0x1743df97510",
+      "tid": 16852,
+      "ts": 278974,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 246826,
+      "tid": 16852,
+      "ts": 278975,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 246846,
+      "tid": 16852,
+      "ts": 278995,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabCacheAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 246847,
+      "tid": 16852,
+      "ts": 278996,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 246854,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 2
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 278996,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 246862,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 2
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 246864,
+      "tid": 16852,
+      "ts": 278997,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 278997,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f84c940",
-      "tid": 43696,
-      "ts": 246866,
+      "id": "0x1743df96d80",
+      "tid": 16852,
+      "ts": 278999,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 246867,
+      "tid": 16852,
+      "ts": 279000,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 246888,
+      "tid": 16852,
+      "ts": 279020,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabCacheAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 246888,
+      "tid": 16852,
+      "ts": 279021,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 246896,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 2
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 279021,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 246903,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 2
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 246905,
+      "tid": 16852,
+      "ts": 279022,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 279022,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f84c5d0",
-      "tid": 43696,
-      "ts": 246907,
+      "id": "0x1743e24a590",
+      "tid": 16852,
+      "ts": 279024,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 246908,
+      "tid": 16852,
+      "ts": 279024,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 246929,
+      "tid": 16852,
+      "ts": 279044,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabCacheAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 246929,
+      "tid": 16852,
+      "ts": 279045,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 246936,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 2
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 279045,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 246944,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 2
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 246946,
+      "tid": 16852,
+      "ts": 279046,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 279046,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f84d650",
-      "tid": 43696,
-      "ts": 246948,
+      "id": "0x1743df9bfa0",
+      "tid": 16852,
+      "ts": 279048,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 246948,
+      "tid": 16852,
+      "ts": 279048,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 246970,
+      "tid": 16852,
+      "ts": 279068,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabCacheAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 246970,
+      "tid": 16852,
+      "ts": 279068,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 246978,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 2
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 279069,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 246986,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 2
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 246987,
+      "tid": 16852,
+      "ts": 279069,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 279070,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f84c680",
-      "tid": 43696,
-      "ts": 246990,
+      "id": "0x1743df9b550",
+      "tid": 16852,
+      "ts": 279072,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 246990,
+      "tid": 16852,
+      "ts": 279073,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 247011,
+      "tid": 16852,
+      "ts": 279092,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 279093,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 279093,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 247011,
+      "tid": 16852,
+      "ts": 279094,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 247019,
+      "id": "0x1743de44d98",
+      "tid": 16852,
+      "ts": 279107,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 2
+          "UnusedPoolSize": 12582912
         }
       }
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "GPUMemoryBlock",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 247027,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 2
-        }
-      }
+      "ph": "D",
+      "id": "0x1743e24e290",
+      "tid": 16852,
+      "ts": 279109,
+      "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 247029,
+      "tid": 16852,
+      "ts": 279110,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 279110,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 279116,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f84c7e0",
-      "tid": 43696,
-      "ts": 247031,
+      "id": "0x1743df9c310",
+      "tid": 16852,
+      "ts": 279386,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 247032,
+      "tid": 16852,
+      "ts": 279388,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 247082,
+      "tid": 16852,
+      "ts": 279444,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -7518,43 +7320,118 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 247084,
+      "tid": 16852,
+      "ts": 279447,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 279448,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 279453,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 247086,
+      "tid": 16852,
+      "ts": 279456,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 247095,
+      "id": "0x1743de44d98",
+      "tid": 16852,
+      "ts": 279464,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 2
+          "UnusedPoolSize": 8388608
         }
       }
+    },
+    {
+      "name": "ResourceAllocator.CreateResourceHeap",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 279466,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x1743e24e0e0",
+      "tid": 16852,
+      "ts": 280204,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743e24e0e0",
+      "tid": 16852,
+      "ts": 280224,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 0,
+          "MemorySegmentGroup": 0,
+          "SubAllocatedRefs": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743e24e0e0",
+      "tid": 16852,
+      "ts": 280240,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 0,
+          "SubAllocatedRefs": 0
+        }
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResourceHeap",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 280241,
+      "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 247103,
+      "id": "0x1743de44d98",
+      "tid": 16852,
+      "ts": 280248,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 2
+          "UnusedPoolSize": 12582912
         }
       }
     },
@@ -7562,17 +7439,33 @@
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 247105,
+      "tid": 16852,
+      "ts": 280250,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 280252,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 280253,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 247120,
+      "id": "0x1743e24e0e0",
+      "tid": 16852,
+      "ts": 280264,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7587,9 +7480,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 247151,
+      "id": "0x1743e24e0e0",
+      "tid": 16852,
+      "ts": 280294,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7604,27 +7497,27 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f84d650",
-      "tid": 43696,
-      "ts": 247154,
+      "id": "0x1743df9cd60",
+      "tid": 16852,
+      "ts": 280296,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f84d650",
-      "tid": 43696,
-      "ts": 247170,
+      "id": "0x1743df9cd60",
+      "tid": 16852,
+      "ts": 280310,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 65536,
-          "HeapOffset": 1572864,
+          "HeapOffset": 0,
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90f843b40"
+            "id_ref": "0x1743e24e0e0"
           }
         }
       }
@@ -7633,16 +7526,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 247173,
+      "tid": 16852,
+      "ts": 280312,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 247242,
+      "tid": 16852,
+      "ts": 280382,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -7672,68 +7565,56 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 247243,
+      "tid": 16852,
+      "ts": 280384,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 247244,
+      "tid": 16852,
+      "ts": 280385,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 247251,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 280386,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 247259,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 247262,
+      "tid": 16852,
+      "ts": 280388,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 280389,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 247276,
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 280401,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 4
+          "SubAllocatedRefs": 5
         }
       }
     },
@@ -7741,16 +7622,16 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 247302,
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 280426,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 4
+          "SubAllocatedRefs": 5
         }
       }
     },
@@ -7758,27 +7639,27 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f846c40",
-      "tid": 43696,
-      "ts": 247305,
+      "id": "0x1743df9bc30",
+      "tid": 16852,
+      "ts": 280427,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f846c40",
-      "tid": 43696,
-      "ts": 247321,
+      "id": "0x1743df9bc30",
+      "tid": 16852,
+      "ts": 280441,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 65536,
-          "HeapOffset": 196608,
+          "HeapOffset": 851968,
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90d9e8230"
+            "id_ref": "0x1743c092260"
           }
         }
       }
@@ -7787,16 +7668,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 247323,
+      "tid": 16852,
+      "ts": 280443,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 247388,
+      "tid": 16852,
+      "ts": 280507,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -7826,68 +7707,56 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 247389,
+      "tid": 16852,
+      "ts": 280509,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 247390,
+      "tid": 16852,
+      "ts": 280509,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 247398,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 280510,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 247406,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 247408,
+      "tid": 16852,
+      "ts": 280512,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 280513,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 247422,
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 280525,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 5
+          "SubAllocatedRefs": 6
         }
       }
     },
@@ -7895,16 +7764,16 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 247448,
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 280548,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 5
+          "SubAllocatedRefs": 6
         }
       }
     },
@@ -7912,27 +7781,27 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f8478a0",
-      "tid": 43696,
-      "ts": 247450,
+      "id": "0x1743df97b40",
+      "tid": 16852,
+      "ts": 280550,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f8478a0",
-      "tid": 43696,
-      "ts": 247465,
+      "id": "0x1743df97b40",
+      "tid": 16852,
+      "ts": 280564,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 65536,
-          "HeapOffset": 262144,
+          "HeapOffset": 786432,
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90d9e8230"
+            "id_ref": "0x1743c092260"
           }
         }
       }
@@ -7941,16 +7810,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 247468,
+      "tid": 16852,
+      "ts": 280565,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 247531,
+      "tid": 16852,
+      "ts": 280629,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -7980,68 +7849,56 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 247533,
+      "tid": 16852,
+      "ts": 280631,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 247534,
+      "tid": 16852,
+      "ts": 280632,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 247541,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 280632,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 247548,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 247551,
+      "tid": 16852,
+      "ts": 280634,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 280635,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 247564,
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 280647,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 6
+          "SubAllocatedRefs": 7
         }
       }
     },
@@ -8049,16 +7906,16 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 247589,
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 280671,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 6
+          "SubAllocatedRefs": 7
         }
       }
     },
@@ -8066,27 +7923,27 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f847110",
-      "tid": 43696,
-      "ts": 247592,
+      "id": "0x1743df97510",
+      "tid": 16852,
+      "ts": 280673,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f847110",
-      "tid": 43696,
-      "ts": 247607,
+      "id": "0x1743df97510",
+      "tid": 16852,
+      "ts": 280686,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 65536,
-          "HeapOffset": 327680,
+          "HeapOffset": 720896,
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90d9e8230"
+            "id_ref": "0x1743c092260"
           }
         }
       }
@@ -8095,16 +7952,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 247609,
+      "tid": 16852,
+      "ts": 280688,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 247673,
+      "tid": 16852,
+      "ts": 280752,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -8134,68 +7991,56 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 247674,
+      "tid": 16852,
+      "ts": 280754,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 247675,
+      "tid": 16852,
+      "ts": 280754,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 247682,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 280755,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 247690,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 247693,
+      "tid": 16852,
+      "ts": 280757,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 280758,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 247706,
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 280770,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 7
+          "SubAllocatedRefs": 8
         }
       }
     },
@@ -8203,16 +8048,16 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 247732,
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 280793,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 7
+          "SubAllocatedRefs": 8
         }
       }
     },
@@ -8220,27 +8065,27 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f846ae0",
-      "tid": 43696,
-      "ts": 247734,
+      "id": "0x1743df975c0",
+      "tid": 16852,
+      "ts": 280795,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f846ae0",
-      "tid": 43696,
-      "ts": 247749,
+      "id": "0x1743df975c0",
+      "tid": 16852,
+      "ts": 280808,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 65536,
-          "HeapOffset": 393216,
+          "HeapOffset": 655360,
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90d9e8230"
+            "id_ref": "0x1743c092260"
           }
         }
       }
@@ -8249,16 +8094,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 247752,
+      "tid": 16852,
+      "ts": 280810,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 247815,
+      "tid": 16852,
+      "ts": 280873,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -8288,68 +8133,56 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 247817,
+      "tid": 16852,
+      "ts": 280875,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 247817,
+      "tid": 16852,
+      "ts": 280875,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 247824,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 280876,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 247832,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 247835,
+      "tid": 16852,
+      "ts": 280878,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 280879,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 247848,
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 280891,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 8
+          "SubAllocatedRefs": 9
         }
       }
     },
@@ -8357,16 +8190,16 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 247873,
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 280913,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 8
+          "SubAllocatedRefs": 9
         }
       }
     },
@@ -8374,27 +8207,27 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f847690",
-      "tid": 43696,
-      "ts": 247875,
+      "id": "0x1743df987a0",
+      "tid": 16852,
+      "ts": 280915,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f847690",
-      "tid": 43696,
-      "ts": 247890,
+      "id": "0x1743df987a0",
+      "tid": 16852,
+      "ts": 280928,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 65536,
-          "HeapOffset": 458752,
+          "HeapOffset": 589824,
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90d9e8230"
+            "id_ref": "0x1743c092260"
           }
         }
       }
@@ -8403,361 +8236,301 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 247892,
+      "tid": 16852,
+      "ts": 280930,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 247932,
+      "tid": 16852,
+      "ts": 280973,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabCacheAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 247933,
+      "tid": 16852,
+      "ts": 280974,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 247940,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 280975,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 247948,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 247949,
+      "tid": 16852,
+      "ts": 280975,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 280976,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f846c40",
-      "tid": 43696,
-      "ts": 247952,
+      "id": "0x1743df9bc30",
+      "tid": 16852,
+      "ts": 280979,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 247953,
+      "tid": 16852,
+      "ts": 280980,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 247974,
+      "tid": 16852,
+      "ts": 281000,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabCacheAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 247974,
+      "tid": 16852,
+      "ts": 281000,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 247981,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 281001,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 247989,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 247991,
+      "tid": 16852,
+      "ts": 281001,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 281001,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f8478a0",
-      "tid": 43696,
-      "ts": 247993,
+      "id": "0x1743df97b40",
+      "tid": 16852,
+      "ts": 281003,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 247993,
+      "tid": 16852,
+      "ts": 281003,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 248014,
+      "tid": 16852,
+      "ts": 281023,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabCacheAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 248015,
+      "tid": 16852,
+      "ts": 281024,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 248022,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 281024,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 248030,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 248032,
+      "tid": 16852,
+      "ts": 281025,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 281025,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f847110",
-      "tid": 43696,
-      "ts": 248033,
+      "id": "0x1743df97510",
+      "tid": 16852,
+      "ts": 281026,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 248034,
+      "tid": 16852,
+      "ts": 281027,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 248055,
+      "tid": 16852,
+      "ts": 281046,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabCacheAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 248055,
+      "tid": 16852,
+      "ts": 281047,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 248062,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 281047,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 248070,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 248072,
+      "tid": 16852,
+      "ts": 281048,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 281048,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f846ae0",
-      "tid": 43696,
-      "ts": 248074,
+      "id": "0x1743df975c0",
+      "tid": 16852,
+      "ts": 281049,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 248074,
+      "tid": 16852,
+      "ts": 281050,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 248095,
+      "tid": 16852,
+      "ts": 281069,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabCacheAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 248095,
+      "tid": 16852,
+      "ts": 281070,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 248103,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 281070,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 248110,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 248112,
+      "tid": 16852,
+      "ts": 281071,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 281071,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f847690",
-      "tid": 43696,
-      "ts": 248114,
+      "id": "0x1743df987a0",
+      "tid": 16852,
+      "ts": 281072,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 248114,
+      "tid": 16852,
+      "ts": 281073,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 248159,
+      "tid": 16852,
+      "ts": 281114,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -8787,43 +8560,118 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 248161,
+      "tid": 16852,
+      "ts": 281116,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 281116,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 281119,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 248161,
+      "tid": 16852,
+      "ts": 281122,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 248169,
+      "id": "0x1743de44098",
+      "tid": 16852,
+      "ts": 281129,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 4194304
         }
       }
+    },
+    {
+      "name": "ResourceAllocator.CreateResourceHeap",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 281131,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x1743e24f640",
+      "tid": 16852,
+      "ts": 283641,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743e24f640",
+      "tid": 16852,
+      "ts": 283660,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 0,
+          "MemorySegmentGroup": 1,
+          "SubAllocatedRefs": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743e24f640",
+      "tid": 16852,
+      "ts": 283675,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 1,
+          "SubAllocatedRefs": 0
+        }
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResourceHeap",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 283677,
+      "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 248177,
+      "id": "0x1743de44098",
+      "tid": 16852,
+      "ts": 283683,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 8388608
         }
       }
     },
@@ -8831,24 +8679,40 @@
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 248179,
+      "tid": 16852,
+      "ts": 283686,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 283687,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 283688,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 248193,
+      "id": "0x1743e24f640",
+      "tid": 16852,
+      "ts": 283699,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 4
+          "SubAllocatedRefs": 2
         }
       }
     },
@@ -8856,16 +8720,16 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 248218,
+      "id": "0x1743e24f640",
+      "tid": 16852,
+      "ts": 283726,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 4
+          "SubAllocatedRefs": 2
         }
       }
     },
@@ -8873,27 +8737,27 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f847110",
-      "tid": 43696,
-      "ts": 248220,
+      "id": "0x1743df975c0",
+      "tid": 16852,
+      "ts": 283728,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f847110",
-      "tid": 43696,
-      "ts": 248236,
+      "id": "0x1743df975c0",
+      "tid": 16852,
+      "ts": 283742,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 131072,
-          "HeapOffset": 262144,
+          "HeapOffset": 0,
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90d9e8230"
+            "id_ref": "0x1743e24f640"
           }
         }
       }
@@ -8902,16 +8766,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 248238,
+      "tid": 16852,
+      "ts": 283744,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 248306,
+      "tid": 16852,
+      "ts": 283811,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -8941,43 +8805,118 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 248307,
+      "tid": 16852,
+      "ts": 283812,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 283813,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 283818,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 248308,
+      "tid": 16852,
+      "ts": 283821,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 248315,
+      "id": "0x1743de44098",
+      "tid": 16852,
+      "ts": 283830,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 8388608
         }
       }
+    },
+    {
+      "name": "ResourceAllocator.CreateResourceHeap",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 283832,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x1743e24e710",
+      "tid": 16852,
+      "ts": 286502,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743e24e710",
+      "tid": 16852,
+      "ts": 286552,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 0,
+          "MemorySegmentGroup": 1,
+          "SubAllocatedRefs": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743e24e710",
+      "tid": 16852,
+      "ts": 286580,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 1,
+          "SubAllocatedRefs": 0
+        }
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResourceHeap",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 286582,
+      "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 248322,
+      "id": "0x1743de44098",
+      "tid": 16852,
+      "ts": 286589,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 12582912
         }
       }
     },
@@ -8985,24 +8924,40 @@
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 248325,
+      "tid": 16852,
+      "ts": 286591,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 286593,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 286605,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 248338,
+      "id": "0x1743e24e710",
+      "tid": 16852,
+      "ts": 286617,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 5
+          "SubAllocatedRefs": 2
         }
       }
     },
@@ -9010,16 +8965,16 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 248363,
+      "id": "0x1743e24e710",
+      "tid": 16852,
+      "ts": 286647,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 5
+          "SubAllocatedRefs": 2
         }
       }
     },
@@ -9027,18 +8982,302 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f846ae0",
-      "tid": 43696,
-      "ts": 248365,
+      "id": "0x1743df9bfa0",
+      "tid": 16852,
+      "ts": 286660,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f846ae0",
-      "tid": 43696,
-      "ts": 248381,
+      "id": "0x1743df9bfa0",
+      "tid": 16852,
+      "ts": 286675,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 524288,
+          "HeapOffset": 0,
+          "OffsetFromResource": 0,
+          "Method": 2,
+          "ResourceHeap": {
+            "id_ref": "0x1743e24e710"
+          }
+        }
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 286677,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16852,
+      "ts": 286761,
+      "pid": "GPGMM",
+      "args": {
+        "allocationDescriptor": {
+          "Flags": 0,
+          "HeapType": 2
+        },
+        "resourceDescriptor": {
+          "Dimension": 1,
+          "Alignment": 0,
+          "Width": 131072,
+          "Height": 1,
+          "DepthOrArraySize": 1,
+          "MipLevels": 1,
+          "Format": 0,
+          "Layout": 1,
+          "SampleDesc": {
+            "Count": 1,
+            "Quality": 0
+          },
+          "Flags": 0
+        },
+        "initialResourceState": 2755,
+        "clearValue": {}
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 286763,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 286764,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 286765,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 286768,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 286768,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743e24f640",
+      "tid": 16852,
+      "ts": 286781,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 1,
+          "SubAllocatedRefs": 3
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743e24f640",
+      "tid": 16852,
+      "ts": 286816,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 1,
+          "SubAllocatedRefs": 3
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x1743df97f60",
+      "tid": 16852,
+      "ts": 286819,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743df97f60",
+      "tid": 16852,
+      "ts": 286844,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 131072,
+          "HeapOffset": 131072,
+          "OffsetFromResource": 0,
+          "Method": 2,
+          "ResourceHeap": {
+            "id_ref": "0x1743e24f640"
+          }
+        }
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 286847,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16852,
+      "ts": 287064,
+      "pid": "GPGMM",
+      "args": {
+        "allocationDescriptor": {
+          "Flags": 0,
+          "HeapType": 2
+        },
+        "resourceDescriptor": {
+          "Dimension": 1,
+          "Alignment": 0,
+          "Width": 524288,
+          "Height": 1,
+          "DepthOrArraySize": 1,
+          "MipLevels": 1,
+          "Format": 0,
+          "Layout": 1,
+          "SampleDesc": {
+            "Count": 1,
+            "Quality": 0
+          },
+          "Flags": 0
+        },
+        "initialResourceState": 2755,
+        "clearValue": {}
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 287116,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 287117,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 287118,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 287136,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 287137,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743e24e710",
+      "tid": 16852,
+      "ts": 287221,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 1,
+          "SubAllocatedRefs": 3
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743e24e710",
+      "tid": 16852,
+      "ts": 287415,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 1,
+          "SubAllocatedRefs": 3
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x1743e278ca0",
+      "tid": 16852,
+      "ts": 287417,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743e278ca0",
+      "tid": 16852,
+      "ts": 287442,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9047,7 +9286,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90d9e8230"
+            "id_ref": "0x1743e24e710"
           }
         }
       }
@@ -9056,16 +9295,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 248383,
+      "tid": 16852,
+      "ts": 287444,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 248450,
+      "tid": 16852,
+      "ts": 287514,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -9095,68 +9334,56 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 248451,
+      "tid": 16852,
+      "ts": 287515,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 248452,
+      "tid": 16852,
+      "ts": 287516,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 248459,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 287517,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 248467,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 248469,
+      "tid": 16852,
+      "ts": 287520,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 287520,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 248483,
+      "id": "0x1743e24f640",
+      "tid": 16852,
+      "ts": 287533,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 6
+          "SubAllocatedRefs": 4
         }
       }
     },
@@ -9164,16 +9391,16 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 248507,
+      "id": "0x1743e24f640",
+      "tid": 16852,
+      "ts": 287558,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 6
+          "SubAllocatedRefs": 4
         }
       }
     },
@@ -9181,27 +9408,27 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90fadcbb0",
-      "tid": 43696,
-      "ts": 248510,
+      "id": "0x1743e277540",
+      "tid": 16852,
+      "ts": 287560,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90fadcbb0",
-      "tid": 43696,
-      "ts": 248525,
+      "id": "0x1743e277540",
+      "tid": 16852,
+      "ts": 287574,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 131072,
-          "HeapOffset": 393216,
+          "HeapOffset": 262144,
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90d9e8230"
+            "id_ref": "0x1743e24f640"
           }
         }
       }
@@ -9210,16 +9437,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 248527,
+      "tid": 16852,
+      "ts": 287576,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 248595,
+      "tid": 16852,
+      "ts": 287641,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -9249,68 +9476,56 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 248596,
+      "tid": 16852,
+      "ts": 287643,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 248597,
+      "tid": 16852,
+      "ts": 287644,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 248605,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 287645,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 248613,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 248615,
+      "tid": 16852,
+      "ts": 287647,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 287648,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 248629,
+      "id": "0x1743e24e710",
+      "tid": 16852,
+      "ts": 287660,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 7
+          "SubAllocatedRefs": 4
         }
       }
     },
@@ -9318,16 +9533,16 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 248656,
+      "id": "0x1743e24e710",
+      "tid": 16852,
+      "ts": 287684,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 7
+          "SubAllocatedRefs": 4
         }
       }
     },
@@ -9335,18 +9550,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f848af0",
-      "tid": 43696,
-      "ts": 248659,
+      "id": "0x1743e277960",
+      "tid": 16852,
+      "ts": 287686,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f848af0",
-      "tid": 43696,
-      "ts": 248674,
+      "id": "0x1743e277960",
+      "tid": 16852,
+      "ts": 287700,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9355,7 +9570,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90d9e8230"
+            "id_ref": "0x1743e24e710"
           }
         }
       }
@@ -9364,482 +9579,87 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 248676,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "i",
-      "tid": 43696,
-      "ts": 248743,
-      "pid": "GPGMM",
-      "args": {
-        "allocationDescriptor": {
-          "Flags": 0,
-          "HeapType": 2
-        },
-        "resourceDescriptor": {
-          "Dimension": 1,
-          "Alignment": 0,
-          "Width": 131072,
-          "Height": 1,
-          "DepthOrArraySize": 1,
-          "MipLevels": 1,
-          "Format": 0,
-          "Layout": 1,
-          "SampleDesc": {
-            "Count": 1,
-            "Quality": 0
-          },
-          "Flags": 0
-        },
-        "initialResourceState": 2755,
-        "clearValue": {}
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 248746,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 248746,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 248754,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 248763,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 248765,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 248779,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 8
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 248804,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 8
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f849330",
-      "tid": 43696,
-      "ts": 248806,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f849330",
-      "tid": 43696,
-      "ts": 248821,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 131072,
-          "HeapOffset": 1572864,
-          "OffsetFromResource": 0,
-          "Method": 2,
-          "ResourceHeap": {
-            "id_ref": "0x1a90d9e8230"
-          }
-        }
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 248823,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "i",
-      "tid": 43696,
-      "ts": 248891,
-      "pid": "GPGMM",
-      "args": {
-        "allocationDescriptor": {
-          "Flags": 0,
-          "HeapType": 2
-        },
-        "resourceDescriptor": {
-          "Dimension": 1,
-          "Alignment": 0,
-          "Width": 524288,
-          "Height": 1,
-          "DepthOrArraySize": 1,
-          "MipLevels": 1,
-          "Format": 0,
-          "Layout": 1,
-          "SampleDesc": {
-            "Count": 1,
-            "Quality": 0
-          },
-          "Flags": 0
-        },
-        "initialResourceState": 2755,
-        "clearValue": {}
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 248893,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 248893,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 248902,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 248909,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 248912,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 248925,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 9
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 248950,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 9
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f848570",
-      "tid": 43696,
-      "ts": 248952,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f848570",
-      "tid": 43696,
-      "ts": 248968,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 524288,
-          "HeapOffset": 2097152,
-          "OffsetFromResource": 0,
-          "Method": 2,
-          "ResourceHeap": {
-            "id_ref": "0x1a90d9e8230"
-          }
-        }
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 248970,
+      "tid": 16852,
+      "ts": 287713,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 249008,
+      "tid": 16852,
+      "ts": 287755,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f8450a0",
-      "tid": 43696,
-      "ts": 249009,
+      "id": "0x1743e24f760",
+      "tid": 16852,
+      "ts": 287755,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f84dbd0",
-      "tid": 43696,
-      "ts": 255079,
+      "id": "0x1743df9b6b0",
+      "tid": 16852,
+      "ts": 293583,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 255082,
+      "tid": 16852,
+      "ts": 293585,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 255109,
+      "tid": 16852,
+      "ts": 293613,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 293614,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 293615,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 255110,
+      "tid": 16852,
+      "ts": 293616,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 255125,
+      "id": "0x1743de44d98",
+      "tid": 16852,
+      "ts": 293629,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 2
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 255134,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 2
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 255135,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f84db20",
-      "tid": 43696,
-      "ts": 255141,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 255142,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 255158,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f8437e0",
-      "tid": 43696,
-      "ts": 255159,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f84cf70",
-      "tid": 43696,
-      "ts": 255411,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 255413,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 255443,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 255443,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 255456,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 2
+          "UnusedPoolSize": 12582912
         }
       }
     },
@@ -9847,235 +9667,129 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f843750",
-      "tid": 43696,
-      "ts": 255459,
+      "id": "0x1743e24fd00",
+      "tid": 16852,
+      "ts": 293632,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 255460,
+      "tid": 16852,
+      "ts": 293633,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 293633,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 293639,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f84c1b0",
-      "tid": 43696,
-      "ts": 255650,
+      "id": "0x1743df9cb50",
+      "tid": 16852,
+      "ts": 293875,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 255651,
+      "tid": 16852,
+      "ts": 293877,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 255677,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 255678,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 255690,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 255698,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 255701,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90faddc30",
-      "tid": 43696,
-      "ts": 255706,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 255707,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 255729,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 255729,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 255737,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 255745,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 255746,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90fadcc60",
-      "tid": 43696,
-      "ts": 255750,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 255750,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 255767,
+      "tid": 16852,
+      "ts": 293898,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90d9e8500",
-      "tid": 43696,
-      "ts": 255767,
+      "id": "0x1743e24ee60",
+      "tid": 16852,
+      "ts": 293898,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90faddfa0",
-      "tid": 43696,
-      "ts": 256370,
+      "id": "0x1743df9bad0",
+      "tid": 16852,
+      "ts": 294135,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 256372,
+      "tid": 16852,
+      "ts": 294137,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 256399,
+      "tid": 16852,
+      "ts": 294165,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 294165,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 294166,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 256400,
+      "tid": 16852,
+      "ts": 294167,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 256428,
+      "id": "0x1743de44d98",
+      "tid": 16852,
+      "ts": 294179,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 8388608
         }
       }
     },
@@ -10083,477 +9797,243 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f843b40",
-      "tid": 43696,
-      "ts": 256431,
+      "id": "0x1743e24f520",
+      "tid": 16852,
+      "ts": 294181,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 256432,
+      "tid": 16852,
+      "ts": 294182,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 294183,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 294188,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f84d650",
-      "tid": 43696,
-      "ts": 256685,
+      "id": "0x1743df9d230",
+      "tid": 16852,
+      "ts": 294405,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 256687,
+      "tid": 16852,
+      "ts": 294407,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 256714,
+      "tid": 16852,
+      "ts": 294433,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabCacheAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 256714,
+      "tid": 16852,
+      "ts": 294433,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 256728,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 294434,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 256736,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 256738,
+      "tid": 16852,
+      "ts": 294435,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 294436,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90fadce70",
-      "tid": 43696,
-      "ts": 256744,
+      "id": "0x1743e24a2d0",
+      "tid": 16852,
+      "ts": 294441,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 256744,
+      "tid": 16852,
+      "ts": 294442,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 256767,
+      "tid": 16852,
+      "ts": 294463,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabCacheAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 256767,
+      "tid": 16852,
+      "ts": 294463,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 256775,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 294464,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 256783,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 256785,
+      "tid": 16852,
+      "ts": 294464,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 294465,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f849330",
-      "tid": 43696,
-      "ts": 256787,
+      "id": "0x1743e24ae80",
+      "tid": 16852,
+      "ts": 294468,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 256788,
+      "tid": 16852,
+      "ts": 294468,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 256809,
+      "tid": 16852,
+      "ts": 294483,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "GPUMemoryBlock",
       "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 256810,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 256817,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 256825,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 256827,
+      "ph": "D",
+      "id": "0x1743e24f6d0",
+      "tid": 16852,
+      "ts": 294484,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90fadcbb0",
-      "tid": 43696,
-      "ts": 256840,
+      "id": "0x1743e24bda0",
+      "tid": 16852,
+      "ts": 295037,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 256841,
+      "tid": 16852,
+      "ts": 295039,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 256862,
+      "tid": 16852,
+      "ts": 295067,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 295067,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 295068,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 256862,
+      "tid": 16852,
+      "ts": 295069,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 256881,
+      "id": "0x1743de44d98",
+      "tid": 16852,
+      "ts": 295084,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 256889,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 256891,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f847110",
-      "tid": 43696,
-      "ts": 256893,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 256894,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 256914,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 256915,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 256923,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 256930,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 256932,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f848570",
-      "tid": 43696,
-      "ts": 256934,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 256935,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 256956,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 256956,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 256963,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 256971,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 256973,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f848af0",
-      "tid": 43696,
-      "ts": 256975,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 256976,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 257002,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 257003,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 257015,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 4194304
         }
       }
     },
@@ -10561,187 +10041,647 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90d9e8230",
-      "tid": 43696,
-      "ts": 257017,
+      "id": "0x1743e24e0e0",
+      "tid": 16852,
+      "ts": 295086,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 257018,
+      "tid": 16852,
+      "ts": 295087,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 295088,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 295092,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f846ae0",
-      "tid": 43696,
-      "ts": 257270,
+      "id": "0x1743df9cd60",
+      "tid": 16852,
+      "ts": 295340,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 257272,
+      "tid": 16852,
+      "ts": 295342,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 295369,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 295369,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 295370,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 295371,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743de44098",
+      "tid": 16852,
+      "ts": 295383,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "UnusedPoolSize": 12582912
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x1743c092260",
+      "tid": 16852,
+      "ts": 295385,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 295387,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 295387,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 295394,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x1743e24b090",
+      "tid": 16852,
+      "ts": 295646,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 295648,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 295673,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 295673,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 295674,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 295675,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 295676,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x1743e277540",
+      "tid": 16852,
+      "ts": 295679,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 295680,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 295700,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 295700,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 295701,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 295701,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 295701,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x1743df97f60",
+      "tid": 16852,
+      "ts": 295703,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 295704,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 295724,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 295725,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 295725,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 295726,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743de44098",
+      "tid": 16852,
+      "ts": 295737,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "UnusedPoolSize": 8388608
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x1743e24f640",
+      "tid": 16852,
+      "ts": 295739,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 295740,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 295741,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 295745,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x1743df975c0",
+      "tid": 16852,
+      "ts": 295969,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 295971,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 295995,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 295996,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 295997,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 295997,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 295998,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x1743e277960",
+      "tid": 16852,
+      "ts": 296001,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 296001,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 296021,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 296022,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 296022,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 296023,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 296023,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x1743e278ca0",
+      "tid": 16852,
+      "ts": 296025,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 296025,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 296048,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 296048,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 296048,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 296049,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743de44098",
+      "tid": 16852,
+      "ts": 296064,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "UnusedPoolSize": 4194304
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x1743e24e710",
+      "tid": 16852,
+      "ts": 296067,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 296067,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 296068,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 296072,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x1743df9bfa0",
+      "tid": 16852,
+      "ts": 296310,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 296312,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f79e410",
-      "tid": 43696,
-      "ts": 257285,
+      "id": "0x1743e0f9ed0",
+      "tid": 16852,
+      "ts": 296325,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f6f1c70",
-      "tid": 43696,
-      "ts": 257287,
+      "id": "0x1743de44698",
+      "tid": 16852,
+      "ts": 296332,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f6f1130",
-      "tid": 43696,
-      "ts": 257290,
+      "id": "0x1743de44298",
+      "tid": 16852,
+      "ts": 296337,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f6f1f40",
-      "tid": 43696,
-      "ts": 257291,
+      "id": "0x1743de44998",
+      "tid": 16852,
+      "ts": 296340,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f6f27b0",
-      "tid": 43696,
-      "ts": 257293,
+      "id": "0x1743de44a98",
+      "tid": 16852,
+      "ts": 296343,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f6f2a80",
-      "tid": 43696,
-      "ts": 257294,
+      "id": "0x1743de44098",
+      "tid": 16852,
+      "ts": 296346,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f6f18b0",
-      "tid": 43696,
-      "ts": 257296,
+      "id": "0x1743de44d98",
+      "tid": 16852,
+      "ts": 296349,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f6f2c60",
-      "tid": 43696,
-      "ts": 257298,
+      "id": "0x1743de43598",
+      "tid": 16852,
+      "ts": 296351,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f6f15e0",
-      "tid": 43696,
-      "ts": 257299,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f6f1d60",
-      "tid": 43696,
-      "ts": 257301,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f6f1220",
-      "tid": 43696,
-      "ts": 257304,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f6f1310",
-      "tid": 43696,
-      "ts": 257306,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f6f24e0",
-      "tid": 43696,
-      "ts": 257308,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f6f28a0",
-      "tid": 43696,
-      "ts": 257310,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f6f1e50",
-      "tid": 43696,
-      "ts": 257313,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f6f2b70",
-      "tid": 43696,
-      "ts": 257314,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f6f0e60",
-      "tid": 43696,
-      "ts": 257317,
+      "id": "0x1743de43698",
+      "tid": 16852,
+      "ts": 296353,
       "pid": "GPGMM"
     }
   ]

--- a/src/tests/capture_replay_tests/traces/webnn_end2end_mobilenetv2nchwtests_nchwtest0.json
+++ b/src/tests/capture_replay_tests/traces/webnn_end2end_mobilenetv2nchwtests_nchwtest0.json
@@ -5,8 +5,8 @@
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 408806,
+      "tid": 16852,
+      "ts": 444913,
       "pid": "GPGMM",
       "args": {
         "Flags": 0,
@@ -26,161 +26,89 @@
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f699850",
-      "tid": 43696,
-      "ts": 408812,
+      "id": "0x1743c0ff5c0",
+      "tid": 16852,
+      "ts": 444917,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f75c2f0",
-      "tid": 43696,
-      "ts": 408829,
+      "id": "0x1743de44a98",
+      "tid": 16852,
+      "ts": 444937,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f75df10",
-      "tid": 43696,
-      "ts": 408840,
+      "id": "0x1743de44b98",
+      "tid": 16852,
+      "ts": 444963,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f75ca70",
-      "tid": 43696,
-      "ts": 408845,
+      "id": "0x1743de43d98",
+      "tid": 16852,
+      "ts": 444968,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f75ce30",
-      "tid": 43696,
-      "ts": 408854,
+      "id": "0x1743de44398",
+      "tid": 16852,
+      "ts": 444990,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f75d790",
-      "tid": 43696,
-      "ts": 408861,
+      "id": "0x1743de45398",
+      "tid": 16852,
+      "ts": 444995,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f75d6a0",
-      "tid": 43696,
-      "ts": 408868,
+      "id": "0x1743de44298",
+      "tid": 16852,
+      "ts": 445015,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f75c5c0",
-      "tid": 43696,
-      "ts": 408873,
+      "id": "0x1743de43598",
+      "tid": 16852,
+      "ts": 445020,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f75c6b0",
-      "tid": 43696,
-      "ts": 408881,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f75cf20",
-      "tid": 43696,
-      "ts": 408886,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f75d880",
-      "tid": 43696,
-      "ts": 408891,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f75d2e0",
-      "tid": 43696,
-      "ts": 408895,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f75c890",
-      "tid": 43696,
-      "ts": 408901,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f75d970",
-      "tid": 43696,
-      "ts": 408906,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f75da60",
-      "tid": 43696,
-      "ts": 408911,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f75cb60",
-      "tid": 43696,
-      "ts": 408916,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f75cd40",
-      "tid": 43696,
-      "ts": 408925,
+      "id": "0x1743de43e98",
+      "tid": 16852,
+      "ts": 445028,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 409074,
+      "tid": 16852,
+      "ts": 445110,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -210,50 +138,50 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 409077,
+      "tid": 16852,
+      "ts": 445112,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 409080,
+      "tid": 16852,
+      "ts": 445114,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 409081,
+      "tid": 16852,
+      "ts": 445119,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 409085,
+      "tid": 16852,
+      "ts": 445122,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f892960",
-      "tid": 43696,
-      "ts": 414850,
+      "id": "0x1743de4e710",
+      "tid": 16852,
+      "ts": 450445,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f892960",
-      "tid": 43696,
-      "ts": 414878,
+      "id": "0x1743de4e710",
+      "tid": 16852,
+      "ts": 450470,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -268,9 +196,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f892960",
-      "tid": 43696,
-      "ts": 414899,
+      "id": "0x1743de4e710",
+      "tid": 16852,
+      "ts": 450493,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -285,17 +213,17 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 414901,
+      "tid": 16852,
+      "ts": 450494,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f892960",
-      "tid": 43696,
-      "ts": 414917,
+      "id": "0x1743de4e710",
+      "tid": 16852,
+      "ts": 450507,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -310,9 +238,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f892960",
-      "tid": 43696,
-      "ts": 414966,
+      "id": "0x1743de4e710",
+      "tid": 16852,
+      "ts": 450550,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -327,18 +255,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f6ada80",
-      "tid": 43696,
-      "ts": 414969,
+      "id": "0x1743e1025d0",
+      "tid": 16852,
+      "ts": 450553,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f6ada80",
-      "tid": 43696,
-      "ts": 414986,
+      "id": "0x1743e1025d0",
+      "tid": 16852,
+      "ts": 450567,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -347,7 +275,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x1a90f892960"
+            "id_ref": "0x1743de4e710"
           }
         }
       }
@@ -356,16 +284,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 414989,
+      "tid": 16852,
+      "ts": 450569,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 415074,
+      "tid": 16852,
+      "ts": 450654,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -395,50 +323,50 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 415084,
+      "tid": 16852,
+      "ts": 450656,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 415085,
+      "tid": 16852,
+      "ts": 450657,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 415085,
+      "tid": 16852,
+      "ts": 450661,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 415087,
+      "tid": 16852,
+      "ts": 450663,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f8929f0",
-      "tid": 43696,
-      "ts": 416752,
+      "id": "0x1743e10c580",
+      "tid": 16852,
+      "ts": 452526,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f8929f0",
-      "tid": 43696,
-      "ts": 416774,
+      "id": "0x1743e10c580",
+      "tid": 16852,
+      "ts": 452561,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -453,9 +381,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f8929f0",
-      "tid": 43696,
-      "ts": 416792,
+      "id": "0x1743e10c580",
+      "tid": 16852,
+      "ts": 452576,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -470,17 +398,17 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 416794,
+      "tid": 16852,
+      "ts": 452578,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f8929f0",
-      "tid": 43696,
-      "ts": 416808,
+      "id": "0x1743e10c580",
+      "tid": 16852,
+      "ts": 452595,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -495,9 +423,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f8929f0",
-      "tid": 43696,
-      "ts": 416839,
+      "id": "0x1743e10c580",
+      "tid": 16852,
+      "ts": 452635,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -512,18 +440,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f6acab0",
-      "tid": 43696,
-      "ts": 416841,
+      "id": "0x1743e102050",
+      "tid": 16852,
+      "ts": 452648,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f6acab0",
-      "tid": 43696,
-      "ts": 416857,
+      "id": "0x1743e102050",
+      "tid": 16852,
+      "ts": 452662,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -532,7 +460,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x1a90f8929f0"
+            "id_ref": "0x1743e10c580"
           }
         }
       }
@@ -541,16 +469,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 416860,
+      "tid": 16852,
+      "ts": 452664,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 416939,
+      "tid": 16852,
+      "ts": 452744,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -580,25 +508,41 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 416941,
+      "tid": 16852,
+      "ts": 452745,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 452746,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 452752,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 416942,
+      "tid": 16852,
+      "ts": 452756,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f75d2e0",
-      "tid": 43696,
-      "ts": 416960,
+      "id": "0x1743de44298",
+      "tid": 16852,
+      "ts": 452770,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -610,26 +554,26 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 416962,
+      "tid": 16852,
+      "ts": 452772,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f801bc0",
-      "tid": 43696,
-      "ts": 417639,
+      "id": "0x1743e10d420",
+      "tid": 16852,
+      "ts": 453632,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f801bc0",
-      "tid": 43696,
-      "ts": 417660,
+      "id": "0x1743e10d420",
+      "tid": 16852,
+      "ts": 453666,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -644,9 +588,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f801bc0",
-      "tid": 43696,
-      "ts": 417676,
+      "id": "0x1743e10d420",
+      "tid": 16852,
+      "ts": 453682,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -661,21 +605,21 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 417678,
+      "tid": 16852,
+      "ts": 453684,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f75d2e0",
-      "tid": 43696,
-      "ts": 417686,
+      "id": "0x1743de44298",
+      "tid": 16852,
+      "ts": 453701,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 4194304
         }
       }
     },
@@ -683,24 +627,40 @@
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 417689,
+      "tid": 16852,
+      "ts": 453704,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 453706,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 453707,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f801bc0",
-      "tid": 43696,
-      "ts": 417702,
+      "id": "0x1743e10d420",
+      "tid": 16852,
+      "ts": 453719,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 1
+          "SubAllocatedRefs": 2
         }
       }
     },
@@ -708,16 +668,16 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f801bc0",
-      "tid": 43696,
-      "ts": 417738,
+      "id": "0x1743e10d420",
+      "tid": 16852,
+      "ts": 453762,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 1
+          "SubAllocatedRefs": 2
         }
       }
     },
@@ -725,18 +685,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f6ad3a0",
-      "tid": 43696,
-      "ts": 417741,
+      "id": "0x1743e102b50",
+      "tid": 16852,
+      "ts": 453764,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f6ad3a0",
-      "tid": 43696,
-      "ts": 417757,
+      "id": "0x1743e102b50",
+      "tid": 16852,
+      "ts": 453778,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -745,7 +705,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90f801bc0"
+            "id_ref": "0x1743e10d420"
           }
         }
       }
@@ -754,16 +714,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 417759,
+      "tid": 16852,
+      "ts": 453780,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 417848,
+      "tid": 16852,
+      "ts": 453913,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -793,50 +753,50 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 417849,
+      "tid": 16852,
+      "ts": 453915,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 417850,
+      "tid": 16852,
+      "ts": 453916,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 417862,
+      "tid": 16852,
+      "ts": 453920,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 417864,
+      "tid": 16852,
+      "ts": 453922,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f801860",
-      "tid": 43696,
-      "ts": 419493,
+      "id": "0x1743e10d5d0",
+      "tid": 16852,
+      "ts": 455803,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f801860",
-      "tid": 43696,
-      "ts": 419513,
+      "id": "0x1743e10d5d0",
+      "tid": 16852,
+      "ts": 455839,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -851,9 +811,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f801860",
-      "tid": 43696,
-      "ts": 419530,
+      "id": "0x1743e10d5d0",
+      "tid": 16852,
+      "ts": 455863,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -868,17 +828,17 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 419532,
+      "tid": 16852,
+      "ts": 455864,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f801860",
-      "tid": 43696,
-      "ts": 419546,
+      "id": "0x1743e10d5d0",
+      "tid": 16852,
+      "ts": 455876,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -893,9 +853,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f801860",
-      "tid": 43696,
-      "ts": 419580,
+      "id": "0x1743e10d5d0",
+      "tid": 16852,
+      "ts": 455905,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -910,18 +870,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f809930",
-      "tid": 43696,
-      "ts": 419582,
+      "id": "0x1743e102100",
+      "tid": 16852,
+      "ts": 455907,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f809930",
-      "tid": 43696,
-      "ts": 419598,
+      "id": "0x1743e102100",
+      "tid": 16852,
+      "ts": 455921,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -930,7 +890,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x1a90f801860"
+            "id_ref": "0x1743e10d5d0"
           }
         }
       }
@@ -939,50 +899,50 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 419600,
+      "tid": 16852,
+      "ts": 455923,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 419644,
+      "tid": 16852,
+      "ts": 455977,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f892960",
-      "tid": 43696,
-      "ts": 419645,
+      "id": "0x1743de4e710",
+      "tid": 16852,
+      "ts": 455977,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f6ada80",
-      "tid": 43696,
-      "ts": 419844,
+      "id": "0x1743e1025d0",
+      "tid": 16852,
+      "ts": 456230,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 419846,
+      "tid": 16852,
+      "ts": 456232,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 419901,
+      "tid": 16852,
+      "ts": 456284,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1012,25 +972,41 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 419903,
+      "tid": 16852,
+      "ts": 456286,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 456287,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 456291,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 419903,
+      "tid": 16852,
+      "ts": 456295,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f75cf20",
-      "tid": 43696,
-      "ts": 419918,
+      "id": "0x1743de45398",
+      "tid": 16852,
+      "ts": 456308,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1042,26 +1018,26 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 419920,
+      "tid": 16852,
+      "ts": 456310,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f7fffa0",
-      "tid": 43696,
-      "ts": 420537,
+      "id": "0x1743e10c8e0",
+      "tid": 16852,
+      "ts": 456917,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f7fffa0",
-      "tid": 43696,
-      "ts": 420560,
+      "id": "0x1743e10c8e0",
+      "tid": 16852,
+      "ts": 456936,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1076,9 +1052,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f7fffa0",
-      "tid": 43696,
-      "ts": 420579,
+      "id": "0x1743e10c8e0",
+      "tid": 16852,
+      "ts": 456951,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1093,21 +1069,21 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 420581,
+      "tid": 16852,
+      "ts": 456953,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f75cf20",
-      "tid": 43696,
-      "ts": 420588,
+      "id": "0x1743de45398",
+      "tid": 16852,
+      "ts": 456960,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 4194304
         }
       }
     },
@@ -1115,24 +1091,40 @@
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 420591,
+      "tid": 16852,
+      "ts": 456962,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 456964,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 456965,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f7fffa0",
-      "tid": 43696,
-      "ts": 420605,
+      "id": "0x1743e10c8e0",
+      "tid": 16852,
+      "ts": 456977,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 1
+          "SubAllocatedRefs": 2
         }
       }
     },
@@ -1140,16 +1132,16 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f7fffa0",
-      "tid": 43696,
-      "ts": 420638,
+      "id": "0x1743e10c8e0",
+      "tid": 16852,
+      "ts": 457004,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 1
+          "SubAllocatedRefs": 2
         }
       }
     },
@@ -1157,18 +1149,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f809720",
-      "tid": 43696,
-      "ts": 420640,
+      "id": "0x1743e102520",
+      "tid": 16852,
+      "ts": 457006,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f809720",
-      "tid": 43696,
-      "ts": 420656,
+      "id": "0x1743e102520",
+      "tid": 16852,
+      "ts": 457020,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1177,7 +1169,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90f7fffa0"
+            "id_ref": "0x1743e10c8e0"
           }
         }
       }
@@ -1186,50 +1178,50 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 420658,
+      "tid": 16852,
+      "ts": 457022,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 420714,
+      "tid": 16852,
+      "ts": 457078,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f8929f0",
-      "tid": 43696,
-      "ts": 420715,
+      "id": "0x1743e10c580",
+      "tid": 16852,
+      "ts": 457078,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f6acab0",
-      "tid": 43696,
-      "ts": 420887,
+      "id": "0x1743e102050",
+      "tid": 16852,
+      "ts": 457323,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 420889,
+      "tid": 16852,
+      "ts": 457325,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 420943,
+      "tid": 16852,
+      "ts": 457375,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1259,43 +1251,118 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 420944,
+      "tid": 16852,
+      "ts": 457377,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 457378,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 457382,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 420945,
+      "tid": 16852,
+      "ts": 457385,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f75d2e0",
-      "tid": 43696,
-      "ts": 420953,
+      "id": "0x1743de44298",
+      "tid": 16852,
+      "ts": 457393,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 4194304
         }
       }
+    },
+    {
+      "name": "ResourceAllocator.CreateResourceHeap",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 457395,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x1743e10c2b0",
+      "tid": 16852,
+      "ts": 458403,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743e10c2b0",
+      "tid": 16852,
+      "ts": 458422,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 0,
+          "MemorySegmentGroup": 0,
+          "SubAllocatedRefs": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743e10c2b0",
+      "tid": 16852,
+      "ts": 458437,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 0,
+          "SubAllocatedRefs": 0
+        }
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResourceHeap",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 458439,
+      "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f75d2e0",
-      "tid": 43696,
-      "ts": 420961,
+      "id": "0x1743de44298",
+      "tid": 16852,
+      "ts": 458446,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 8388608
         }
       }
     },
@@ -1303,17 +1370,33 @@
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 420964,
+      "tid": 16852,
+      "ts": 458449,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 458450,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 458451,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f801bc0",
-      "tid": 43696,
-      "ts": 420978,
+      "id": "0x1743e10c2b0",
+      "tid": 16852,
+      "ts": 458463,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1328,9 +1411,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f801bc0",
-      "tid": 43696,
-      "ts": 421008,
+      "id": "0x1743e10c2b0",
+      "tid": 16852,
+      "ts": 458490,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1345,27 +1428,27 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f80a170",
-      "tid": 43696,
-      "ts": 421010,
+      "id": "0x1743e1025d0",
+      "tid": 16852,
+      "ts": 458492,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f80a170",
-      "tid": 43696,
-      "ts": 421026,
+      "id": "0x1743e1025d0",
+      "tid": 16852,
+      "ts": 458506,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 1048576,
-          "HeapOffset": 1048576,
+          "HeapOffset": 0,
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90f801bc0"
+            "id_ref": "0x1743e10c2b0"
           }
         }
       }
@@ -1374,16 +1457,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 421028,
+      "tid": 16852,
+      "ts": 458508,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 421096,
+      "tid": 16852,
+      "ts": 458576,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1413,25 +1496,41 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 421098,
+      "tid": 16852,
+      "ts": 458578,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 458579,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 458583,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 421099,
+      "tid": 16852,
+      "ts": 458586,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f75c5c0",
-      "tid": 43696,
-      "ts": 421113,
+      "id": "0x1743de44398",
+      "tid": 16852,
+      "ts": 458604,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1443,26 +1542,26 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 421116,
+      "tid": 16852,
+      "ts": 458608,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f801c50",
-      "tid": 43696,
-      "ts": 421736,
+      "id": "0x1743e10cdf0",
+      "tid": 16852,
+      "ts": 459157,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f801c50",
-      "tid": 43696,
-      "ts": 421757,
+      "id": "0x1743e10cdf0",
+      "tid": 16852,
+      "ts": 459176,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1477,9 +1576,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f801c50",
-      "tid": 43696,
-      "ts": 421774,
+      "id": "0x1743e10cdf0",
+      "tid": 16852,
+      "ts": 459210,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1494,21 +1593,21 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 421776,
+      "tid": 16852,
+      "ts": 459212,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f75c5c0",
-      "tid": 43696,
-      "ts": 421784,
+      "id": "0x1743de44398",
+      "tid": 16852,
+      "ts": 459219,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 4194304
         }
       }
     },
@@ -1516,24 +1615,40 @@
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 421786,
+      "tid": 16852,
+      "ts": 459221,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 459222,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 459223,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f801c50",
-      "tid": 43696,
-      "ts": 421799,
+      "id": "0x1743e10cdf0",
+      "tid": 16852,
+      "ts": 459235,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 1
+          "SubAllocatedRefs": 2
         }
       }
     },
@@ -1541,16 +1656,16 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f801c50",
-      "tid": 43696,
-      "ts": 421833,
+      "id": "0x1743e10cdf0",
+      "tid": 16852,
+      "ts": 459263,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 1
+          "SubAllocatedRefs": 2
         }
       }
     },
@@ -1558,18 +1673,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f80a590",
-      "tid": 43696,
-      "ts": 421835,
+      "id": "0x1743e1035a0",
+      "tid": 16852,
+      "ts": 459265,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f80a590",
-      "tid": 43696,
-      "ts": 421851,
+      "id": "0x1743e1035a0",
+      "tid": 16852,
+      "ts": 459279,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1578,7 +1693,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90f801c50"
+            "id_ref": "0x1743e10cdf0"
           }
         }
       }
@@ -1587,16 +1702,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 421853,
+      "tid": 16852,
+      "ts": 459281,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 421940,
+      "tid": 16852,
+      "ts": 459366,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1626,61 +1741,49 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 421941,
+      "tid": 16852,
+      "ts": 459367,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 421962,
+      "tid": 16852,
+      "ts": 459368,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f75d2e0",
-      "tid": 43696,
-      "ts": 421970,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 459370,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f75d2e0",
-      "tid": 43696,
-      "ts": 421980,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 421983,
+      "tid": 16852,
+      "ts": 459372,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 459373,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f801bc0",
-      "tid": 43696,
-      "ts": 421997,
+      "id": "0x1743e10d420",
+      "tid": 16852,
+      "ts": 459388,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1695,9 +1798,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f801bc0",
-      "tid": 43696,
-      "ts": 422024,
+      "id": "0x1743e10d420",
+      "tid": 16852,
+      "ts": 459414,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1712,18 +1815,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f80a430",
-      "tid": 43696,
-      "ts": 422026,
+      "id": "0x1743e1173c0",
+      "tid": 16852,
+      "ts": 459415,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f80a430",
-      "tid": 43696,
-      "ts": 422042,
+      "id": "0x1743e1173c0",
+      "tid": 16852,
+      "ts": 459429,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1732,7 +1835,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90f801bc0"
+            "id_ref": "0x1743e10d420"
           }
         }
       }
@@ -1741,85 +1844,73 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 422044,
+      "tid": 16852,
+      "ts": 459431,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 422088,
+      "tid": 16852,
+      "ts": 459476,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabCacheAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 422089,
+      "tid": 16852,
+      "ts": 459476,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f75d2e0",
-      "tid": 43696,
-      "ts": 422097,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 459477,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f75d2e0",
-      "tid": 43696,
-      "ts": 422105,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 422106,
+      "tid": 16852,
+      "ts": 459478,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 459479,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f6ad3a0",
-      "tid": 43696,
-      "ts": 422110,
+      "id": "0x1743e102b50",
+      "tid": 16852,
+      "ts": 459482,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 422111,
+      "tid": 16852,
+      "ts": 459482,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 422157,
+      "tid": 16852,
+      "ts": 459525,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1849,50 +1940,50 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 422159,
+      "tid": 16852,
+      "ts": 459526,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 422160,
+      "tid": 16852,
+      "ts": 459527,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 422160,
+      "tid": 16852,
+      "ts": 459531,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 422161,
+      "tid": 16852,
+      "ts": 459533,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f800db0",
-      "tid": 43696,
-      "ts": 423662,
+      "id": "0x1743e10d270",
+      "tid": 16852,
+      "ts": 461164,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f800db0",
-      "tid": 43696,
-      "ts": 423697,
+      "id": "0x1743e10d270",
+      "tid": 16852,
+      "ts": 461199,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1907,9 +1998,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f800db0",
-      "tid": 43696,
-      "ts": 423725,
+      "id": "0x1743e10d270",
+      "tid": 16852,
+      "ts": 461213,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1924,17 +2015,17 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 423727,
+      "tid": 16852,
+      "ts": 461215,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f800db0",
-      "tid": 43696,
-      "ts": 423741,
+      "id": "0x1743e10d270",
+      "tid": 16852,
+      "ts": 461227,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1949,9 +2040,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f800db0",
-      "tid": 43696,
-      "ts": 423776,
+      "id": "0x1743e10d270",
+      "tid": 16852,
+      "ts": 461253,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1966,18 +2057,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f808d80",
-      "tid": 43696,
-      "ts": 423778,
+      "id": "0x1743e116760",
+      "tid": 16852,
+      "ts": 461255,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f808d80",
-      "tid": 43696,
-      "ts": 423794,
+      "id": "0x1743e116760",
+      "tid": 16852,
+      "ts": 461268,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1986,7 +2077,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x1a90f800db0"
+            "id_ref": "0x1743e10d270"
           }
         }
       }
@@ -1995,174 +2086,121 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 423796,
+      "tid": 16852,
+      "ts": 461272,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 423846,
+      "tid": 16852,
+      "ts": 461323,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f801860",
-      "tid": 43696,
-      "ts": 423846,
+      "id": "0x1743e10d5d0",
+      "tid": 16852,
+      "ts": 461324,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f809930",
-      "tid": 43696,
-      "ts": 424051,
+      "id": "0x1743e102100",
+      "tid": 16852,
+      "ts": 461574,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 424054,
+      "tid": 16852,
+      "ts": 461576,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 424074,
+      "tid": 16852,
+      "ts": 461594,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f800db0",
-      "tid": 43696,
-      "ts": 424075,
+      "id": "0x1743e10d270",
+      "tid": 16852,
+      "ts": 461595,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f808d80",
-      "tid": 43696,
-      "ts": 424266,
+      "id": "0x1743e116760",
+      "tid": 16852,
+      "ts": 461838,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 424269,
+      "tid": 16852,
+      "ts": 461840,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 424295,
+      "tid": 16852,
+      "ts": 461864,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 461864,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 461865,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 424295,
+      "tid": 16852,
+      "ts": 461866,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f75d2e0",
-      "tid": 43696,
-      "ts": 424309,
+      "id": "0x1743de44298",
+      "tid": 16852,
+      "ts": 461877,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f75d2e0",
-      "tid": 43696,
-      "ts": 424317,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 424319,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f80a430",
-      "tid": 43696,
-      "ts": 424323,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 43696,
-      "ts": 424323,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 424348,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 43696,
-      "ts": 424348,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f75d2e0",
-      "tid": 43696,
-      "ts": 424361,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 8388608
         }
       }
     },
@@ -2170,63 +2208,95 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f801bc0",
-      "tid": 43696,
-      "ts": 424364,
+      "id": "0x1743e10d420",
+      "tid": 16852,
+      "ts": 461879,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 424365,
+      "tid": 16852,
+      "ts": 461880,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 461881,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 461886,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f80a170",
-      "tid": 43696,
-      "ts": 424538,
+      "id": "0x1743e1173c0",
+      "tid": 16852,
+      "ts": 462124,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 424540,
+      "tid": 16852,
+      "ts": 462126,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 424570,
+      "tid": 16852,
+      "ts": 462153,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 462153,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 462154,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 424570,
+      "tid": 16852,
+      "ts": 462155,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f75c5c0",
-      "tid": 43696,
-      "ts": 424587,
+      "id": "0x1743de44298",
+      "tid": 16852,
+      "ts": 462169,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 4194304
         }
       }
     },
@@ -2234,63 +2304,95 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f801c50",
-      "tid": 43696,
-      "ts": 424589,
+      "id": "0x1743e10c2b0",
+      "tid": 16852,
+      "ts": 462171,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 424590,
+      "tid": 16852,
+      "ts": 462172,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 462172,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 462176,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f80a590",
-      "tid": 43696,
-      "ts": 424757,
+      "id": "0x1743e1025d0",
+      "tid": 16852,
+      "ts": 462420,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 424759,
+      "tid": 16852,
+      "ts": 462422,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 424788,
+      "tid": 16852,
+      "ts": 462448,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 462449,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 462450,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 424789,
+      "tid": 16852,
+      "ts": 462450,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f75cf20",
-      "tid": 43696,
-      "ts": 424805,
+      "id": "0x1743de44398",
+      "tid": 16852,
+      "ts": 462464,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 4194304
         }
       }
     },
@@ -2298,187 +2400,227 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f7fffa0",
-      "tid": 43696,
-      "ts": 424807,
+      "id": "0x1743e10cdf0",
+      "tid": 16852,
+      "ts": 462466,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 424808,
+      "tid": 16852,
+      "ts": 462467,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 462467,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 462472,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f809720",
-      "tid": 43696,
-      "ts": 424992,
+      "id": "0x1743e1035a0",
+      "tid": 16852,
+      "ts": 462715,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 424994,
+      "tid": 16852,
+      "ts": 462717,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 462744,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 462744,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 462745,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 462746,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743de45398",
+      "tid": 16852,
+      "ts": 462760,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "UnusedPoolSize": 4194304
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x1743e10c8e0",
+      "tid": 16852,
+      "ts": 462762,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 462763,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 462763,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 462767,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x1743e102520",
+      "tid": 16852,
+      "ts": 463010,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "ResourceAllocation.Release",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 463012,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f699850",
-      "tid": 43696,
-      "ts": 425011,
+      "id": "0x1743c0ff5c0",
+      "tid": 16852,
+      "ts": 463024,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f75df10",
-      "tid": 43696,
-      "ts": 425013,
+      "id": "0x1743de44a98",
+      "tid": 16852,
+      "ts": 463031,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f75ce30",
-      "tid": 43696,
-      "ts": 425016,
+      "id": "0x1743de44b98",
+      "tid": 16852,
+      "ts": 463035,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f75d6a0",
-      "tid": 43696,
-      "ts": 425018,
+      "id": "0x1743de43d98",
+      "tid": 16852,
+      "ts": 463038,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f75c6b0",
-      "tid": 43696,
-      "ts": 425020,
+      "id": "0x1743de44398",
+      "tid": 16852,
+      "ts": 463041,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f75d880",
-      "tid": 43696,
-      "ts": 425022,
+      "id": "0x1743de45398",
+      "tid": 16852,
+      "ts": 463043,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f75c890",
-      "tid": 43696,
-      "ts": 425023,
+      "id": "0x1743de44298",
+      "tid": 16852,
+      "ts": 463046,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f75da60",
-      "tid": 43696,
-      "ts": 425025,
+      "id": "0x1743de43598",
+      "tid": 16852,
+      "ts": 463048,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f75cd40",
-      "tid": 43696,
-      "ts": 425027,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f75c2f0",
-      "tid": 43696,
-      "ts": 425029,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f75ca70",
-      "tid": 43696,
-      "ts": 425032,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f75d790",
-      "tid": 43696,
-      "ts": 425034,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f75c5c0",
-      "tid": 43696,
-      "ts": 425037,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f75cf20",
-      "tid": 43696,
-      "ts": 425039,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f75d2e0",
-      "tid": 43696,
-      "ts": 425042,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f75d970",
-      "tid": 43696,
-      "ts": 425044,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f75cb60",
-      "tid": 43696,
-      "ts": 425046,
+      "id": "0x1743de43e98",
+      "tid": 16852,
+      "ts": 463050,
       "pid": "GPGMM"
     }
   ]

--- a/src/tests/capture_replay_tests/traces/webnn_mobilenetv2_nchw.json
+++ b/src/tests/capture_replay_tests/traces/webnn_mobilenetv2_nchw.json
@@ -5,8 +5,8 @@
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 571367,
+      "tid": 16852,
+      "ts": 610619,
       "pid": "GPGMM",
       "args": {
         "Flags": 0,
@@ -26,161 +26,89 @@
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f74ae80",
-      "tid": 43696,
-      "ts": 571372,
+      "id": "0x1743c0ee550",
+      "tid": 16852,
+      "ts": 610622,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d9fd450",
-      "tid": 43696,
-      "ts": 571386,
+      "id": "0x1743de45398",
+      "tid": 16852,
+      "ts": 610631,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d9fcfa0",
-      "tid": 43696,
-      "ts": 571406,
+      "id": "0x1743de44298",
+      "tid": 16852,
+      "ts": 610641,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d9fe350",
-      "tid": 43696,
-      "ts": 571410,
+      "id": "0x1743de44398",
+      "tid": 16852,
+      "ts": 610647,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d9fcdc0",
-      "tid": 43696,
-      "ts": 571415,
+      "id": "0x1743de43998",
+      "tid": 16852,
+      "ts": 610664,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d9fdea0",
-      "tid": 43696,
-      "ts": 571420,
+      "id": "0x1743de44798",
+      "tid": 16852,
+      "ts": 610669,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d9fd270",
-      "tid": 43696,
-      "ts": 571424,
+      "id": "0x1743de44a98",
+      "tid": 16852,
+      "ts": 610689,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d9fdf90",
-      "tid": 43696,
-      "ts": 571428,
+      "id": "0x1743de44b98",
+      "tid": 16852,
+      "ts": 610695,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d9fc640",
-      "tid": 43696,
-      "ts": 571433,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90d9fc820",
-      "tid": 43696,
-      "ts": 571436,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90d9fd090",
-      "tid": 43696,
-      "ts": 571439,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90d9fc910",
-      "tid": 43696,
-      "ts": 571442,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90d9fc550",
-      "tid": 43696,
-      "ts": 571445,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90d9fe080",
-      "tid": 43696,
-      "ts": 571459,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90d9fccd0",
-      "tid": 43696,
-      "ts": 571462,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90d9fca00",
-      "tid": 43696,
-      "ts": 571464,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90d9fcaf0",
-      "tid": 43696,
-      "ts": 571470,
+      "id": "0x1743de43698",
+      "tid": 16852,
+      "ts": 610717,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 571552,
+      "tid": 16852,
+      "ts": 610814,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -210,25 +138,41 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 571553,
+      "tid": 16852,
+      "ts": 610816,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 610818,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 610823,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 571555,
+      "tid": 16852,
+      "ts": 610827,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9fc820",
-      "tid": 43696,
-      "ts": 571569,
+      "id": "0x1743de44798",
+      "tid": 16852,
+      "ts": 610840,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -240,26 +184,26 @@
       "name": "SegmentedMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 571572,
+      "tid": 16852,
+      "ts": 610843,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f837810",
-      "tid": 43696,
-      "ts": 571573,
+      "id": "0x1743de4dcf0",
+      "tid": 16852,
+      "ts": 610846,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f837810",
-      "tid": 43696,
-      "ts": 571581,
+      "id": "0x1743de4dcf0",
+      "tid": 16852,
+      "ts": 610852,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -271,26 +215,26 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 571583,
+      "tid": 16852,
+      "ts": 610854,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d9e7ae0",
-      "tid": 43696,
-      "ts": 578572,
+      "id": "0x1743def3b10",
+      "tid": 16852,
+      "ts": 614236,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e7ae0",
-      "tid": 43696,
-      "ts": 578597,
+      "id": "0x1743def3b10",
+      "tid": 16852,
+      "ts": 614272,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -305,9 +249,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e7ae0",
-      "tid": 43696,
-      "ts": 578618,
+      "id": "0x1743def3b10",
+      "tid": 16852,
+      "ts": 614289,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -322,29 +266,29 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 578619,
+      "tid": 16852,
+      "ts": 614291,
       "pid": "GPGMM"
     },
     {
       "name": "SegmentedMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 578621,
+      "tid": 16852,
+      "ts": 614292,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9fc820",
-      "tid": 43696,
-      "ts": 578628,
+      "id": "0x1743de44798",
+      "tid": 16852,
+      "ts": 614298,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 16777216
         }
       }
     },
@@ -352,26 +296,42 @@
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 578631,
+      "tid": 16852,
+      "ts": 614301,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 614302,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 614303,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e7ae0",
-      "tid": 43696,
-      "ts": 578653,
+      "id": "0x1743def3b10",
+      "tid": 16852,
+      "ts": 614318,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 16777216,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 1,
+          "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x1a90f837810"
+            "id_ref": "0x1743de4dcf0"
           }
         }
       }
@@ -380,18 +340,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e7ae0",
-      "tid": 43696,
-      "ts": 578701,
+      "id": "0x1743def3b10",
+      "tid": 16852,
+      "ts": 614362,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 16777216,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 1,
+          "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x1a90f837810"
+            "id_ref": "0x1743de4dcf0"
           }
         }
       }
@@ -400,18 +360,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f818a40",
-      "tid": 43696,
-      "ts": 578703,
+      "id": "0x1743def2310",
+      "tid": 16852,
+      "ts": 614365,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f818a40",
-      "tid": 43696,
-      "ts": 578719,
+      "id": "0x1743def2310",
+      "tid": 16852,
+      "ts": 614379,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -420,7 +380,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90d9e7ae0"
+            "id_ref": "0x1743def3b10"
           }
         }
       }
@@ -429,16 +389,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 578722,
+      "tid": 16852,
+      "ts": 614386,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 578820,
+      "tid": 16852,
+      "ts": 614476,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -468,25 +428,41 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 578821,
+      "tid": 16852,
+      "ts": 614477,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 614478,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 614482,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 578822,
+      "tid": 16852,
+      "ts": 614485,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9fc910",
-      "tid": 43696,
-      "ts": 578836,
+      "id": "0x1743de44a98",
+      "tid": 16852,
+      "ts": 614497,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -498,26 +474,26 @@
       "name": "SegmentedMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 578839,
+      "tid": 16852,
+      "ts": 614499,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f751e50",
-      "tid": 43696,
-      "ts": 578839,
+      "id": "0x1743def3600",
+      "tid": 16852,
+      "ts": 614500,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f751e50",
-      "tid": 43696,
-      "ts": 578847,
+      "id": "0x1743def3600",
+      "tid": 16852,
+      "ts": 614505,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -529,26 +505,26 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 578849,
+      "tid": 16852,
+      "ts": 614507,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d9e8590",
-      "tid": 43696,
-      "ts": 580467,
+      "id": "0x1743def4fe0",
+      "tid": 16852,
+      "ts": 616101,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8590",
-      "tid": 43696,
-      "ts": 580504,
+      "id": "0x1743def4fe0",
+      "tid": 16852,
+      "ts": 616121,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -563,9 +539,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8590",
-      "tid": 43696,
-      "ts": 580521,
+      "id": "0x1743def4fe0",
+      "tid": 16852,
+      "ts": 616137,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -580,29 +556,29 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 580523,
+      "tid": 16852,
+      "ts": 616138,
       "pid": "GPGMM"
     },
     {
       "name": "SegmentedMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 580525,
+      "tid": 16852,
+      "ts": 616140,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9fc910",
-      "tid": 43696,
-      "ts": 580532,
+      "id": "0x1743de44a98",
+      "tid": 16852,
+      "ts": 616147,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 16777216
         }
       }
     },
@@ -610,26 +586,42 @@
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 580534,
+      "tid": 16852,
+      "ts": 616149,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 616151,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 616152,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8590",
-      "tid": 43696,
-      "ts": 580550,
+      "id": "0x1743def4fe0",
+      "tid": 16852,
+      "ts": 616165,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 16777216,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 1,
+          "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x1a90f751e50"
+            "id_ref": "0x1743def3600"
           }
         }
       }
@@ -638,18 +630,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8590",
-      "tid": 43696,
-      "ts": 580583,
+      "id": "0x1743def4fe0",
+      "tid": 16852,
+      "ts": 616196,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 16777216,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 1,
+          "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x1a90f751e50"
+            "id_ref": "0x1743def3600"
           }
         }
       }
@@ -658,18 +650,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f8193e0",
-      "tid": 43696,
-      "ts": 580585,
+      "id": "0x1743def2470",
+      "tid": 16852,
+      "ts": 616198,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f8193e0",
-      "tid": 43696,
-      "ts": 580601,
+      "id": "0x1743def2470",
+      "tid": 16852,
+      "ts": 616212,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -678,7 +670,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90d9e8590"
+            "id_ref": "0x1743def4fe0"
           }
         }
       }
@@ -687,16 +679,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 580603,
+      "tid": 16852,
+      "ts": 616214,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 580696,
+      "tid": 16852,
+      "ts": 616304,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -726,29 +718,45 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 580698,
+      "tid": 16852,
+      "ts": 616305,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 616306,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 616310,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 580699,
+      "tid": 16852,
+      "ts": 616313,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9fc910",
-      "tid": 43696,
-      "ts": 580711,
+      "id": "0x1743de44a98",
+      "tid": 16852,
+      "ts": 616321,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 16777216
         }
       }
     },
@@ -756,17 +764,17 @@
       "name": "SegmentedMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 580715,
+      "tid": 16852,
+      "ts": 616323,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f751e50",
-      "tid": 43696,
-      "ts": 580722,
+      "id": "0x1743def3600",
+      "tid": 16852,
+      "ts": 616335,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -778,26 +786,26 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 580724,
+      "tid": 16852,
+      "ts": 616337,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d996c40",
-      "tid": 43696,
-      "ts": 582402,
+      "id": "0x1743def5070",
+      "tid": 16852,
+      "ts": 617985,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d996c40",
-      "tid": 43696,
-      "ts": 582423,
+      "id": "0x1743def5070",
+      "tid": 16852,
+      "ts": 618004,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -812,9 +820,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d996c40",
-      "tid": 43696,
-      "ts": 582440,
+      "id": "0x1743def5070",
+      "tid": 16852,
+      "ts": 618020,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -829,29 +837,29 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 582442,
+      "tid": 16852,
+      "ts": 618021,
       "pid": "GPGMM"
     },
     {
       "name": "SegmentedMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 582443,
+      "tid": 16852,
+      "ts": 618023,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9fc910",
-      "tid": 43696,
-      "ts": 582450,
+      "id": "0x1743de44a98",
+      "tid": 16852,
+      "ts": 618029,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 2
+          "UnusedPoolSize": 33554432
         }
       }
     },
@@ -859,26 +867,42 @@
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 582453,
+      "tid": 16852,
+      "ts": 618032,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 618033,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 618034,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d996c40",
-      "tid": 43696,
-      "ts": 582468,
+      "id": "0x1743def5070",
+      "tid": 16852,
+      "ts": 618048,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 16777216,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 1,
+          "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x1a90f751e50"
+            "id_ref": "0x1743def3600"
           }
         }
       }
@@ -887,18 +911,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d996c40",
-      "tid": 43696,
-      "ts": 582501,
+      "id": "0x1743def5070",
+      "tid": 16852,
+      "ts": 618080,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 16777216,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 1,
+          "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x1a90f751e50"
+            "id_ref": "0x1743def3600"
           }
         }
       }
@@ -907,18 +931,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f818af0",
-      "tid": 43696,
-      "ts": 582503,
+      "id": "0x1743def1c30",
+      "tid": 16852,
+      "ts": 618082,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f818af0",
-      "tid": 43696,
-      "ts": 582519,
+      "id": "0x1743def1c30",
+      "tid": 16852,
+      "ts": 618096,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -927,7 +951,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90d996c40"
+            "id_ref": "0x1743def5070"
           }
         }
       }
@@ -936,16 +960,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 582521,
+      "tid": 16852,
+      "ts": 618098,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 582615,
+      "tid": 16852,
+      "ts": 618189,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -975,29 +999,45 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 582616,
+      "tid": 16852,
+      "ts": 618191,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 618192,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 618193,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 582617,
+      "tid": 16852,
+      "ts": 618195,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9fc910",
-      "tid": 43696,
-      "ts": 582627,
+      "id": "0x1743de44a98",
+      "tid": 16852,
+      "ts": 618203,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 2
+          "UnusedPoolSize": 33554432
         }
       }
     },
@@ -1005,17 +1045,17 @@
       "name": "SegmentedMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 582629,
+      "tid": 16852,
+      "ts": 618207,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f751e50",
-      "tid": 43696,
-      "ts": 582636,
+      "id": "0x1743def3600",
+      "tid": 16852,
+      "ts": 618212,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1027,26 +1067,26 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 582638,
+      "tid": 16852,
+      "ts": 618214,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d997f60",
-      "tid": 43696,
-      "ts": 584297,
+      "id": "0x1743def4ec0",
+      "tid": 16852,
+      "ts": 619837,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d997f60",
-      "tid": 43696,
-      "ts": 584318,
+      "id": "0x1743def4ec0",
+      "tid": 16852,
+      "ts": 619857,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1061,9 +1101,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d997f60",
-      "tid": 43696,
-      "ts": 584335,
+      "id": "0x1743def4ec0",
+      "tid": 16852,
+      "ts": 619873,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1078,29 +1118,29 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 584336,
+      "tid": 16852,
+      "ts": 619874,
       "pid": "GPGMM"
     },
     {
       "name": "SegmentedMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 584338,
+      "tid": 16852,
+      "ts": 619876,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9fc910",
-      "tid": 43696,
-      "ts": 584345,
+      "id": "0x1743de44a98",
+      "tid": 16852,
+      "ts": 619882,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 3
+          "UnusedPoolSize": 50331648
         }
       }
     },
@@ -1108,26 +1148,42 @@
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 584348,
+      "tid": 16852,
+      "ts": 619884,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 619886,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 619887,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d997f60",
-      "tid": 43696,
-      "ts": 584363,
+      "id": "0x1743def4ec0",
+      "tid": 16852,
+      "ts": 619901,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 16777216,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 1,
+          "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x1a90f751e50"
+            "id_ref": "0x1743def3600"
           }
         }
       }
@@ -1136,18 +1192,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d997f60",
-      "tid": 43696,
-      "ts": 584394,
+      "id": "0x1743def4ec0",
+      "tid": 16852,
+      "ts": 619930,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 16777216,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 1,
+          "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x1a90f751e50"
+            "id_ref": "0x1743def3600"
           }
         }
       }
@@ -1156,18 +1212,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f817e90",
-      "tid": 43696,
-      "ts": 584396,
+      "id": "0x1743def1a20",
+      "tid": 16852,
+      "ts": 619932,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f817e90",
-      "tid": 43696,
-      "ts": 584411,
+      "id": "0x1743def1a20",
+      "tid": 16852,
+      "ts": 619946,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1176,7 +1232,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90d997f60"
+            "id_ref": "0x1743def4ec0"
           }
         }
       }
@@ -1185,37 +1241,53 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 584414,
+      "tid": 16852,
+      "ts": 619948,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 584484,
+      "tid": 16852,
+      "ts": 620022,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 620023,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 620024,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 584484,
+      "tid": 16852,
+      "ts": 620025,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9fc820",
-      "tid": 43696,
-      "ts": 584496,
+      "id": "0x1743de44798",
+      "tid": 16852,
+      "ts": 620036,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 16777216
         }
       }
     },
@@ -1223,21 +1295,21 @@
       "name": "SegmentedMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 584498,
+      "tid": 16852,
+      "ts": 620038,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f837810",
-      "tid": 43696,
-      "ts": 584508,
+      "id": "0x1743de4dcf0",
+      "tid": 16852,
+      "ts": 620054,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 16777216
         }
       }
     },
@@ -1245,41 +1317,57 @@
       "name": "SegmentedMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 584510,
+      "tid": 16852,
+      "ts": 620056,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 584510,
+      "tid": 16852,
+      "ts": 620056,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 620057,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 620061,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f818a40",
-      "tid": 43696,
-      "ts": 584515,
+      "id": "0x1743def2310",
+      "tid": 16852,
+      "ts": 620067,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 584516,
+      "tid": 16852,
+      "ts": 620067,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 584564,
+      "tid": 16852,
+      "ts": 620113,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1309,25 +1397,41 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 584565,
+      "tid": 16852,
+      "ts": 620115,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 620116,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 620118,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 584566,
+      "tid": 16852,
+      "ts": 620121,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9fc820",
-      "tid": 43696,
-      "ts": 584579,
+      "id": "0x1743de44798",
+      "tid": 16852,
+      "ts": 620132,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1339,17 +1443,17 @@
       "name": "SegmentedMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 584581,
+      "tid": 16852,
+      "ts": 620134,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f837810",
-      "tid": 43696,
-      "ts": 584588,
+      "id": "0x1743de4dcf0",
+      "tid": 16852,
+      "ts": 620139,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1361,21 +1465,21 @@
       "name": "SegmentedMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 584590,
+      "tid": 16852,
+      "ts": 620141,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9fc820",
-      "tid": 43696,
-      "ts": 584596,
+      "id": "0x1743de44798",
+      "tid": 16852,
+      "ts": 620158,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 16777216
         }
       }
     },
@@ -1383,26 +1487,42 @@
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 584599,
+      "tid": 16852,
+      "ts": 620160,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 620161,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 620188,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e7ae0",
-      "tid": 43696,
-      "ts": 584614,
+      "id": "0x1743def3b10",
+      "tid": 16852,
+      "ts": 620202,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 16777216,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 1,
+          "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x1a90f837810"
+            "id_ref": "0x1743de4dcf0"
           }
         }
       }
@@ -1411,18 +1531,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e7ae0",
-      "tid": 43696,
-      "ts": 584646,
+      "id": "0x1743def3b10",
+      "tid": 16852,
+      "ts": 620241,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 16777216,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 1,
+          "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x1a90f837810"
+            "id_ref": "0x1743de4dcf0"
           }
         }
       }
@@ -1431,18 +1551,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f818e60",
-      "tid": 43696,
-      "ts": 584648,
+      "id": "0x1743def25d0",
+      "tid": 16852,
+      "ts": 620244,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f818e60",
-      "tid": 43696,
-      "ts": 584663,
+      "id": "0x1743def25d0",
+      "tid": 16852,
+      "ts": 620258,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1451,7 +1571,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90d9e7ae0"
+            "id_ref": "0x1743def3b10"
           }
         }
       }
@@ -1460,37 +1580,53 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 584665,
+      "tid": 16852,
+      "ts": 620260,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 584719,
+      "tid": 16852,
+      "ts": 620329,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 620329,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 620330,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 584720,
+      "tid": 16852,
+      "ts": 620331,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9fc910",
-      "tid": 43696,
-      "ts": 584727,
+      "id": "0x1743de44a98",
+      "tid": 16852,
+      "ts": 620338,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 3
+          "UnusedPoolSize": 50331648
         }
       }
     },
@@ -1498,21 +1634,21 @@
       "name": "SegmentedMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 584729,
+      "tid": 16852,
+      "ts": 620340,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f751e50",
-      "tid": 43696,
-      "ts": 584738,
+      "id": "0x1743def3600",
+      "tid": 16852,
+      "ts": 620362,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 16777216
         }
       }
     },
@@ -1520,41 +1656,57 @@
       "name": "SegmentedMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 584740,
+      "tid": 16852,
+      "ts": 620364,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 584740,
+      "tid": 16852,
+      "ts": 620364,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 620365,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 620365,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f8193e0",
-      "tid": 43696,
-      "ts": 584744,
+      "id": "0x1743def2470",
+      "tid": 16852,
+      "ts": 620369,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 584744,
+      "tid": 16852,
+      "ts": 620369,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 584789,
+      "tid": 16852,
+      "ts": 620440,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1584,43 +1736,89 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 584809,
+      "tid": 16852,
+      "ts": 620442,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 620443,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 620458,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 584810,
+      "tid": 16852,
+      "ts": 620461,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9fc910",
-      "tid": 43696,
-      "ts": 584818,
+      "id": "0x1743de44a98",
+      "tid": 16852,
+      "ts": 620468,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 2
+          "UnusedPoolSize": 33554432
         }
       }
+    },
+    {
+      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 620469,
+      "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9fc910",
-      "tid": 43696,
-      "ts": 584826,
+      "id": "0x1743def3600",
+      "tid": 16852,
+      "ts": 620475,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 2
+          "UnusedPoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 620477,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743de44a98",
+      "tid": 16852,
+      "ts": 620482,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "UnusedPoolSize": 50331648
         }
       }
     },
@@ -1628,17 +1826,33 @@
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 584828,
+      "tid": 16852,
+      "ts": 620484,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 620485,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 620486,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d996c40",
-      "tid": 43696,
-      "ts": 584844,
+      "id": "0x1743def4fe0",
+      "tid": 16852,
+      "ts": 620500,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1647,7 +1861,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x1a90f751e50"
+            "id_ref": "0x1743def3600"
           }
         }
       }
@@ -1656,9 +1870,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d996c40",
-      "tid": 43696,
-      "ts": 584880,
+      "id": "0x1743def4fe0",
+      "tid": 16852,
+      "ts": 620530,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1667,7 +1881,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x1a90f751e50"
+            "id_ref": "0x1743def3600"
           }
         }
       }
@@ -1676,27 +1890,27 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f8184c0",
-      "tid": 43696,
-      "ts": 584882,
+      "id": "0x1743def2ec0",
+      "tid": 16852,
+      "ts": 620532,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f8184c0",
-      "tid": 43696,
-      "ts": 584898,
+      "id": "0x1743def2ec0",
+      "tid": 16852,
+      "ts": 620545,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 1048576,
-          "HeapOffset": 1048576,
+          "HeapOffset": 0,
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90d996c40"
+            "id_ref": "0x1743def4fe0"
           }
         }
       }
@@ -1705,16 +1919,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 584900,
+      "tid": 16852,
+      "ts": 620548,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 584965,
+      "tid": 16852,
+      "ts": 620648,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1744,25 +1958,41 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 584967,
+      "tid": 16852,
+      "ts": 620650,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 620651,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 620654,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 584968,
+      "tid": 16852,
+      "ts": 620657,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9fdf90",
-      "tid": 43696,
-      "ts": 584982,
+      "id": "0x1743de43998",
+      "tid": 16852,
+      "ts": 620683,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1774,26 +2004,26 @@
       "name": "SegmentedMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 584984,
+      "tid": 16852,
+      "ts": 620684,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f836b90",
-      "tid": 43696,
-      "ts": 584985,
+      "id": "0x1743def44a0",
+      "tid": 16852,
+      "ts": 620685,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f836b90",
-      "tid": 43696,
-      "ts": 584992,
+      "id": "0x1743def44a0",
+      "tid": 16852,
+      "ts": 620690,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1805,26 +2035,26 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 584994,
+      "tid": 16852,
+      "ts": 620692,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d997390",
-      "tid": 43696,
-      "ts": 586718,
+      "id": "0x1743def4b60",
+      "tid": 16852,
+      "ts": 621937,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d997390",
-      "tid": 43696,
-      "ts": 586738,
+      "id": "0x1743def4b60",
+      "tid": 16852,
+      "ts": 621957,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1839,9 +2069,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d997390",
-      "tid": 43696,
-      "ts": 586755,
+      "id": "0x1743def4b60",
+      "tid": 16852,
+      "ts": 621972,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1856,29 +2086,29 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 586757,
+      "tid": 16852,
+      "ts": 621974,
       "pid": "GPGMM"
     },
     {
       "name": "SegmentedMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 586759,
+      "tid": 16852,
+      "ts": 621975,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9fdf90",
-      "tid": 43696,
-      "ts": 586766,
+      "id": "0x1743de43998",
+      "tid": 16852,
+      "ts": 621981,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 16777216
         }
       }
     },
@@ -1886,26 +2116,42 @@
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 586769,
+      "tid": 16852,
+      "ts": 621984,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 621985,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 621986,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d997390",
-      "tid": 43696,
-      "ts": 586784,
+      "id": "0x1743def4b60",
+      "tid": 16852,
+      "ts": 622000,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 16777216,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 1,
+          "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x1a90f836b90"
+            "id_ref": "0x1743def44a0"
           }
         }
       }
@@ -1914,18 +2160,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d997390",
-      "tid": 43696,
-      "ts": 586815,
+      "id": "0x1743def4b60",
+      "tid": 16852,
+      "ts": 622029,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 16777216,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 1,
+          "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x1a90f836b90"
+            "id_ref": "0x1743def44a0"
           }
         }
       }
@@ -1934,18 +2180,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f8186d0",
-      "tid": 43696,
-      "ts": 586817,
+      "id": "0x1743def16b0",
+      "tid": 16852,
+      "ts": 622031,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f8186d0",
-      "tid": 43696,
-      "ts": 586833,
+      "id": "0x1743def16b0",
+      "tid": 16852,
+      "ts": 622045,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1954,7 +2200,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90d997390"
+            "id_ref": "0x1743def4b60"
           }
         }
       }
@@ -1963,16 +2209,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 586835,
+      "tid": 16852,
+      "ts": 622047,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 586928,
+      "tid": 16852,
+      "ts": 622141,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -2002,61 +2248,49 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 586929,
+      "tid": 16852,
+      "ts": 622142,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 586930,
+      "tid": 16852,
+      "ts": 622143,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d9fc910",
-      "tid": 43696,
-      "ts": 586938,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 2
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 622144,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d9fc910",
-      "tid": 43696,
-      "ts": 586946,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 2
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 586948,
+      "tid": 16852,
+      "ts": 622147,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 622147,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d996c40",
-      "tid": 43696,
-      "ts": 586964,
+      "id": "0x1743def5070",
+      "tid": 16852,
+      "ts": 622161,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2065,7 +2299,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 3,
           "MemoryPool": {
-            "id_ref": "0x1a90f751e50"
+            "id_ref": "0x1743def3600"
           }
         }
       }
@@ -2074,9 +2308,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d996c40",
-      "tid": 43696,
-      "ts": 586994,
+      "id": "0x1743def5070",
+      "tid": 16852,
+      "ts": 622187,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2085,7 +2319,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 3,
           "MemoryPool": {
-            "id_ref": "0x1a90f751e50"
+            "id_ref": "0x1743def3600"
           }
         }
       }
@@ -2094,18 +2328,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f8188e0",
-      "tid": 43696,
-      "ts": 586996,
+      "id": "0x1743def2b50",
+      "tid": 16852,
+      "ts": 622189,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f8188e0",
-      "tid": 43696,
-      "ts": 587011,
+      "id": "0x1743def2b50",
+      "tid": 16852,
+      "ts": 622203,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2114,7 +2348,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90d996c40"
+            "id_ref": "0x1743def5070"
           }
         }
       }
@@ -2123,85 +2357,73 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 587013,
+      "tid": 16852,
+      "ts": 622205,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 587057,
+      "tid": 16852,
+      "ts": 622250,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabCacheAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 587058,
+      "tid": 16852,
+      "ts": 622250,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d9fc910",
-      "tid": 43696,
-      "ts": 587065,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 2
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 622251,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90d9fc910",
-      "tid": 43696,
-      "ts": 587073,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 2
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 587075,
+      "tid": 16852,
+      "ts": 622252,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 622252,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f818af0",
-      "tid": 43696,
-      "ts": 587078,
+      "id": "0x1743def1c30",
+      "tid": 16852,
+      "ts": 622256,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 587079,
+      "tid": 16852,
+      "ts": 622256,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 587124,
+      "tid": 16852,
+      "ts": 622299,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -2231,29 +2453,45 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 587125,
+      "tid": 16852,
+      "ts": 622300,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 622301,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 622302,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 587126,
+      "tid": 16852,
+      "ts": 622303,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9fc910",
-      "tid": 43696,
-      "ts": 587133,
+      "id": "0x1743de44a98",
+      "tid": 16852,
+      "ts": 622310,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 2
+          "UnusedPoolSize": 50331648
         }
       }
     },
@@ -2261,17 +2499,17 @@
       "name": "SegmentedMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 587135,
+      "tid": 16852,
+      "ts": 622312,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f751e50",
-      "tid": 43696,
-      "ts": 587142,
+      "id": "0x1743def3600",
+      "tid": 16852,
+      "ts": 622317,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2280,24 +2518,83 @@
       }
     },
     {
+      "name": "ResourceAllocator.CreateResourceHeap",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 622319,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x1743def32a0",
+      "tid": 16852,
+      "ts": 623944,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743def32a0",
+      "tid": 16852,
+      "ts": 623963,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 16777216,
+          "IsResident": 0,
+          "MemorySegmentGroup": 0,
+          "SubAllocatedRefs": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743def32a0",
+      "tid": 16852,
+      "ts": 623978,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 16777216,
+          "IsResident": 1,
+          "MemorySegmentGroup": 0,
+          "SubAllocatedRefs": 0
+        }
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResourceHeap",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 623980,
+      "pid": "GPGMM"
+    },
+    {
       "name": "SegmentedMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 587144,
+      "tid": 16852,
+      "ts": 623981,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9fc910",
-      "tid": 43696,
-      "ts": 587151,
+      "id": "0x1743de44a98",
+      "tid": 16852,
+      "ts": 623987,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 3
+          "UnusedPoolSize": 67108864
         }
       }
     },
@@ -2305,26 +2602,42 @@
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 587153,
+      "tid": 16852,
+      "ts": 623990,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 623991,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 623992,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8590",
-      "tid": 43696,
-      "ts": 587169,
+      "id": "0x1743def32a0",
+      "tid": 16852,
+      "ts": 624006,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 16777216,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 1,
+          "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x1a90f751e50"
+            "id_ref": "0x1743def3600"
           }
         }
       }
@@ -2333,18 +2646,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e8590",
-      "tid": 43696,
-      "ts": 587197,
+      "id": "0x1743def32a0",
+      "tid": 16852,
+      "ts": 624034,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 16777216,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 1,
+          "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x1a90f751e50"
+            "id_ref": "0x1743def3600"
           }
         }
       }
@@ -2353,18 +2666,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f818af0",
-      "tid": 43696,
-      "ts": 587199,
+      "id": "0x1743def2c00",
+      "tid": 16852,
+      "ts": 624036,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f818af0",
-      "tid": 43696,
-      "ts": 587214,
+      "id": "0x1743def2c00",
+      "tid": 16852,
+      "ts": 624050,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2373,7 +2686,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90d9e8590"
+            "id_ref": "0x1743def32a0"
           }
         }
       }
@@ -2382,37 +2695,53 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 587216,
+      "tid": 16852,
+      "ts": 624052,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 587272,
+      "tid": 16852,
+      "ts": 624109,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 624109,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 624110,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 587273,
+      "tid": 16852,
+      "ts": 624111,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9fc910",
-      "tid": 43696,
-      "ts": 587281,
+      "id": "0x1743de44a98",
+      "tid": 16852,
+      "ts": 624119,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 3
+          "UnusedPoolSize": 67108864
         }
       }
     },
@@ -2420,21 +2749,21 @@
       "name": "SegmentedMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 587283,
+      "tid": 16852,
+      "ts": 624120,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f751e50",
-      "tid": 43696,
-      "ts": 587290,
+      "id": "0x1743def3600",
+      "tid": 16852,
+      "ts": 624126,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 16777216
         }
       }
     },
@@ -2442,62 +2771,94 @@
       "name": "SegmentedMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 587292,
+      "tid": 16852,
+      "ts": 624128,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 587292,
+      "tid": 16852,
+      "ts": 624128,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 624129,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 624129,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f817e90",
-      "tid": 43696,
-      "ts": 587295,
+      "id": "0x1743def1a20",
+      "tid": 16852,
+      "ts": 624133,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 587296,
+      "tid": 16852,
+      "ts": 624133,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 587322,
+      "tid": 16852,
+      "ts": 624160,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 624161,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 624161,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 587322,
+      "tid": 16852,
+      "ts": 624162,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9fc910",
-      "tid": 43696,
-      "ts": 587329,
+      "id": "0x1743de44a98",
+      "tid": 16852,
+      "ts": 624169,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 2
+          "UnusedPoolSize": 50331648
         }
       }
     },
@@ -2505,21 +2866,21 @@
       "name": "SegmentedMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 587332,
+      "tid": 16852,
+      "ts": 624171,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f751e50",
-      "tid": 43696,
-      "ts": 587338,
+      "id": "0x1743def3600",
+      "tid": 16852,
+      "ts": 624177,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 2
+          "UnusedPoolSize": 33554432
         }
       }
     },
@@ -2527,131 +2888,211 @@
       "name": "SegmentedMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 587340,
+      "tid": 16852,
+      "ts": 624178,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 587340,
+      "tid": 16852,
+      "ts": 624178,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 624179,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 624183,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f818af0",
-      "tid": 43696,
-      "ts": 587342,
+      "id": "0x1743def2c00",
+      "tid": 16852,
+      "ts": 624185,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 587343,
+      "tid": 16852,
+      "ts": 624186,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 587363,
+      "tid": 16852,
+      "ts": 624245,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 624245,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 624246,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 587363,
+      "tid": 16852,
+      "ts": 624247,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9fc910",
-      "tid": 43696,
-      "ts": 587371,
+      "id": "0x1743de44a98",
+      "tid": 16852,
+      "ts": 624255,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 33554432
         }
       }
+    },
+    {
+      "name": "SegmentedMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 624257,
+      "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9fc910",
-      "tid": 43696,
-      "ts": 587379,
+      "id": "0x1743def3600",
+      "tid": 16852,
+      "ts": 624262,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 50331648
         }
       }
+    },
+    {
+      "name": "SegmentedMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 624264,
+      "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 587381,
+      "tid": 16852,
+      "ts": 624264,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 624264,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 624268,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f8188e0",
-      "tid": 43696,
-      "ts": 587383,
+      "id": "0x1743def2b50",
+      "tid": 16852,
+      "ts": 624271,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 587384,
+      "tid": 16852,
+      "ts": 624271,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 587410,
+      "tid": 16852,
+      "ts": 624298,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 624298,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 624299,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 587410,
+      "tid": 16852,
+      "ts": 624300,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9fc910",
-      "tid": 43696,
-      "ts": 587420,
+      "id": "0x1743de44a98",
+      "tid": 16852,
+      "ts": 624309,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 16777216
         }
       }
     },
@@ -2659,21 +3100,21 @@
       "name": "SegmentedMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 587422,
+      "tid": 16852,
+      "ts": 624311,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f751e50",
-      "tid": 43696,
-      "ts": 587429,
+      "id": "0x1743def3600",
+      "tid": 16852,
+      "ts": 624317,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 3
+          "UnusedPoolSize": 67108864
         }
       }
     },
@@ -2681,62 +3122,94 @@
       "name": "SegmentedMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 587432,
+      "tid": 16852,
+      "ts": 624318,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 587432,
+      "tid": 16852,
+      "ts": 624319,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 624319,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 624322,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f8184c0",
-      "tid": 43696,
-      "ts": 587435,
+      "id": "0x1743def2ec0",
+      "tid": 16852,
+      "ts": 624325,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 587435,
+      "tid": 16852,
+      "ts": 624325,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 587462,
+      "tid": 16852,
+      "ts": 624351,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 624352,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 624352,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 587462,
+      "tid": 16852,
+      "ts": 624353,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9fdf90",
-      "tid": 43696,
-      "ts": 587474,
+      "id": "0x1743de43998",
+      "tid": 16852,
+      "ts": 624362,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 16777216
         }
       }
     },
@@ -2744,21 +3217,21 @@
       "name": "SegmentedMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 587476,
+      "tid": 16852,
+      "ts": 624364,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f836b90",
-      "tid": 43696,
-      "ts": 587484,
+      "id": "0x1743def44a0",
+      "tid": 16852,
+      "ts": 624372,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 16777216
         }
       }
     },
@@ -2766,62 +3239,94 @@
       "name": "SegmentedMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 587486,
+      "tid": 16852,
+      "ts": 624374,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 587486,
+      "tid": 16852,
+      "ts": 624374,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 624374,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 624378,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f8186d0",
-      "tid": 43696,
-      "ts": 587489,
+      "id": "0x1743def16b0",
+      "tid": 16852,
+      "ts": 624380,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 587489,
+      "tid": 16852,
+      "ts": 624381,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 587515,
+      "tid": 16852,
+      "ts": 624407,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 624408,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 624408,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 587516,
+      "tid": 16852,
+      "ts": 624409,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9fc820",
-      "tid": 43696,
-      "ts": 587526,
+      "id": "0x1743de44798",
+      "tid": 16852,
+      "ts": 624418,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 16777216
         }
       }
     },
@@ -2829,21 +3334,21 @@
       "name": "SegmentedMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 587528,
+      "tid": 16852,
+      "ts": 624420,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f837810",
-      "tid": 43696,
-      "ts": 587535,
+      "id": "0x1743de4dcf0",
+      "tid": 16852,
+      "ts": 624426,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 16777216
         }
       }
     },
@@ -2851,258 +3356,211 @@
       "name": "SegmentedMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 587536,
+      "tid": 16852,
+      "ts": 624428,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 587537,
+      "tid": 16852,
+      "ts": 624428,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 624428,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 624431,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f818e60",
-      "tid": 43696,
-      "ts": 587539,
+      "id": "0x1743def25d0",
+      "tid": 16852,
+      "ts": 624434,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 587539,
+      "tid": 16852,
+      "ts": 624434,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f74ae80",
-      "tid": 43696,
-      "ts": 587550,
+      "id": "0x1743c0ee550",
+      "tid": 16852,
+      "ts": 624444,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90d9fcfa0",
-      "tid": 43696,
-      "ts": 587551,
+      "id": "0x1743de45398",
+      "tid": 16852,
+      "ts": 624450,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90d9fcdc0",
-      "tid": 43696,
-      "ts": 587554,
+      "id": "0x1743de44298",
+      "tid": 16852,
+      "ts": 624454,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90d9fd270",
-      "tid": 43696,
-      "ts": 587556,
+      "id": "0x1743de44398",
+      "tid": 16852,
+      "ts": 624457,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90d9fc640",
-      "tid": 43696,
-      "ts": 587558,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90d9fd090",
-      "tid": 43696,
-      "ts": 587559,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90d9fc550",
-      "tid": 43696,
-      "ts": 587560,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90d9fccd0",
-      "tid": 43696,
-      "ts": 587562,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90d9fcaf0",
-      "tid": 43696,
-      "ts": 587563,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90d9fd450",
-      "tid": 43696,
-      "ts": 587565,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90d9fe350",
-      "tid": 43696,
-      "ts": 587568,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90d9fdea0",
-      "tid": 43696,
-      "ts": 587570,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90d9fdf90",
-      "tid": 43696,
-      "ts": 587572,
+      "id": "0x1743de43998",
+      "tid": 16852,
+      "ts": 624460,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90d997390",
-      "tid": 43696,
-      "ts": 587574,
+      "id": "0x1743def4b60",
+      "tid": 16852,
+      "ts": 624462,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f836b90",
-      "tid": 43696,
-      "ts": 587874,
+      "id": "0x1743def44a0",
+      "tid": 16852,
+      "ts": 624653,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90d9fc820",
-      "tid": 43696,
-      "ts": 587877,
+      "id": "0x1743de44798",
+      "tid": 16852,
+      "ts": 624657,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90d9e7ae0",
-      "tid": 43696,
-      "ts": 587879,
+      "id": "0x1743def3b10",
+      "tid": 16852,
+      "ts": 624659,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f837810",
-      "tid": 43696,
-      "ts": 588134,
+      "id": "0x1743de4dcf0",
+      "tid": 16852,
+      "ts": 624796,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90d9fc910",
-      "tid": 43696,
-      "ts": 588137,
+      "id": "0x1743de44a98",
+      "tid": 16852,
+      "ts": 624800,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90d996c40",
-      "tid": 43696,
-      "ts": 588139,
+      "id": "0x1743def4fe0",
+      "tid": 16852,
+      "ts": 624802,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90d9e8590",
-      "tid": 43696,
-      "ts": 588366,
+      "id": "0x1743def5070",
+      "tid": 16852,
+      "ts": 624933,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90d997f60",
-      "tid": 43696,
-      "ts": 588581,
+      "id": "0x1743def32a0",
+      "tid": 16852,
+      "ts": 625120,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x1743def4ec0",
+      "tid": 16852,
+      "ts": 625309,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f751e50",
-      "tid": 43696,
-      "ts": 588805,
+      "id": "0x1743def3600",
+      "tid": 16852,
+      "ts": 625488,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90d9fe080",
-      "tid": 43696,
-      "ts": 588808,
+      "id": "0x1743de44b98",
+      "tid": 16852,
+      "ts": 625492,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90d9fca00",
-      "tid": 43696,
-      "ts": 588810,
+      "id": "0x1743de43698",
+      "tid": 16852,
+      "ts": 625495,
       "pid": "GPGMM"
     }
   ]

--- a/src/tests/capture_replay_tests/traces/webnn_resnet50v2_nchw.json
+++ b/src/tests/capture_replay_tests/traces/webnn_resnet50v2_nchw.json
@@ -5,8 +5,8 @@
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 739197,
+      "tid": 16852,
+      "ts": 777428,
       "pid": "GPGMM",
       "args": {
         "Flags": 0,
@@ -26,161 +26,89 @@
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f77e040",
-      "tid": 43696,
-      "ts": 739201,
+      "id": "0x1743e0fcd50",
+      "tid": 16852,
+      "ts": 777432,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f892290",
-      "tid": 43696,
-      "ts": 739211,
+      "id": "0x1743de43d98",
+      "tid": 16852,
+      "ts": 777454,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f8910c0",
-      "tid": 43696,
-      "ts": 739227,
+      "id": "0x1743de44b98",
+      "tid": 16852,
+      "ts": 777480,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f892380",
-      "tid": 43696,
-      "ts": 739231,
+      "id": "0x1743de44e98",
+      "tid": 16852,
+      "ts": 777485,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f892470",
-      "tid": 43696,
-      "ts": 739236,
+      "id": "0x1743de43698",
+      "tid": 16852,
+      "ts": 777492,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f892740",
-      "tid": 43696,
-      "ts": 739241,
+      "id": "0x1743de44398",
+      "tid": 16852,
+      "ts": 777518,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f891660",
-      "tid": 43696,
-      "ts": 739248,
+      "id": "0x1743de43598",
+      "tid": 16852,
+      "ts": 777523,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f891750",
-      "tid": 43696,
-      "ts": 739251,
+      "id": "0x1743de44c98",
+      "tid": 16852,
+      "ts": 777528,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f892560",
-      "tid": 43696,
-      "ts": 739256,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f890940",
-      "tid": 43696,
-      "ts": 739259,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f891ed0",
-      "tid": 43696,
-      "ts": 739262,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f890df0",
-      "tid": 43696,
-      "ts": 739266,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f890b20",
-      "tid": 43696,
-      "ts": 739269,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f890c10",
-      "tid": 43696,
-      "ts": 739272,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f890d00",
-      "tid": 43696,
-      "ts": 739286,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f891de0",
-      "tid": 43696,
-      "ts": 739288,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x1a90f890ee0",
-      "tid": 43696,
-      "ts": 739294,
+      "id": "0x1743de43998",
+      "tid": 16852,
+      "ts": 777535,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 739375,
+      "tid": 16852,
+      "ts": 777615,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -210,50 +138,50 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 739377,
+      "tid": 16852,
+      "ts": 777617,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 739378,
+      "tid": 16852,
+      "ts": 777619,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 739379,
+      "tid": 16852,
+      "ts": 777624,
       "pid": "GPGMM"
     },
     {
       "name": "SegmentedMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 739380,
+      "tid": 16852,
+      "ts": 777627,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f752cd0",
-      "tid": 43696,
-      "ts": 739381,
+      "id": "0x1743de4edf0",
+      "tid": 16852,
+      "ts": 777627,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f752cd0",
-      "tid": 43696,
-      "ts": 739391,
+      "id": "0x1743de4edf0",
+      "tid": 16852,
+      "ts": 777634,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -265,26 +193,26 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 739393,
+      "tid": 16852,
+      "ts": 777639,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d95d770",
-      "tid": 43696,
-      "ts": 784019,
+      "id": "0x1743c127180",
+      "tid": 16852,
+      "ts": 826219,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d95d770",
-      "tid": 43696,
-      "ts": 784057,
+      "id": "0x1743c127180",
+      "tid": 16852,
+      "ts": 826284,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -299,9 +227,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d95d770",
-      "tid": 43696,
-      "ts": 784081,
+      "id": "0x1743c127180",
+      "tid": 16852,
+      "ts": 826308,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -316,25 +244,25 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 784083,
+      "tid": 16852,
+      "ts": 826310,
       "pid": "GPGMM"
     },
     {
       "name": "SegmentedMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 784086,
+      "tid": 16852,
+      "ts": 826313,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d95d770",
-      "tid": 43696,
-      "ts": 784105,
+      "id": "0x1743c127180",
+      "tid": 16852,
+      "ts": 826329,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -343,7 +271,7 @@
           "MemorySegmentGroup": 1,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x1a90f752cd0"
+            "id_ref": "0x1743de4edf0"
           }
         }
       }
@@ -352,9 +280,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d95d770",
-      "tid": 43696,
-      "ts": 784172,
+      "id": "0x1743c127180",
+      "tid": 16852,
+      "ts": 826394,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -363,7 +291,7 @@
           "MemorySegmentGroup": 1,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x1a90f752cd0"
+            "id_ref": "0x1743de4edf0"
           }
         }
       }
@@ -372,18 +300,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f818080",
-      "tid": 43696,
-      "ts": 784181,
+      "id": "0x1743defe890",
+      "tid": 16852,
+      "ts": 826397,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f818080",
-      "tid": 43696,
-      "ts": 784198,
+      "id": "0x1743defe890",
+      "tid": 16852,
+      "ts": 826412,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -392,7 +320,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x1a90d95d770"
+            "id_ref": "0x1743c127180"
           }
         }
       }
@@ -401,16 +329,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 784201,
+      "tid": 16852,
+      "ts": 826414,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 784301,
+      "tid": 16852,
+      "ts": 826523,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -440,50 +368,50 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 784303,
+      "tid": 16852,
+      "ts": 826525,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 784305,
+      "tid": 16852,
+      "ts": 826527,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 784305,
+      "tid": 16852,
+      "ts": 826532,
       "pid": "GPGMM"
     },
     {
       "name": "SegmentedMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 784307,
+      "tid": 16852,
+      "ts": 826535,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f751050",
-      "tid": 43696,
-      "ts": 784308,
+      "id": "0x1743df00250",
+      "tid": 16852,
+      "ts": 826542,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f751050",
-      "tid": 43696,
-      "ts": 784318,
+      "id": "0x1743df00250",
+      "tid": 16852,
+      "ts": 826549,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -495,26 +423,26 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 784320,
+      "tid": 16852,
+      "ts": 826551,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d95e3d0",
-      "tid": 43696,
-      "ts": 795427,
+      "id": "0x1743deff710",
+      "tid": 16852,
+      "ts": 837589,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d95e3d0",
-      "tid": 43696,
-      "ts": 795470,
+      "id": "0x1743deff710",
+      "tid": 16852,
+      "ts": 837651,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -529,9 +457,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d95e3d0",
-      "tid": 43696,
-      "ts": 795491,
+      "id": "0x1743deff710",
+      "tid": 16852,
+      "ts": 837682,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -546,25 +474,25 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 795493,
+      "tid": 16852,
+      "ts": 837684,
       "pid": "GPGMM"
     },
     {
       "name": "SegmentedMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 795495,
+      "tid": 16852,
+      "ts": 837686,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d95e3d0",
-      "tid": 43696,
-      "ts": 795513,
+      "id": "0x1743deff710",
+      "tid": 16852,
+      "ts": 837701,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -573,7 +501,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x1a90f751050"
+            "id_ref": "0x1743df00250"
           }
         }
       }
@@ -582,9 +510,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d95e3d0",
-      "tid": 43696,
-      "ts": 795555,
+      "id": "0x1743deff710",
+      "tid": 16852,
+      "ts": 837772,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -593,7 +521,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x1a90f751050"
+            "id_ref": "0x1743df00250"
           }
         }
       }
@@ -602,18 +530,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f818340",
-      "tid": 43696,
-      "ts": 795558,
+      "id": "0x1743defeec0",
+      "tid": 16852,
+      "ts": 837774,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f818340",
-      "tid": 43696,
-      "ts": 795574,
+      "id": "0x1743defeec0",
+      "tid": 16852,
+      "ts": 837802,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -622,7 +550,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x1a90d95e3d0"
+            "id_ref": "0x1743deff710"
           }
         }
       }
@@ -631,16 +559,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 795576,
+      "tid": 16852,
+      "ts": 837804,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 795671,
+      "tid": 16852,
+      "ts": 838007,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -670,25 +598,41 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 795672,
+      "tid": 16852,
+      "ts": 838009,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 838011,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 838017,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 795673,
+      "tid": 16852,
+      "ts": 838025,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f890df0",
-      "tid": 43696,
-      "ts": 795692,
+      "id": "0x1743de43598",
+      "tid": 16852,
+      "ts": 838040,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -700,26 +644,26 @@
       "name": "SegmentedMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 795694,
+      "tid": 16852,
+      "ts": 838042,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f837b10",
-      "tid": 43696,
-      "ts": 795695,
+      "id": "0x1743df013c0",
+      "tid": 16852,
+      "ts": 838043,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f837b10",
-      "tid": 43696,
-      "ts": 795703,
+      "id": "0x1743df013c0",
+      "tid": 16852,
+      "ts": 838061,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -731,26 +675,26 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 795704,
+      "tid": 16852,
+      "ts": 838063,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d99f1f0",
-      "tid": 43696,
-      "ts": 798275,
+      "id": "0x1743df01450",
+      "tid": 16852,
+      "ts": 839780,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d99f1f0",
-      "tid": 43696,
-      "ts": 798297,
+      "id": "0x1743df01450",
+      "tid": 16852,
+      "ts": 839803,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -765,9 +709,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d99f1f0",
-      "tid": 43696,
-      "ts": 798314,
+      "id": "0x1743df01450",
+      "tid": 16852,
+      "ts": 839819,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -782,29 +726,29 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 798324,
+      "tid": 16852,
+      "ts": 839821,
       "pid": "GPGMM"
     },
     {
       "name": "SegmentedMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 798326,
+      "tid": 16852,
+      "ts": 839823,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f890df0",
-      "tid": 43696,
-      "ts": 798333,
+      "id": "0x1743de43598",
+      "tid": 16852,
+      "ts": 839830,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 16777216
         }
       }
     },
@@ -812,26 +756,42 @@
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 798336,
+      "tid": 16852,
+      "ts": 839832,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 839834,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 839835,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d99f1f0",
-      "tid": 43696,
-      "ts": 798352,
+      "id": "0x1743df01450",
+      "tid": 16852,
+      "ts": 839857,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 16777216,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 1,
+          "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x1a90f837b10"
+            "id_ref": "0x1743df013c0"
           }
         }
       }
@@ -840,18 +800,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d99f1f0",
-      "tid": 43696,
-      "ts": 798388,
+      "id": "0x1743df01450",
+      "tid": 16852,
+      "ts": 839897,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 16777216,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 1,
+          "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x1a90f837b10"
+            "id_ref": "0x1743df013c0"
           }
         }
       }
@@ -860,18 +820,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f8170b0",
-      "tid": 43696,
-      "ts": 798391,
+      "id": "0x1743defdfa0",
+      "tid": 16852,
+      "ts": 839899,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f8170b0",
-      "tid": 43696,
-      "ts": 798407,
+      "id": "0x1743defdfa0",
+      "tid": 16852,
+      "ts": 839913,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -880,7 +840,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90d99f1f0"
+            "id_ref": "0x1743df01450"
           }
         }
       }
@@ -889,16 +849,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 798409,
+      "tid": 16852,
+      "ts": 839915,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 798511,
+      "tid": 16852,
+      "ts": 840018,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -928,41 +888,41 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 798513,
+      "tid": 16852,
+      "ts": 840020,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 798514,
+      "tid": 16852,
+      "ts": 840021,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 798514,
+      "tid": 16852,
+      "ts": 840026,
       "pid": "GPGMM"
     },
     {
       "name": "SegmentedMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 798515,
+      "tid": 16852,
+      "ts": 840028,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f751050",
-      "tid": 43696,
-      "ts": 798523,
+      "id": "0x1743df00250",
+      "tid": 16852,
+      "ts": 840034,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -974,26 +934,26 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 798525,
+      "tid": 16852,
+      "ts": 840036,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d99ddb0",
-      "tid": 43696,
-      "ts": 809428,
+      "id": "0x1743deffe60",
+      "tid": 16852,
+      "ts": 850976,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d99ddb0",
-      "tid": 43696,
-      "ts": 809459,
+      "id": "0x1743deffe60",
+      "tid": 16852,
+      "ts": 851024,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1008,9 +968,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d99ddb0",
-      "tid": 43696,
-      "ts": 809480,
+      "id": "0x1743deffe60",
+      "tid": 16852,
+      "ts": 851041,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1025,25 +985,25 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 809482,
+      "tid": 16852,
+      "ts": 851042,
       "pid": "GPGMM"
     },
     {
       "name": "SegmentedMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 809485,
+      "tid": 16852,
+      "ts": 851044,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d99ddb0",
-      "tid": 43696,
-      "ts": 809502,
+      "id": "0x1743deffe60",
+      "tid": 16852,
+      "ts": 851069,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1052,7 +1012,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x1a90f751050"
+            "id_ref": "0x1743df00250"
           }
         }
       }
@@ -1061,9 +1021,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d99ddb0",
-      "tid": 43696,
-      "ts": 809548,
+      "id": "0x1743deffe60",
+      "tid": 16852,
+      "ts": 851147,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1072,7 +1032,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x1a90f751050"
+            "id_ref": "0x1743df00250"
           }
         }
       }
@@ -1081,18 +1041,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f817fd0",
-      "tid": 43696,
-      "ts": 809550,
+      "id": "0x1743deff230",
+      "tid": 16852,
+      "ts": 851149,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f817fd0",
-      "tid": 43696,
-      "ts": 809567,
+      "id": "0x1743deff230",
+      "tid": 16852,
+      "ts": 851178,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1101,7 +1061,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x1a90d99ddb0"
+            "id_ref": "0x1743deffe60"
           }
         }
       }
@@ -1110,37 +1070,37 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 809569,
+      "tid": 16852,
+      "ts": 851182,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 809633,
+      "tid": 16852,
+      "ts": 851264,
       "pid": "GPGMM"
     },
     {
       "name": "SegmentedMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 809633,
+      "tid": 16852,
+      "ts": 851264,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f752cd0",
-      "tid": 43696,
-      "ts": 809648,
+      "id": "0x1743de4edf0",
+      "tid": 16852,
+      "ts": 851276,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 134217728
         }
       }
     },
@@ -1148,33 +1108,33 @@
       "name": "SegmentedMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 809649,
+      "tid": 16852,
+      "ts": 851277,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f818080",
-      "tid": 43696,
-      "ts": 809656,
+      "id": "0x1743defe890",
+      "tid": 16852,
+      "ts": 851284,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 809656,
+      "tid": 16852,
+      "ts": 851284,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 809708,
+      "tid": 16852,
+      "ts": 851330,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1204,25 +1164,41 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 809710,
+      "tid": 16852,
+      "ts": 851332,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 851333,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 851338,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 809711,
+      "tid": 16852,
+      "ts": 851341,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f890940",
-      "tid": 43696,
-      "ts": 809726,
+      "id": "0x1743de44398",
+      "tid": 16852,
+      "ts": 851353,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1234,26 +1210,26 @@
       "name": "SegmentedMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 809729,
+      "tid": 16852,
+      "ts": 851356,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d9e9ee0",
-      "tid": 43696,
-      "ts": 809730,
+      "id": "0x1743deffef0",
+      "tid": 16852,
+      "ts": 851356,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e9ee0",
-      "tid": 43696,
-      "ts": 809737,
+      "id": "0x1743deffef0",
+      "tid": 16852,
+      "ts": 851361,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1265,26 +1241,26 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 809740,
+      "tid": 16852,
+      "ts": 851363,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d99de40",
-      "tid": 43696,
-      "ts": 816630,
+      "id": "0x1743deffd40",
+      "tid": 16852,
+      "ts": 859673,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d99de40",
-      "tid": 43696,
-      "ts": 816652,
+      "id": "0x1743deffd40",
+      "tid": 16852,
+      "ts": 859698,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1299,9 +1275,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d99de40",
-      "tid": 43696,
-      "ts": 816670,
+      "id": "0x1743deffd40",
+      "tid": 16852,
+      "ts": 859715,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1316,29 +1292,29 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 816672,
+      "tid": 16852,
+      "ts": 859717,
       "pid": "GPGMM"
     },
     {
       "name": "SegmentedMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 816673,
+      "tid": 16852,
+      "ts": 859719,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f890940",
-      "tid": 43696,
-      "ts": 816681,
+      "id": "0x1743de44398",
+      "tid": 16852,
+      "ts": 859726,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 16777216
         }
       }
     },
@@ -1346,26 +1322,42 @@
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 816687,
+      "tid": 16852,
+      "ts": 859729,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 859731,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 859732,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d99de40",
-      "tid": 43696,
-      "ts": 816703,
+      "id": "0x1743deffd40",
+      "tid": 16852,
+      "ts": 859747,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 16777216,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 1,
+          "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x1a90d9e9ee0"
+            "id_ref": "0x1743deffef0"
           }
         }
       }
@@ -1374,18 +1366,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d99de40",
-      "tid": 43696,
-      "ts": 816737,
+      "id": "0x1743deffd40",
+      "tid": 16852,
+      "ts": 859787,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 16777216,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 1,
+          "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x1a90d9e9ee0"
+            "id_ref": "0x1743deffef0"
           }
         }
       }
@@ -1394,18 +1386,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f818130",
-      "tid": 43696,
-      "ts": 816740,
+      "id": "0x1743deff440",
+      "tid": 16852,
+      "ts": 859789,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f818130",
-      "tid": 43696,
-      "ts": 816756,
+      "id": "0x1743deff440",
+      "tid": 16852,
+      "ts": 859803,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1414,7 +1406,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90d99de40"
+            "id_ref": "0x1743deffd40"
           }
         }
       }
@@ -1423,37 +1415,37 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 816758,
+      "tid": 16852,
+      "ts": 859805,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 816828,
+      "tid": 16852,
+      "ts": 859881,
       "pid": "GPGMM"
     },
     {
       "name": "SegmentedMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 816829,
+      "tid": 16852,
+      "ts": 859882,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f751050",
-      "tid": 43696,
-      "ts": 816840,
+      "id": "0x1743df00250",
+      "tid": 16852,
+      "ts": 859893,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 134217728
         }
       }
     },
@@ -1461,33 +1453,33 @@
       "name": "SegmentedMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 816842,
+      "tid": 16852,
+      "ts": 859897,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f818340",
-      "tid": 43696,
-      "ts": 816846,
+      "id": "0x1743defeec0",
+      "tid": 16852,
+      "ts": 859903,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 816847,
+      "tid": 16852,
+      "ts": 859904,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 816897,
+      "tid": 16852,
+      "ts": 859950,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1517,43 +1509,148 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 816898,
+      "tid": 16852,
+      "ts": 859951,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 859953,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 859956,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 816899,
+      "tid": 16852,
+      "ts": 859960,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f890df0",
-      "tid": 43696,
-      "ts": 816907,
+      "id": "0x1743de43598",
+      "tid": 16852,
+      "ts": 859969,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 16777216
         }
       }
+    },
+    {
+      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 859991,
+      "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f890df0",
-      "tid": 43696,
-      "ts": 816915,
+      "id": "0x1743df013c0",
+      "tid": 16852,
+      "ts": 859997,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResourceHeap",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 859998,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x1743df00880",
+      "tid": 16852,
+      "ts": 862152,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743df00880",
+      "tid": 16852,
+      "ts": 862172,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 16777216,
+          "IsResident": 0,
+          "MemorySegmentGroup": 0,
+          "SubAllocatedRefs": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743df00880",
+      "tid": 16852,
+      "ts": 862187,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 16777216,
+          "IsResident": 1,
+          "MemorySegmentGroup": 0,
+          "SubAllocatedRefs": 0
+        }
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResourceHeap",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 862189,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 862191,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x1743de43598",
+      "tid": 16852,
+      "ts": 862197,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "UnusedPoolSize": 33554432
         }
       }
     },
@@ -1561,17 +1658,33 @@
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 816918,
+      "tid": 16852,
+      "ts": 862200,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 862201,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 862202,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d99f1f0",
-      "tid": 43696,
-      "ts": 816953,
+      "id": "0x1743df00880",
+      "tid": 16852,
+      "ts": 862216,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1580,7 +1693,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x1a90f837b10"
+            "id_ref": "0x1743df013c0"
           }
         }
       }
@@ -1589,9 +1702,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d99f1f0",
-      "tid": 43696,
-      "ts": 816985,
+      "id": "0x1743df00880",
+      "tid": 16852,
+      "ts": 862247,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1600,7 +1713,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x1a90f837b10"
+            "id_ref": "0x1743df013c0"
           }
         }
       }
@@ -1609,27 +1722,27 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f8181e0",
-      "tid": 43696,
-      "ts": 816987,
+      "id": "0x1743defe260",
+      "tid": 16852,
+      "ts": 862249,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f8181e0",
-      "tid": 43696,
-      "ts": 817002,
+      "id": "0x1743defe260",
+      "tid": 16852,
+      "ts": 862264,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 1048576,
-          "HeapOffset": 1048576,
+          "HeapOffset": 0,
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90d99f1f0"
+            "id_ref": "0x1743df00880"
           }
         }
       }
@@ -1638,16 +1751,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 817005,
+      "tid": 16852,
+      "ts": 862266,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 817074,
+      "tid": 16852,
+      "ts": 862337,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1677,25 +1790,41 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 817075,
+      "tid": 16852,
+      "ts": 862338,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 862340,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 862346,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 817076,
+      "tid": 16852,
+      "ts": 862349,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f891750",
-      "tid": 43696,
-      "ts": 817093,
+      "id": "0x1743de43698",
+      "tid": 16852,
+      "ts": 862360,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1707,26 +1836,26 @@
       "name": "SegmentedMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 817095,
+      "tid": 16852,
+      "ts": 862363,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d99fd20",
-      "tid": 43696,
-      "ts": 817096,
+      "id": "0x1743df00eb0",
+      "tid": 16852,
+      "ts": 862363,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d99fd20",
-      "tid": 43696,
-      "ts": 817103,
+      "id": "0x1743df00eb0",
+      "tid": 16852,
+      "ts": 862369,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1738,26 +1867,26 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 817105,
+      "tid": 16852,
+      "ts": 862370,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d99e080",
-      "tid": 43696,
-      "ts": 818259,
+      "id": "0x1743defff80",
+      "tid": 16852,
+      "ts": 863431,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d99e080",
-      "tid": 43696,
-      "ts": 818311,
+      "id": "0x1743defff80",
+      "tid": 16852,
+      "ts": 863466,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1772,9 +1901,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d99e080",
-      "tid": 43696,
-      "ts": 818328,
+      "id": "0x1743defff80",
+      "tid": 16852,
+      "ts": 863481,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1789,29 +1918,29 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 818330,
+      "tid": 16852,
+      "ts": 863483,
       "pid": "GPGMM"
     },
     {
       "name": "SegmentedMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 818331,
+      "tid": 16852,
+      "ts": 863484,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f891750",
-      "tid": 43696,
-      "ts": 818338,
+      "id": "0x1743de43698",
+      "tid": 16852,
+      "ts": 863490,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 16777216
         }
       }
     },
@@ -1819,26 +1948,42 @@
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 818341,
+      "tid": 16852,
+      "ts": 863493,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 863494,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 863495,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d99e080",
-      "tid": 43696,
-      "ts": 818356,
+      "id": "0x1743defff80",
+      "tid": 16852,
+      "ts": 863509,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 16777216,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 1,
+          "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x1a90d99fd20"
+            "id_ref": "0x1743df00eb0"
           }
         }
       }
@@ -1847,18 +1992,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d99e080",
-      "tid": 43696,
-      "ts": 818422,
+      "id": "0x1743defff80",
+      "tid": 16852,
+      "ts": 863541,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 16777216,
           "IsResident": 1,
           "MemorySegmentGroup": 1,
-          "SubAllocatedRefs": 1,
+          "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x1a90d99fd20"
+            "id_ref": "0x1743df00eb0"
           }
         }
       }
@@ -1867,18 +2012,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f816920",
-      "tid": 43696,
-      "ts": 818429,
+      "id": "0x1743defde40",
+      "tid": 16852,
+      "ts": 863544,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f816920",
-      "tid": 43696,
-      "ts": 818482,
+      "id": "0x1743defde40",
+      "tid": 16852,
+      "ts": 863558,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1887,7 +2032,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90d99e080"
+            "id_ref": "0x1743defff80"
           }
         }
       }
@@ -1896,16 +2041,16 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 818489,
+      "tid": 16852,
+      "ts": 863560,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 818663,
+      "tid": 16852,
+      "ts": 863657,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1935,61 +2080,49 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 818665,
+      "tid": 16852,
+      "ts": 863659,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabCacheAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 818666,
+      "tid": 16852,
+      "ts": 863660,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f890df0",
-      "tid": 43696,
-      "ts": 818674,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 863661,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f890df0",
-      "tid": 43696,
-      "ts": 818685,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 818687,
+      "tid": 16852,
+      "ts": 863663,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 863664,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d99f1f0",
-      "tid": 43696,
-      "ts": 818707,
+      "id": "0x1743df01450",
+      "tid": 16852,
+      "ts": 863678,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1998,7 +2131,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 3,
           "MemoryPool": {
-            "id_ref": "0x1a90f837b10"
+            "id_ref": "0x1743df013c0"
           }
         }
       }
@@ -2007,9 +2140,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d99f1f0",
-      "tid": 43696,
-      "ts": 818742,
+      "id": "0x1743df01450",
+      "tid": 16852,
+      "ts": 863705,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2018,7 +2151,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 3,
           "MemoryPool": {
-            "id_ref": "0x1a90f837b10"
+            "id_ref": "0x1743df013c0"
           }
         }
       }
@@ -2027,18 +2160,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f818340",
-      "tid": 43696,
-      "ts": 818745,
+      "id": "0x1743defe1b0",
+      "tid": 16852,
+      "ts": 863707,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f818340",
-      "tid": 43696,
-      "ts": 818764,
+      "id": "0x1743defe1b0",
+      "tid": 16852,
+      "ts": 863720,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2047,7 +2180,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90d99f1f0"
+            "id_ref": "0x1743df01450"
           }
         }
       }
@@ -2056,85 +2189,73 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 818766,
+      "tid": 16852,
+      "ts": 863722,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 818816,
+      "tid": 16852,
+      "ts": 863769,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabCacheAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 818816,
+      "tid": 16852,
+      "ts": 863769,
       "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f890df0",
-      "tid": 43696,
-      "ts": 818826,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
+      "ph": "B",
+      "tid": 16852,
+      "ts": 863770,
+      "pid": "GPGMM"
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x1a90f890df0",
-      "tid": 43696,
-      "ts": 818836,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "UnusedPoolSize": 1
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "SlabMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 818838,
+      "tid": 16852,
+      "ts": 863771,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 863772,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f8170b0",
-      "tid": 43696,
-      "ts": 818842,
+      "id": "0x1743defdfa0",
+      "tid": 16852,
+      "ts": 863775,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 818842,
+      "tid": 16852,
+      "ts": 863776,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 43696,
-      "ts": 818898,
+      "tid": 16852,
+      "ts": 863819,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -2164,29 +2285,45 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 818900,
+      "tid": 16852,
+      "ts": 863821,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 863822,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 863826,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 818900,
+      "tid": 16852,
+      "ts": 863829,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f890df0",
-      "tid": 43696,
-      "ts": 818911,
+      "id": "0x1743de43598",
+      "tid": 16852,
+      "ts": 863837,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 33554432
         }
       }
     },
@@ -2194,17 +2331,17 @@
       "name": "SegmentedMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 818914,
+      "tid": 16852,
+      "ts": 863839,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f837b10",
-      "tid": 43696,
-      "ts": 818922,
+      "id": "0x1743df013c0",
+      "tid": 16852,
+      "ts": 863845,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2216,26 +2353,26 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 818924,
+      "tid": 16852,
+      "ts": 863847,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90d99ee00",
-      "tid": 43696,
-      "ts": 820532,
+      "id": "0x1743df00910",
+      "tid": 16852,
+      "ts": 865367,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d99ee00",
-      "tid": 43696,
-      "ts": 820552,
+      "id": "0x1743df00910",
+      "tid": 16852,
+      "ts": 865402,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2250,9 +2387,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d99ee00",
-      "tid": 43696,
-      "ts": 820569,
+      "id": "0x1743df00910",
+      "tid": 16852,
+      "ts": 865418,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2267,29 +2404,29 @@
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 820571,
+      "tid": 16852,
+      "ts": 865419,
       "pid": "GPGMM"
     },
     {
       "name": "SegmentedMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 820573,
+      "tid": 16852,
+      "ts": 865421,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f890df0",
-      "tid": 43696,
-      "ts": 820580,
+      "id": "0x1743de43598",
+      "tid": 16852,
+      "ts": 865456,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 2
+          "UnusedPoolSize": 50331648
         }
       }
     },
@@ -2297,26 +2434,42 @@
       "name": "BuddyMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 820582,
+      "tid": 16852,
+      "ts": 865458,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 865460,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 865461,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d99ee00",
-      "tid": 43696,
-      "ts": 820598,
+      "id": "0x1743df00910",
+      "tid": 16852,
+      "ts": 865475,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 16777216,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 1,
+          "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x1a90f837b10"
+            "id_ref": "0x1743df013c0"
           }
         }
       }
@@ -2325,18 +2478,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d99ee00",
-      "tid": 43696,
-      "ts": 820632,
+      "id": "0x1743df00910",
+      "tid": 16852,
+      "ts": 865518,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 16777216,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 1,
+          "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x1a90f837b10"
+            "id_ref": "0x1743df013c0"
           }
         }
       }
@@ -2345,18 +2498,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x1a90f8176e0",
-      "tid": 43696,
-      "ts": 820634,
+      "id": "0x1743defef70",
+      "tid": 16852,
+      "ts": 865520,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f8176e0",
-      "tid": 43696,
-      "ts": 820650,
+      "id": "0x1743defef70",
+      "tid": 16852,
+      "ts": 865534,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2365,7 +2518,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x1a90d99ee00"
+            "id_ref": "0x1743df00910"
           }
         }
       }
@@ -2374,37 +2527,37 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 820652,
+      "tid": 16852,
+      "ts": 865536,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 820717,
+      "tid": 16852,
+      "ts": 865606,
       "pid": "GPGMM"
     },
     {
       "name": "SegmentedMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 820718,
+      "tid": 16852,
+      "ts": 865606,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f751050",
-      "tid": 43696,
-      "ts": 820727,
+      "id": "0x1743df00250",
+      "tid": 16852,
+      "ts": 865614,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 2
+          "UnusedPoolSize": 268435456
         }
       }
     },
@@ -2412,54 +2565,70 @@
       "name": "SegmentedMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 820729,
+      "tid": 16852,
+      "ts": 865616,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f817fd0",
-      "tid": 43696,
-      "ts": 820733,
+      "id": "0x1743deff230",
+      "tid": 16852,
+      "ts": 865620,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 820733,
+      "tid": 16852,
+      "ts": 865621,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 820760,
+      "tid": 16852,
+      "ts": 865648,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 865648,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 865649,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 820760,
+      "tid": 16852,
+      "ts": 865650,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f890df0",
-      "tid": 43696,
-      "ts": 820768,
+      "id": "0x1743de43598",
+      "tid": 16852,
+      "ts": 865658,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 2
+          "UnusedPoolSize": 50331648
         }
       }
     },
@@ -2467,21 +2636,21 @@
       "name": "SegmentedMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 820770,
+      "tid": 16852,
+      "ts": 865660,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f837b10",
-      "tid": 43696,
-      "ts": 820781,
+      "id": "0x1743df013c0",
+      "tid": 16852,
+      "ts": 865668,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 16777216
         }
       }
     },
@@ -2489,131 +2658,211 @@
       "name": "SegmentedMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 820783,
+      "tid": 16852,
+      "ts": 865669,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 820783,
+      "tid": 16852,
+      "ts": 865670,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 865670,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 865674,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f8176e0",
-      "tid": 43696,
-      "ts": 820786,
+      "id": "0x1743defef70",
+      "tid": 16852,
+      "ts": 865677,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 820787,
+      "tid": 16852,
+      "ts": 865677,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 820807,
+      "tid": 16852,
+      "ts": 865698,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 865699,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 865700,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 820807,
+      "tid": 16852,
+      "ts": 865700,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f890df0",
-      "tid": 43696,
-      "ts": 820816,
+      "id": "0x1743de43598",
+      "tid": 16852,
+      "ts": 865707,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 33554432
         }
       }
+    },
+    {
+      "name": "SegmentedMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 865709,
+      "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f890df0",
-      "tid": 43696,
-      "ts": 820824,
+      "id": "0x1743df013c0",
+      "tid": 16852,
+      "ts": 865715,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 33554432
         }
       }
+    },
+    {
+      "name": "SegmentedMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 865716,
+      "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 820826,
+      "tid": 16852,
+      "ts": 865717,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 865717,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 865720,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f818340",
-      "tid": 43696,
-      "ts": 820828,
+      "id": "0x1743defe1b0",
+      "tid": 16852,
+      "ts": 865723,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 820829,
+      "tid": 16852,
+      "ts": 865723,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 820855,
+      "tid": 16852,
+      "ts": 865749,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 865750,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 865750,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 820856,
+      "tid": 16852,
+      "ts": 865751,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f890df0",
-      "tid": 43696,
-      "ts": 820867,
+      "id": "0x1743de43598",
+      "tid": 16852,
+      "ts": 865761,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 16777216
         }
       }
     },
@@ -2621,21 +2870,21 @@
       "name": "SegmentedMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 820869,
+      "tid": 16852,
+      "ts": 865763,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f837b10",
-      "tid": 43696,
-      "ts": 820875,
+      "id": "0x1743df013c0",
+      "tid": 16852,
+      "ts": 865768,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 2
+          "UnusedPoolSize": 50331648
         }
       }
     },
@@ -2643,62 +2892,94 @@
       "name": "SegmentedMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 820877,
+      "tid": 16852,
+      "ts": 865770,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 820878,
+      "tid": 16852,
+      "ts": 865770,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 865770,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 865773,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f8181e0",
-      "tid": 43696,
-      "ts": 820880,
+      "id": "0x1743defe260",
+      "tid": 16852,
+      "ts": 865776,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 820880,
+      "tid": 16852,
+      "ts": 865776,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 820907,
+      "tid": 16852,
+      "ts": 865803,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 865840,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 865841,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 820907,
+      "tid": 16852,
+      "ts": 865842,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f891750",
-      "tid": 43696,
-      "ts": 820919,
+      "id": "0x1743de43698",
+      "tid": 16852,
+      "ts": 865852,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 16777216
         }
       }
     },
@@ -2706,21 +2987,21 @@
       "name": "SegmentedMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 820921,
+      "tid": 16852,
+      "ts": 865854,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d99fd20",
-      "tid": 43696,
-      "ts": 820931,
+      "id": "0x1743df00eb0",
+      "tid": 16852,
+      "ts": 865861,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 16777216
         }
       }
     },
@@ -2728,62 +3009,94 @@
       "name": "SegmentedMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 820933,
+      "tid": 16852,
+      "ts": 865863,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 820933,
+      "tid": 16852,
+      "ts": 865863,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 865864,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 865867,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f816920",
-      "tid": 43696,
-      "ts": 820936,
+      "id": "0x1743defde40",
+      "tid": 16852,
+      "ts": 865870,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 820937,
+      "tid": 16852,
+      "ts": 865871,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 820963,
+      "tid": 16852,
+      "ts": 865898,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 865898,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "B",
+      "tid": 16852,
+      "ts": 865899,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 820964,
+      "tid": 16852,
+      "ts": 865900,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90f890940",
-      "tid": 43696,
-      "ts": 820974,
+      "id": "0x1743de44398",
+      "tid": 16852,
+      "ts": 865910,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 16777216
         }
       }
     },
@@ -2791,21 +3104,21 @@
       "name": "SegmentedMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "B",
-      "tid": 43696,
-      "ts": 820976,
+      "tid": 16852,
+      "ts": 865912,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x1a90d9e9ee0",
-      "tid": 43696,
-      "ts": 820986,
+      "id": "0x1743deffef0",
+      "tid": 16852,
+      "ts": 865919,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "UnusedPoolSize": 1
+          "UnusedPoolSize": 16777216
         }
       }
     },
@@ -2813,294 +3126,247 @@
       "name": "SegmentedMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 820987,
+      "tid": 16852,
+      "ts": 865920,
       "pid": "GPGMM"
     },
     {
       "name": "BuddyMemoryAllocator.DeallocateMemory",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 820988,
+      "tid": 16852,
+      "ts": 865921,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 865921,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "SlabCacheAllocator.DeallocateMemory",
+      "cat": "0",
+      "ph": "E",
+      "tid": 16852,
+      "ts": 865924,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f818130",
-      "tid": 43696,
-      "ts": 820990,
+      "id": "0x1743deff440",
+      "tid": 16852,
+      "ts": 865926,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocation.Release",
       "cat": "0",
       "ph": "E",
-      "tid": 43696,
-      "ts": 820991,
+      "tid": 16852,
+      "ts": 865926,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f77e040",
-      "tid": 43696,
-      "ts": 821003,
+      "id": "0x1743e0fcd50",
+      "tid": 16852,
+      "ts": 865937,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f8910c0",
-      "tid": 43696,
-      "ts": 821005,
+      "id": "0x1743de43d98",
+      "tid": 16852,
+      "ts": 865943,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f892470",
-      "tid": 43696,
-      "ts": 821008,
+      "id": "0x1743de44b98",
+      "tid": 16852,
+      "ts": 865947,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f891660",
-      "tid": 43696,
-      "ts": 821010,
+      "id": "0x1743de44e98",
+      "tid": 16852,
+      "ts": 865950,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f892560",
-      "tid": 43696,
-      "ts": 821011,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f891ed0",
-      "tid": 43696,
-      "ts": 821013,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f890b20",
-      "tid": 43696,
-      "ts": 821014,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f890d00",
-      "tid": 43696,
-      "ts": 821016,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f890ee0",
-      "tid": 43696,
-      "ts": 821017,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f892290",
-      "tid": 43696,
-      "ts": 821019,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f892380",
-      "tid": 43696,
-      "ts": 821022,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f892740",
-      "tid": 43696,
-      "ts": 821024,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f891750",
-      "tid": 43696,
-      "ts": 821027,
+      "id": "0x1743de43698",
+      "tid": 16852,
+      "ts": 865953,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90d99e080",
-      "tid": 43696,
-      "ts": 821029,
+      "id": "0x1743defff80",
+      "tid": 16852,
+      "ts": 865955,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90d99fd20",
-      "tid": 43696,
-      "ts": 821244,
+      "id": "0x1743df00eb0",
+      "tid": 16852,
+      "ts": 866164,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f890940",
-      "tid": 43696,
-      "ts": 821247,
+      "id": "0x1743de44398",
+      "tid": 16852,
+      "ts": 866168,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90d99de40",
-      "tid": 43696,
-      "ts": 821249,
+      "id": "0x1743deffd40",
+      "tid": 16852,
+      "ts": 866170,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90d9e9ee0",
-      "tid": 43696,
-      "ts": 821485,
+      "id": "0x1743deffef0",
+      "tid": 16852,
+      "ts": 866358,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f890df0",
-      "tid": 43696,
-      "ts": 821488,
+      "id": "0x1743de43598",
+      "tid": 16852,
+      "ts": 866362,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90d99f1f0",
-      "tid": 43696,
-      "ts": 821490,
+      "id": "0x1743df00880",
+      "tid": 16852,
+      "ts": 866363,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90d99ee00",
-      "tid": 43696,
-      "ts": 821678,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f837b10",
-      "tid": 43696,
-      "ts": 821859,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f890c10",
-      "tid": 43696,
-      "ts": 821862,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90f891de0",
-      "tid": 43696,
-      "ts": 821864,
+      "id": "0x1743df01450",
+      "tid": 16852,
+      "ts": 866523,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90d95d770",
-      "tid": 43696,
-      "ts": 821871,
+      "id": "0x1743df00910",
+      "tid": 16852,
+      "ts": 866685,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f752cd0",
-      "tid": 43696,
-      "ts": 822095,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90d99ddb0",
-      "tid": 43696,
-      "ts": 822099,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x1a90d95e3d0",
-      "tid": 43696,
-      "ts": 822286,
+      "id": "0x1743df013c0",
+      "tid": 16852,
+      "ts": 866838,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x1a90f751050",
-      "tid": 43696,
-      "ts": 829311,
+      "id": "0x1743de44c98",
+      "tid": 16852,
+      "ts": 866842,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x1743de43998",
+      "tid": 16852,
+      "ts": 866845,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x1743c127180",
+      "tid": 16852,
+      "ts": 866851,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x1743de4edf0",
+      "tid": 16852,
+      "ts": 867039,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x1743deffe60",
+      "tid": 16852,
+      "ts": 867042,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x1743deff710",
+      "tid": 16852,
+      "ts": 867224,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x1743df00250",
+      "tid": 16852,
+      "ts": 872799,
       "pid": "GPGMM"
     }
   ]

--- a/src/tests/unittests/SlabMemoryAllocatorTests.cpp
+++ b/src/tests/unittests/SlabMemoryAllocatorTests.cpp
@@ -169,9 +169,9 @@ TEST(SlabMemoryAllocatorTests, AllocationOverflow) {
 
 // Verify slab will be reused from a pool.
 TEST(SlabMemoryAllocatorTests, ReuseSlabs) {
-    LIFOMemoryPool memoryPool;
-    std::unique_ptr<PooledMemoryAllocator> poolAllocator = std::make_unique<PooledMemoryAllocator>(
-        std::make_unique<DummyMemoryAllocator>(), &memoryPool);
+    LIFOMemoryPool pool(kDefaultSlabSize);
+    std::unique_ptr<PooledMemoryAllocator> poolAllocator =
+        std::make_unique<PooledMemoryAllocator>(std::make_unique<DummyMemoryAllocator>(), &pool);
 
     constexpr uint64_t kBlockSize = 32;
     constexpr uint64_t kMaxSlabSize = 512;
@@ -196,7 +196,7 @@ TEST(SlabMemoryAllocatorTests, ReuseSlabs) {
         allocations.push_back(std::move(allocation));
     }
 
-    ASSERT_EQ(memoryPool.GetPoolSize(), 0u);
+    ASSERT_EQ(pool.GetPoolSize(), 0u);
 
     // Return the allocations to the pool.
     for (auto& allocation : allocations) {
@@ -204,9 +204,9 @@ TEST(SlabMemoryAllocatorTests, ReuseSlabs) {
         allocator.DeallocateMemory(allocation.release());
     }
 
-    ASSERT_EQ(memoryPool.GetPoolSize(), kNumOfSlabs);
+    ASSERT_EQ(pool.GetPoolSize(), kNumOfSlabs);
 
-    memoryPool.ReleasePool();
+    pool.ReleasePool();
 }
 
 TEST(SlabMemoryAllocatorTests, MultipleSlabsSameSize) {


### PR DESCRIPTION

Segments are now linked pools with the same memory size. Also, pool desc reports total pool size (or usage) instead of size of the pool since the total count is not a useful gauge of memory consumption.