### PR TITLE
Specify windows-2019 for workflows.

### DIFF
--- a/.github/workflows/win_clang_dbg_x64.yaml
+++ b/.github/workflows/win_clang_dbg_x64.yaml
@@ -13,7 +13,7 @@ jobs:
 
   job:
 
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
     - name: Git config

--- a/.github/workflows/win_clang_rel_x64.yaml
+++ b/.github/workflows/win_clang_rel_x64.yaml
@@ -13,7 +13,7 @@ jobs:
 
   job:
 
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
     - name: Git config

--- a/.github/workflows/win_dawn_dbg.yaml
+++ b/.github/workflows/win_dawn_dbg.yaml
@@ -7,7 +7,7 @@ jobs:
 
   job:
 
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
     - name: Git config

--- a/.github/workflows/win_dawn_rel.yaml
+++ b/.github/workflows/win_dawn_rel.yaml
@@ -19,7 +19,7 @@ jobs:
 
   job:
 
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
     - name: Git config

--- a/.github/workflows/win_msvc_dbg_x64.yaml
+++ b/.github/workflows/win_msvc_dbg_x64.yaml
@@ -13,7 +13,7 @@ jobs:
 
   job:
 
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
     - name: Git config

--- a/.github/workflows/win_msvc_dbg_x64_cmake.yml
+++ b/.github/workflows/win_msvc_dbg_x64_cmake.yml
@@ -13,7 +13,7 @@ jobs:
 
   job:
 
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
     - name: Git config

--- a/.github/workflows/win_msvc_rel_x64.yaml
+++ b/.github/workflows/win_msvc_rel_x64.yaml
@@ -13,7 +13,7 @@ jobs:
 
   job:
 
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
     - name: Git config

--- a/.github/workflows/win_webnn_rel.yaml
+++ b/.github/workflows/win_webnn_rel.yaml
@@ -17,7 +17,7 @@ jobs:
 
   job:
 
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
     - name: Git config


### PR DESCRIPTION

Windows-latest now points to Windows Server 2022 (Windows 11) which appears to not be supported by vs_toolchain.py. This change specifies the older compatible OS build to restore the workflows until they can be successfully migrated.