### PR TITLE
Fix slab from corrupting memory during allocator tear-down.

### DIFF
--- a/src/gpgmm/AllocatorNode.cpp
+++ b/src/gpgmm/AllocatorNode.cpp
@@ -21,7 +21,7 @@ namespace gpgmm {
     template <typename T>
     AllocatorNode<T>::~AllocatorNode() {
         // Deletes adjacent node recursively (post-order).
-        mChildren.DeleteAll();
+        mChildren.RemoveAndDeleteAll();
         if (LinkNode<T>::IsInList()) {
             LinkNode<T>::RemoveFromList();
         }

--- a/src/gpgmm/SlabMemoryAllocator.cpp
+++ b/src/gpgmm/SlabMemoryAllocator.cpp
@@ -42,8 +42,8 @@ namespace gpgmm {
 
     SlabMemoryAllocator::~SlabMemoryAllocator() {
         for (SlabCache& cache : mCaches) {
-            cache.FreeList.DeleteAll();
-            cache.FullList.DeleteAll();
+            cache.FreeList.RemoveAndDeleteAll();
+            cache.FullList.RemoveAndDeleteAll();
         }
     }
 

--- a/src/gpgmm/SlabMemoryAllocator.h
+++ b/src/gpgmm/SlabMemoryAllocator.h
@@ -70,6 +70,11 @@ namespace gpgmm {
             Slab(uint64_t blockCount, uint64_t blockSize)
                 : RefCounted(0), BlockCount(blockCount), Allocator(blockCount, blockSize) {
             }
+            ~Slab() {
+                if (IsInList()) {
+                    RemoveFromList();
+                }
+            }
             bool IsFull() const {
                 return static_cast<uint32_t>(RefCount()) == BlockCount;
             }

--- a/src/gpgmm/common/LinkedList.h
+++ b/src/gpgmm/common/LinkedList.h
@@ -203,15 +203,17 @@ namespace gpgmm {
             return head() == end();
         }
 
-        // Deletes all nodes by calling ~T.
-        // ~T should call RemoveFromList if IsInList is true to unlink itself.
-        void DeleteAll() const {
+        // Empty the list by deleting all nodes.
+        // ~T must check if IsInList and call RemoveFromList to unlink itself or RemoveAndDeleteAll
+        // will ASSERT to indicate programmer error.
+        void RemoveAndDeleteAll() const {
             auto curr = head();
             while (curr != end()) {
                 auto next = curr->next();
                 delete curr->value();
                 curr = next;
             }
+            ASSERT(empty());
         }
 
       private:

--- a/src/tests/unittests/LinkedListTests.cpp
+++ b/src/tests/unittests/LinkedListTests.cpp
@@ -29,7 +29,7 @@ class FakeObject : public LinkNode<FakeObject> {
     }
 };
 
-TEST(LinkedListTests, DeleteAll) {
+TEST(LinkedListTests, RemoveAndDeleteAll) {
     LinkNode<FakeObject>* first = new FakeObject();
     LinkNode<FakeObject>* second = new FakeObject();
     LinkNode<FakeObject>* third = new FakeObject();
@@ -39,6 +39,6 @@ TEST(LinkedListTests, DeleteAll) {
     list.Append(second);
     list.Append(third);
 
-    list.DeleteAll();
+    list.RemoveAndDeleteAll();
     EXPECT_TRUE(list.empty());
 }


### PR DESCRIPTION

Slabs never fully unliked themselves from the slab cache but were deleted. This caused an access violation to occur when the slab cache wanted to destruct its (non-empty) list. To prevent future errors, RemoveAndDeleteAll will assert that the list is always empty before returning.