### PR TITLE
Improve accuracy of resource memory stats.

### DIFF
--- a/src/tests/capture_replay_tests/traces/dawn_end2end_queuewritebuffertests_manywritebuffer.json
+++ b/src/tests/capture_replay_tests/traces/dawn_end2end_queuewritebuffertests_manywritebuffer.json
@@ -5,8 +5,8 @@
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abaccf880",
-      "tid": 16484,
+      "id": "0x15afcc5c650",
+      "tid": 22764,
       "ts": 0,
       "pid": "GPGMM"
     },
@@ -14,18 +14,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 12,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 11,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 96,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 62,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -37,18 +37,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 99,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 65,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 105,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 71,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -60,11 +60,51 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 90,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 99,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
       "ts": 126,
       "pid": "GPGMM",
       "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 139,
+      "pid": "GPGMM",
+      "args": {
         "snapshot": {
           "PoolSize": 0
         }
@@ -74,9 +114,37 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 135,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 151,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 167,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 172,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -88,8 +156,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 163,
+      "tid": 22764,
+      "ts": 195,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -100,9 +168,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 176,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 206,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -114,9 +182,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 186,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 212,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -128,9 +196,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 203,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 237,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -142,9 +210,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 209,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 242,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -156,8 +224,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 232,
+      "tid": 22764,
+      "ts": 265,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -168,9 +236,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 251,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 287,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -182,9 +250,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 257,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 293,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -196,9 +264,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 283,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 307,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -210,24 +278,24 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 289,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
+      "id": "0x15aff714630",
+      "tid": 22764,
       "ts": 312,
       "pid": "GPGMM",
       "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 334,
+      "pid": "GPGMM",
+      "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
         "ID": 1
       }
@@ -236,9 +304,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 324,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 350,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -250,9 +318,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 330,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 355,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -264,9 +332,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 347,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 382,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -278,9 +346,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 353,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 387,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -292,8 +360,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 375,
+      "tid": 22764,
+      "ts": 409,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -304,9 +372,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 388,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 451,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -318,9 +386,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 394,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 457,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -332,9 +400,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 410,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 472,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -346,9 +414,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 416,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 477,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -360,8 +428,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 438,
+      "tid": 22764,
+      "ts": 499,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -372,9 +440,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 474,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 510,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -386,9 +454,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 480,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 516,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -400,9 +468,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 497,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 530,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -414,9 +482,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 503,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 535,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -428,8 +496,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 525,
+      "tid": 22764,
+      "ts": 556,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -440,9 +508,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 538,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 567,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -454,9 +522,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 544,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 573,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -468,9 +536,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 560,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 587,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -482,9 +550,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 566,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 593,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -496,8 +564,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 588,
+      "tid": 22764,
+      "ts": 613,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -508,9 +576,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 601,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 625,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -522,9 +590,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 607,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 630,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -536,9 +604,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 636,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 645,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -550,9 +618,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 642,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 650,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -564,8 +632,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 676,
+      "tid": 22764,
+      "ts": 682,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -576,22 +644,8 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 688,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
+      "id": "0x15aff53df58",
+      "tid": 22764,
       "ts": 694,
       "pid": "GPGMM",
       "args": {
@@ -604,9 +658,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 711,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 700,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -618,35 +672,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 716,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 739,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 751,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 714,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -658,37 +686,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 758,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 773,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 780,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 720,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -700,8 +700,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 802,
+      "tid": 22764,
+      "ts": 741,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -712,9 +712,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 814,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 753,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -726,9 +726,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 858,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 778,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -740,9 +740,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 875,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 793,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -754,9 +754,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 881,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 798,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -768,8 +768,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 904,
+      "tid": 22764,
+      "ts": 820,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -780,8 +780,118 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 831,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 837,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 852,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 857,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 879,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 890,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 896,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 910,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714630",
+      "tid": 22764,
       "ts": 916,
       "pid": "GPGMM",
       "args": {
@@ -791,12 +901,24 @@
       }
     },
     {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 937,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 922,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 949,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -808,9 +930,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 939,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 954,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -822,9 +944,23 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 945,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 969,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 974,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -836,8 +972,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 967,
+      "tid": 22764,
+      "ts": 996,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -848,50 +984,8 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 979,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 985,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 1001,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
+      "id": "0x15aff53df58",
+      "tid": 22764,
       "ts": 1007,
       "pid": "GPGMM",
       "args": {
@@ -901,24 +995,12 @@
       }
     },
     {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 1030,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 1042,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 1013,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -930,9 +1012,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 1048,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 1028,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -944,23 +1026,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 1064,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 1070,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 1033,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -972,8 +1040,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 1092,
+      "tid": 22764,
+      "ts": 1055,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -984,9 +1052,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 1105,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 1066,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -998,9 +1066,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 1111,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 1082,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1012,9 +1080,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 1127,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 1097,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1026,9 +1094,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 1133,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 1102,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1040,8 +1108,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 1155,
+      "tid": 22764,
+      "ts": 1123,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1052,9 +1120,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 1168,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 1134,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1066,9 +1134,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 1174,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 1140,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1080,9 +1148,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 1190,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 1154,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1094,8 +1162,34 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 1160,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 1180,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53df58",
+      "tid": 22764,
       "ts": 1196,
       "pid": "GPGMM",
       "args": {
@@ -1105,24 +1199,12 @@
       }
     },
     {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 1218,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 1231,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 1201,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1134,9 +1216,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 1237,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 1216,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1148,23 +1230,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 1253,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 1259,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 1221,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1176,76 +1244,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 1281,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 1298,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 1304,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 1320,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 1327,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 1349,
+      "tid": 22764,
+      "ts": 1242,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -1256,9 +1256,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 1367,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 1258,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1270,9 +1270,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 1373,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 1264,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1284,9 +1284,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 1389,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 1278,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1298,9 +1298,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 1395,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 1283,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1312,8 +1312,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 1417,
+      "tid": 22764,
+      "ts": 1304,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -1324,9 +1324,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 1433,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 1318,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1338,9 +1338,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 1439,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 1324,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1352,9 +1352,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 1455,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 1338,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1366,9 +1366,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 1461,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 1344,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1380,8 +1380,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 1483,
+      "tid": 22764,
+      "ts": 1364,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -1392,9 +1392,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 1499,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 1379,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1406,9 +1406,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 1505,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 1384,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1420,9 +1420,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 1597,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 1435,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1434,9 +1434,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 1603,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 1441,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1448,8 +1448,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 1639,
+      "tid": 22764,
+      "ts": 1464,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -1460,9 +1460,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 1668,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 1480,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1474,9 +1474,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 1674,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 1485,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1488,9 +1488,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 1690,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 1500,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1502,9 +1502,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 1696,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 1505,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1516,8 +1516,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 1719,
+      "tid": 22764,
+      "ts": 1526,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -1528,9 +1528,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 1734,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 1540,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1542,9 +1542,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 1740,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 1546,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1556,9 +1556,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 1756,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 1560,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1570,9 +1570,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 1762,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 1566,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1584,11 +1584,215 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 1580,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 1586,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 1607,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 1623,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 1639,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 1654,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 1670,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 1686,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 1701,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 1717,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 1732,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 1748,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 1763,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
       "ts": 1778,
       "pid": "GPGMM",
       "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 1785,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 1804,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 1806,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 1810,
+      "pid": "GPGMM",
+      "args": {
         "snapshot": {
           "PoolSize": 0
         }
@@ -1598,9 +1802,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 1784,
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 1825,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1609,188 +1813,174 @@
       }
     },
     {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 1806,
+      "ph": "O",
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 1830,
       "pid": "GPGMM",
       "args": {
-        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
-        "ID": 0
+        "snapshot": {
+          "PoolSize": 0
+        }
       }
     },
     {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 1823,
+      "tid": 22764,
+      "ts": 1852,
       "pid": "GPGMM",
       "args": {
-        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
-        "ID": 0
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
       }
     },
     {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 1839,
+      "ph": "O",
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 1863,
       "pid": "GPGMM",
       "args": {
-        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
-        "ID": 0
+        "snapshot": {
+          "PoolSize": 0
+        }
       }
     },
     {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 1856,
+      "ph": "O",
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 1868,
       "pid": "GPGMM",
       "args": {
-        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
-        "ID": 0
+        "snapshot": {
+          "PoolSize": 0
+        }
       }
     },
     {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 1872,
+      "ph": "O",
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 1883,
       "pid": "GPGMM",
       "args": {
-        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
-        "ID": 0
+        "snapshot": {
+          "PoolSize": 0
+        }
       }
     },
     {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "i",
-      "tid": 16484,
+      "ph": "O",
+      "id": "0x15aff7150e0",
+      "tid": 22764,
       "ts": 1888,
       "pid": "GPGMM",
       "args": {
-        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
-        "ID": 0
+        "snapshot": {
+          "PoolSize": 0
+        }
       }
     },
     {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 1904,
+      "tid": 22764,
+      "ts": 1909,
       "pid": "GPGMM",
       "args": {
-        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
-        "ID": 0
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
       }
     },
     {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 1920,
+      "ph": "O",
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 1931,
       "pid": "GPGMM",
       "args": {
-        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
-        "ID": 0
+        "snapshot": {
+          "PoolSize": 0
+        }
       }
     },
     {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 1936,
+      "ph": "O",
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 1937,
       "pid": "GPGMM",
       "args": {
-        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
-        "ID": 0
+        "snapshot": {
+          "PoolSize": 0
+        }
       }
     },
     {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "i",
-      "tid": 16484,
+      "ph": "O",
+      "id": "0x15aff53d158",
+      "tid": 22764,
       "ts": 1952,
       "pid": "GPGMM",
       "args": {
-        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 1968,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 1984,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
-        "ID": 0
+        "snapshot": {
+          "PoolSize": 0
+        }
       }
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "N",
-      "id": "0x22ab6568558",
-      "tid": 16484,
+      "ph": "O",
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 1957,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
       "ts": 1990,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 2011,
       "pid": "GPGMM",
       "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
       }
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "N",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 2014,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 2019,
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 2001,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1802,9 +1992,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 2036,
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 2006,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1816,9 +2006,23 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 2042,
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 2032,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 2038,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1830,8 +2034,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 2065,
+      "tid": 22764,
+      "ts": 2059,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1842,9 +2046,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 2078,
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 2070,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1856,9 +2060,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 2084,
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 2076,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1870,9 +2074,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 2100,
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 2090,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1884,9 +2088,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 2106,
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 2096,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1898,8 +2102,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 2128,
+      "tid": 22764,
+      "ts": 2117,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1910,9 +2114,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 2141,
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 2129,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1924,9 +2128,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 2147,
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 2134,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1938,9 +2142,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 2163,
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 2149,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1952,9 +2156,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 2169,
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 2155,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1966,8 +2170,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 2191,
+      "tid": 22764,
+      "ts": 2187,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1978,8 +2182,22 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 2198,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff7150e0",
+      "tid": 22764,
       "ts": 2203,
       "pid": "GPGMM",
       "args": {
@@ -1992,9 +2210,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 2209,
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 2218,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2006,23 +2224,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 2226,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 2232,
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 2223,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2034,8 +2238,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 2253,
+      "tid": 22764,
+      "ts": 2255,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2046,9 +2250,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 2266,
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 2267,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2060,8 +2264,8 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
+      "id": "0x15aff7150e0",
+      "tid": 22764,
       "ts": 2272,
       "pid": "GPGMM",
       "args": {
@@ -2074,9 +2278,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 2288,
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 2287,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2088,77 +2292,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 2294,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 2316,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 2329,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 2335,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 2351,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 2357,
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 2303,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2170,8 +2306,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 2379,
+      "tid": 22764,
+      "ts": 2324,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2182,9 +2318,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 2392,
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 2336,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2196,9 +2332,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 2398,
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 2341,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2210,9 +2346,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 2414,
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 2356,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2224,9 +2360,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 2420,
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 2361,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2238,8 +2374,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 2442,
+      "tid": 22764,
+      "ts": 2382,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2250,9 +2386,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 2455,
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 2393,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2264,9 +2400,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 2461,
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 2410,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2278,9 +2414,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 2477,
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 2425,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2292,9 +2428,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 2483,
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 2430,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2306,8 +2442,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 2505,
+      "tid": 22764,
+      "ts": 2453,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2318,8 +2454,50 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 2465,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 2470,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 2496,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff7150e0",
+      "tid": 22764,
       "ts": 2517,
       "pid": "GPGMM",
       "args": {
@@ -2329,53 +2507,11 @@
       }
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 2524,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 2540,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 2546,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 2568,
+      "tid": 22764,
+      "ts": 2538,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2386,9 +2522,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 2580,
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 2560,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2400,8 +2536,36 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 2566,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 2581,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff7150e0",
+      "tid": 22764,
       "ts": 2586,
       "pid": "GPGMM",
       "args": {
@@ -2411,12 +2575,24 @@
       }
     },
     {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 2607,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 2603,
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 2618,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2428,9 +2604,37 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 2609,
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 2623,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 2638,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 2643,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2442,8 +2646,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 2643,
+      "tid": 22764,
+      "ts": 2664,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2454,9 +2658,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 2667,
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 2675,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2468,9 +2672,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 2673,
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 2680,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2482,22 +2686,8 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 2689,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
+      "id": "0x15aff53d158",
+      "tid": 22764,
       "ts": 2695,
       "pid": "GPGMM",
       "args": {
@@ -2507,11 +2697,25 @@
       }
     },
     {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 2700,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 2717,
+      "tid": 22764,
+      "ts": 2721,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2522,9 +2726,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 2730,
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 2732,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2536,9 +2740,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 2736,
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 2737,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2550,8 +2754,8 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
+      "id": "0x15aff53d158",
+      "tid": 22764,
       "ts": 2752,
       "pid": "GPGMM",
       "args": {
@@ -2564,9 +2768,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 2758,
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 2757,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2578,8 +2782,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 2780,
+      "tid": 22764,
+      "ts": 2778,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2590,9 +2794,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 2792,
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 2789,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2604,9 +2808,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 2798,
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 2795,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2618,8 +2822,22 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 2809,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff7150e0",
+      "tid": 22764,
       "ts": 2814,
       "pid": "GPGMM",
       "args": {
@@ -2629,25 +2847,11 @@
       }
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 2820,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 2842,
+      "tid": 22764,
+      "ts": 2835,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2658,9 +2862,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 2855,
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 2846,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2672,9 +2876,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 2861,
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 2922,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2686,9 +2890,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 2877,
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 2937,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2700,9 +2904,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 2883,
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 2943,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2714,8 +2918,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 2905,
+      "tid": 22764,
+      "ts": 2964,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2726,9 +2930,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 2917,
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 2979,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2740,9 +2944,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 2923,
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 2985,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2754,9 +2958,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 2939,
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 2999,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2768,9 +2972,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 2945,
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 3005,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2782,11 +2986,11 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 2967,
+      "tid": 22764,
+      "ts": 3025,
       "pid": "GPGMM",
       "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
         "ID": 1
       }
     },
@@ -2794,9 +2998,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 2980,
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 3041,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2808,9 +3012,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 2986,
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 3046,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2822,9 +3026,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 3002,
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 3060,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2836,9 +3040,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 3008,
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 3066,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2850,11 +3054,11 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 3030,
+      "tid": 22764,
+      "ts": 3087,
       "pid": "GPGMM",
       "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
         "ID": 1
       }
     },
@@ -2862,9 +3066,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 3043,
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 3101,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2876,9 +3080,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 3227,
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 3107,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2890,9 +3094,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 3256,
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 3121,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2904,9 +3108,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 3262,
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 3126,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2918,21 +3122,171 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
+      "tid": 22764,
+      "ts": 3147,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 3162,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 3168,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 3182,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 3188,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 3209,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 3224,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 3230,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 3244,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 3250,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 3271,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d158",
+      "tid": 22764,
       "ts": 3285,
       "pid": "GPGMM",
       "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
+        "snapshot": {
+          "PoolSize": 0
+        }
       }
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 3303,
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 3291,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2944,8 +3298,22 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 3305,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff7150e0",
+      "tid": 22764,
       "ts": 3310,
       "pid": "GPGMM",
       "args": {
@@ -2958,9 +3326,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 3326,
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 3325,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2972,9 +3340,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 3333,
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 3331,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2983,296 +3351,165 @@
       }
     },
     {
-      "name": "SlabBlockAllocator.AllocateBlock",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 3355,
+      "tid": 22764,
+      "ts": 3351,
       "pid": "GPGMM",
       "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
-        "ID": 1
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
       }
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 3373,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 3380,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 3396,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 3402,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 3436,
+      "tid": 22764,
+      "ts": 3367,
       "pid": "GPGMM",
       "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
-        "ID": 1
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
       }
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 3452,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 3458,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 3475,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 3481,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 3503,
+      "tid": 22764,
+      "ts": 3382,
       "pid": "GPGMM",
       "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
-        "ID": 1
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
       }
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 3519,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 3525,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 3541,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 3548,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 3570,
+      "tid": 22764,
+      "ts": 3398,
       "pid": "GPGMM",
       "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
-        "ID": 1
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
       }
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 3588,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 3595,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 3611,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 3628,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 3663,
+      "tid": 22764,
+      "ts": 3414,
       "pid": "GPGMM",
       "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
-        "ID": 1
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 3429,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 3446,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 3494,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 3526,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 3559,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 3618,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 3649,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
       }
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
+      "ph": "N",
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 3660,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 3679,
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 3697,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3283,24 +3520,19 @@
     {
       "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 3685,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
+      "ph": "N",
+      "id": "0x15aff715440",
+      "tid": 22764,
       "ts": 3701,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 3708,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3312,9 +3544,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 3707,
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 3734,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3326,9 +3558,35 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 3723,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 3743,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 3778,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 3810,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3340,9 +3598,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 3729,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 3819,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3351,216 +3609,94 @@
       }
     },
     {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 3751,
+      "ph": "O",
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 3847,
       "pid": "GPGMM",
       "args": {
-        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
-        "ID": 0
+        "snapshot": {
+          "PoolSize": 0
+        }
       }
     },
     {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 3767,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 3784,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 3800,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 3816,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
+      "ph": "O",
+      "id": "0x15aff715440",
+      "tid": 22764,
       "ts": 3857,
       "pid": "GPGMM",
       "args": {
-        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
-        "ID": 0
+        "snapshot": {
+          "PoolSize": 0
+        }
       }
     },
     {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 3873,
+      "tid": 22764,
+      "ts": 3893,
       "pid": "GPGMM",
       "args": {
-        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 3889,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 3905,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 3921,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 3937,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 3953,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
-        "ID": 0
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
       }
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "N",
-      "id": "0x22ab6567458",
-      "tid": 16484,
+      "ph": "O",
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 3913,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 3923,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 3949,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715440",
+      "tid": 22764,
       "ts": 3959,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 3982,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 3985,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 3989,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 4006,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 4012,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3572,8 +3708,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 4035,
+      "tid": 22764,
+      "ts": 3995,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3584,9 +3720,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 4048,
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 4016,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3598,9 +3734,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 4054,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 4028,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3612,9 +3748,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 4070,
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 4065,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3626,9 +3762,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 4076,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 4077,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3640,8 +3776,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 4109,
+      "tid": 22764,
+      "ts": 4127,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3652,9 +3788,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 4122,
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 4154,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3666,9 +3802,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 4129,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 4167,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3680,51 +3816,11 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 4157,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 4163,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
+      "id": "0x15aff53c858",
+      "tid": 22764,
       "ts": 4201,
       "pid": "GPGMM",
       "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 4225,
-      "pid": "GPGMM",
-      "args": {
         "snapshot": {
           "PoolSize": 0
         }
@@ -3734,37 +3830,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 4244,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 4272,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 4279,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 4214,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3776,8 +3844,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 4313,
+      "tid": 22764,
+      "ts": 4262,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3788,9 +3856,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 4338,
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 4288,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3802,9 +3870,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 4345,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 4309,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3816,9 +3884,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 4362,
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 4339,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3830,9 +3898,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 4368,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 4351,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3844,8 +3912,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 4391,
+      "tid": 22764,
+      "ts": 4393,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3856,9 +3924,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 4404,
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 4415,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3870,9 +3938,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 4411,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 4424,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3884,48 +3952,8 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 4428,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 4434,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 4468,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
+      "id": "0x15aff53c858",
+      "tid": 22764,
       "ts": 4481,
       "pid": "GPGMM",
       "args": {
@@ -3938,37 +3966,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 4487,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 4504,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 4510,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 4491,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3980,8 +3980,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 4533,
+      "tid": 22764,
+      "ts": 4541,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3992,9 +3992,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 4561,
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 4555,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4006,9 +4006,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 4567,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 4563,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4020,9 +4020,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 4599,
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 4591,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4034,9 +4034,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 4620,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 4598,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4048,23 +4048,51 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
+      "tid": 22764,
+      "ts": 4621,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 4634,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 4641,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c858",
+      "tid": 22764,
       "ts": 4657,
       "pid": "GPGMM",
       "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 4681,
-      "pid": "GPGMM",
-      "args": {
         "snapshot": {
           "PoolSize": 0
         }
@@ -4074,23 +4102,35 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 4663,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
       "ts": 4687,
       "pid": "GPGMM",
       "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
       }
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 4715,
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 4700,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4102,9 +4142,37 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 4736,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 4706,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 4723,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 4729,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4116,8 +4184,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 4774,
+      "tid": 22764,
+      "ts": 4752,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4128,9 +4196,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 4787,
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 4765,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4142,9 +4210,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 4793,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 4772,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4156,9 +4224,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 4809,
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 4788,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4170,9 +4238,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 4816,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 4795,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4184,8 +4252,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 4849,
+      "tid": 22764,
+      "ts": 4818,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4196,9 +4264,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 4863,
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 4830,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4210,9 +4278,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 4869,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 4837,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4224,9 +4292,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 4897,
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 4853,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4238,9 +4306,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 4919,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 4860,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4252,8 +4320,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 4956,
+      "tid": 22764,
+      "ts": 4883,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4264,9 +4332,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 4969,
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 4896,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4278,9 +4346,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 4975,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 4902,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4292,9 +4360,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 4991,
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 4918,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4306,9 +4374,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 4997,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 4925,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4320,8 +4388,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 5020,
+      "tid": 22764,
+      "ts": 4948,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4332,8 +4400,90 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 4961,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 4967,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 4983,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 4990,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 5013,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 5026,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715440",
+      "tid": 22764,
       "ts": 5033,
       "pid": "GPGMM",
       "args": {
@@ -4346,9 +4496,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 5039,
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 5050,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4360,23 +4510,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 5056,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 5062,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 5057,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4388,8 +4524,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 5084,
+      "tid": 22764,
+      "ts": 5080,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4400,9 +4536,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 5097,
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 5093,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4414,9 +4550,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 5103,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 5100,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4428,9 +4564,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 5132,
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 5116,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4442,9 +4578,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 5139,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 5123,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4456,8 +4592,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 5162,
+      "tid": 22764,
+      "ts": 5146,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4468,9 +4604,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 5186,
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 5159,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4482,9 +4618,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 5192,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 5165,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4496,9 +4632,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 5224,
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 5182,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4510,9 +4646,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 5230,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 5188,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4524,8 +4660,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 5268,
+      "tid": 22764,
+      "ts": 5211,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4536,9 +4672,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 5284,
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 5229,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4550,9 +4686,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 5291,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 5236,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4564,9 +4700,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 5319,
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 5252,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4578,9 +4714,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 5325,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 5258,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4592,11 +4728,11 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 5348,
+      "tid": 22764,
+      "ts": 5281,
       "pid": "GPGMM",
       "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
         "ID": 1
       }
     },
@@ -4604,9 +4740,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 5361,
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 5299,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4618,8 +4754,62 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 5306,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 5322,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 5329,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 5352,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c858",
+      "tid": 22764,
       "ts": 5368,
       "pid": "GPGMM",
       "args": {
@@ -4632,9 +4822,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 5384,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 5375,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4646,35 +4836,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 5391,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 5425,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 5443,
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 5392,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4686,37 +4850,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 5450,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 5467,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 5473,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 5398,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4728,11 +4864,11 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 5497,
+      "tid": 22764,
+      "ts": 5421,
       "pid": "GPGMM",
       "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
         "ID": 1
       }
     },
@@ -4740,9 +4876,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 5515,
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 5438,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4754,8 +4890,90 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 5445,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 5460,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 5465,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 5486,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 5502,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 5508,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c858",
+      "tid": 22764,
       "ts": 5522,
       "pid": "GPGMM",
       "args": {
@@ -4768,23 +4986,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 5539,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 5546,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 5527,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4796,212 +5000,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 5569,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 5586,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 5592,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 5609,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 5617,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 5641,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 5658,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 5664,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 5682,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 5688,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 5711,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 5729,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 5736,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 5753,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 5759,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 5783,
+      "tid": 22764,
+      "ts": 5548,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -5012,9 +5012,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 5800,
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 5563,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5026,9 +5026,255 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 5568,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 5583,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 5588,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 5602,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 5608,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 5628,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 5646,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 5662,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 5677,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 5693,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 5708,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 5724,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 5739,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 5754,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 5770,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 5785,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 5801,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x15aff53cf58",
+      "tid": 22764,
       "ts": 5807,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 5826,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 5828,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 5833,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5040,9 +5286,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 5835,
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 5848,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5054,9 +5300,35 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 5841,
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 5853,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 5875,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 5887,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5068,9 +5340,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 5889,
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 5892,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5082,9 +5354,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 5895,
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 5907,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5093,188 +5365,310 @@
       }
     },
     {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 5948,
+      "ph": "O",
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 5912,
       "pid": "GPGMM",
       "args": {
-        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
-        "ID": 0
+        "snapshot": {
+          "PoolSize": 0
+        }
       }
     },
     {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 5966,
+      "tid": 22764,
+      "ts": 5933,
       "pid": "GPGMM",
       "args": {
-        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
-        "ID": 0
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
       }
     },
     {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 5983,
+      "ph": "O",
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 5944,
       "pid": "GPGMM",
       "args": {
-        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
-        "ID": 0
+        "snapshot": {
+          "PoolSize": 0
+        }
       }
     },
     {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 6010,
+      "ph": "O",
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 5950,
       "pid": "GPGMM",
       "args": {
-        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
-        "ID": 0
+        "snapshot": {
+          "PoolSize": 0
+        }
       }
     },
     {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 6042,
+      "ph": "O",
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 5964,
       "pid": "GPGMM",
       "args": {
-        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
-        "ID": 0
+        "snapshot": {
+          "PoolSize": 0
+        }
       }
     },
     {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 5970,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
+      "tid": 22764,
+      "ts": 5990,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 6002,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 6007,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 6022,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 6027,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 6048,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53cf58",
+      "tid": 22764,
       "ts": 6059,
       "pid": "GPGMM",
       "args": {
-        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 6086,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 6102,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 6118,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 6133,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 6149,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 6166,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
-        "ID": 0
+        "snapshot": {
+          "PoolSize": 0
+        }
       }
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "N",
-      "id": "0x22ab6568658",
-      "tid": 16484,
+      "ph": "O",
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 6064,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 6079,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 6084,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 6105,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 6116,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 6121,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 6136,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 6141,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 6162,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53cf58",
+      "tid": 22764,
       "ts": 6173,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 6194,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 6197,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 6201,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5286,11 +5680,65 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 6179,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 6193,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 6198,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
       "ts": 6219,
       "pid": "GPGMM",
       "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 6230,
+      "pid": "GPGMM",
+      "args": {
         "snapshot": {
           "PoolSize": 0
         }
@@ -5300,9 +5748,37 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 6224,
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 6236,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 6250,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 6256,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5314,8 +5790,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 6247,
+      "tid": 22764,
+      "ts": 6592,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5326,9 +5802,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 6271,
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 6604,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5340,9 +5816,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 6277,
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 6610,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5354,9 +5830,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 6294,
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 6625,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5368,320 +5844,8 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 6300,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 6334,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 6346,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 6352,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 6369,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 6374,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 6397,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 6409,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 6415,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 6431,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 6438,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 6460,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 6472,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 6478,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 6494,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 6500,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 6534,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 6546,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 6553,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 6569,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 6575,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 6598,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 6622,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
+      "id": "0x15aff714870",
+      "tid": 22764,
       "ts": 6630,
       "pid": "GPGMM",
       "args": {
@@ -5691,12 +5855,24 @@
       }
     },
     {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 6651,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 6658,
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 6662,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5708,9 +5884,37 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 6664,
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 6668,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 6682,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 6688,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5722,8 +5926,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 6687,
+      "tid": 22764,
+      "ts": 6708,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5734,9 +5938,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 6699,
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 6720,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5748,9 +5952,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 6705,
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 6725,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5762,22 +5966,8 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 6722,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
+      "id": "0x15aff53cf58",
+      "tid": 22764,
       "ts": 6740,
       "pid": "GPGMM",
       "args": {
@@ -5787,11 +5977,25 @@
       }
     },
     {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 6745,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 7132,
+      "tid": 22764,
+      "ts": 6766,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5802,8 +6006,444 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 6777,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 6783,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 6797,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 6803,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 6824,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 6835,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 6840,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 6855,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 6860,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 6881,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 6892,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 6898,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 6912,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 6917,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 6938,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 6949,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 6955,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 6969,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 6975,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 6995,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 7006,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 7012,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 7026,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 7032,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 7053,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 7064,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 7070,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 7084,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 7089,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 7110,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 7126,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 7131,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53cf58",
+      "tid": 22764,
       "ts": 7146,
       "pid": "GPGMM",
       "args": {
@@ -5816,37 +6456,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 7152,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 7168,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 7174,
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 7151,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5858,11 +6470,11 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 7196,
+      "tid": 22764,
+      "ts": 7172,
       "pid": "GPGMM",
       "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
         "ID": 1
       }
     },
@@ -5870,9 +6482,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 7209,
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 7188,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5884,9 +6496,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 7215,
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 7193,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5898,9 +6510,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 7231,
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 7207,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5912,9 +6524,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 7237,
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 7213,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5926,11 +6538,11 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 7259,
+      "tid": 22764,
+      "ts": 7234,
       "pid": "GPGMM",
       "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
         "ID": 1
       }
     },
@@ -5938,9 +6550,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 7271,
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 7250,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5952,9 +6564,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 7277,
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 7256,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5966,9 +6578,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 7294,
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 7270,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5980,9 +6592,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 7299,
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 7276,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5994,11 +6606,11 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 7321,
+      "tid": 22764,
+      "ts": 7297,
       "pid": "GPGMM",
       "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
         "ID": 1
       }
     },
@@ -6006,9 +6618,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 7334,
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 7311,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6020,9 +6632,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 7340,
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 7317,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6034,9 +6646,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 7356,
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 7331,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6048,9 +6660,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 7362,
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 7337,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6062,11 +6674,11 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 7384,
+      "tid": 22764,
+      "ts": 7358,
       "pid": "GPGMM",
       "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
         "ID": 1
       }
     },
@@ -6074,9 +6686,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 7397,
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 7373,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6088,9 +6700,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 7403,
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 7379,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6102,9 +6714,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 7419,
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 7393,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6116,9 +6728,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 7425,
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 7399,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6130,11 +6742,11 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 7447,
+      "tid": 22764,
+      "ts": 7420,
       "pid": "GPGMM",
       "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
         "ID": 1
       }
     },
@@ -6142,8 +6754,50 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 7434,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 7441,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 7456,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff714870",
+      "tid": 22764,
       "ts": 7461,
       "pid": "GPGMM",
       "args": {
@@ -6156,9 +6810,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 7467,
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 7475,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6170,9 +6824,199 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 7483,
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 7481,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 7501,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 7517,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 7533,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 7548,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 7564,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 7579,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 7595,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 7610,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 7625,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 7641,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 7656,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 7671,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 7677,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 7696,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 7698,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 7702,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6184,9 +7028,23 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 7489,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 7717,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 7723,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6198,8 +7056,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 7511,
+      "tid": 22764,
+      "ts": 7744,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6210,9 +7068,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 7524,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 7755,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6224,9 +7082,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 7530,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 7761,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6238,9 +7096,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 7555,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 7775,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6252,9 +7110,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 7562,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 7780,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6266,8 +7124,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 7584,
+      "tid": 22764,
+      "ts": 7802,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6278,9 +7136,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 7597,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 7813,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6292,9 +7150,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 7604,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 7818,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6306,212 +7164,8 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 7620,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 7628,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 7651,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 7664,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 7670,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 7687,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 7693,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 7715,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 7741,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 7747,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 7764,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 7770,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 7793,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 7810,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 7817,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
+      "id": "0x15aff53e058",
+      "tid": 22764,
       "ts": 7833,
       "pid": "GPGMM",
       "args": {
@@ -6524,9 +7178,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 7840,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 7838,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6538,11 +7192,11 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 7862,
+      "tid": 22764,
+      "ts": 7859,
       "pid": "GPGMM",
       "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
         "ID": 1
       }
     },
@@ -6550,9 +7204,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 7879,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 7870,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6564,9 +7218,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 7885,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 7876,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6578,9 +7232,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 7902,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 7890,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6592,9 +7246,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 7908,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 7895,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6606,11 +7260,11 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 7931,
+      "tid": 22764,
+      "ts": 7916,
       "pid": "GPGMM",
       "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
         "ID": 1
       }
     },
@@ -6618,8 +7272,36 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 7927,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 7933,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53e058",
+      "tid": 22764,
       "ts": 7947,
       "pid": "GPGMM",
       "args": {
@@ -6632,8 +7314,8 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
+      "id": "0x15aff715e60",
+      "tid": 22764,
       "ts": 7953,
       "pid": "GPGMM",
       "args": {
@@ -6643,42 +7325,14 @@
       }
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 7970,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 7976,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 7999,
+      "tid": 22764,
+      "ts": 7973,
       "pid": "GPGMM",
       "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
         "ID": 1
       }
     },
@@ -6686,9 +7340,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 8016,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 7985,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6700,9 +7354,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 8023,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 7990,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6714,9 +7368,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 8039,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 8005,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6728,9 +7382,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 8045,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 8010,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6742,11 +7396,79 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
+      "tid": 22764,
+      "ts": 8031,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 8042,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 8048,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 8062,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715e60",
+      "tid": 22764,
       "ts": 8068,
       "pid": "GPGMM",
       "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 8088,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
         "ID": 1
       }
     },
@@ -6754,9 +7476,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 8084,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 8100,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6768,9 +7490,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 8090,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 8105,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6782,9 +7504,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 8107,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 8120,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6796,9 +7518,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 8113,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 8125,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6807,195 +7529,26 @@
       }
     },
     {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 8129,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 8135,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
+      "tid": 22764,
+      "ts": 8146,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53e058",
+      "tid": 22764,
       "ts": 8157,
       "pid": "GPGMM",
       "args": {
-        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 8174,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 8190,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 8207,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 8223,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 8240,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 8256,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 8272,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 8289,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 8305,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 8321,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 8338,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 8344,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 8365,
-      "pid": "GPGMM",
-      "args": {
         "snapshot": {
           "PoolSize": 0
         }
@@ -7004,19 +7557,10 @@
     {
       "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "N",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 8368,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
       "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 8373,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 8162,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7028,9 +7572,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 8390,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 8177,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7042,9 +7586,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 8396,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 8182,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7056,8 +7600,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 8420,
+      "tid": 22764,
+      "ts": 8203,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7068,9 +7612,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 8433,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 8214,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7082,9 +7626,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 8439,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 8219,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7096,9 +7640,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 8456,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 8234,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7110,9 +7654,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 8462,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 8239,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7124,8 +7668,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 8485,
+      "tid": 22764,
+      "ts": 8260,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7136,9 +7680,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 8498,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 8271,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7150,9 +7694,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 8504,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 8277,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7164,9 +7708,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 8521,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 8291,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7178,8 +7722,280 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 8297,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 8317,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 8329,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 8334,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 8348,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 8354,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 8375,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 8386,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 8391,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 8406,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 8411,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 8431,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 8444,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 8449,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 8464,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 8470,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 8491,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 8502,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 8507,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 8522,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715e60",
+      "tid": 22764,
       "ts": 8527,
       "pid": "GPGMM",
       "args": {
@@ -7192,8 +8008,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 8549,
+      "tid": 22764,
+      "ts": 8548,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7204,9 +8020,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 8562,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 8559,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7218,9 +8034,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 8569,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 8564,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7232,9 +8048,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 8585,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 8579,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7246,9 +8062,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 8592,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 8584,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7260,8 +8076,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 8614,
+      "tid": 22764,
+      "ts": 8605,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7272,9 +8088,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 8628,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 8616,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7286,9 +8102,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 8634,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 8621,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7300,9 +8116,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 8651,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 8636,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7314,9 +8130,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 8657,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 8641,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7328,8 +8144,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 8680,
+      "tid": 22764,
+      "ts": 8662,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7340,9 +8156,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 8693,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 8677,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7354,9 +8170,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 8699,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 8683,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7368,9 +8184,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 8716,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 8697,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7382,9 +8198,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 8722,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 8703,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7396,824 +8212,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 8744,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 8757,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 8763,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 8780,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 8786,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 8809,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 8821,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 8828,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 8844,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 8850,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 8873,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 8886,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 8892,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 8908,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 8914,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 8937,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 8950,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 8956,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 8973,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 8979,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 9001,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 9014,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 9021,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 9037,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 9043,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 9066,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 9079,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 9085,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 9101,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 9107,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 9130,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 9143,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 9149,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 9166,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 9172,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 9194,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 9207,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 9213,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 9231,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 9237,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 9260,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 9273,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 9279,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 9295,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 9302,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 9324,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 9337,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 9343,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 9360,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 9366,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 9389,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 9402,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 9408,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 9425,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 9431,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 9453,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 9470,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 9476,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 9492,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 9499,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 9521,
+      "tid": 22764,
+      "ts": 8724,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -8224,9 +8224,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 9538,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 8739,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8238,9 +8238,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 9545,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 8744,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8252,9 +8252,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 9561,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 8759,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8266,9 +8266,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 9567,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 8764,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8280,8 +8280,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 9590,
+      "tid": 22764,
+      "ts": 8787,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -8292,9 +8292,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 9616,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 8803,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8306,9 +8306,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 9624,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 8809,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8320,9 +8320,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 9641,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 8823,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8334,9 +8334,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 9647,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 8829,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8348,8 +8348,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 9669,
+      "tid": 22764,
+      "ts": 8855,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -8360,9 +8360,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 9686,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 8871,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8374,9 +8374,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 9692,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 8876,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8388,9 +8388,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 9709,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 8891,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8402,9 +8402,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 9715,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 8896,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8416,8 +8416,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 9745,
+      "tid": 22764,
+      "ts": 8917,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -8428,9 +8428,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 9764,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 8932,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8442,9 +8442,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 9771,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 8938,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8456,9 +8456,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 9787,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 8952,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8470,9 +8470,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 9794,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 8958,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8484,8 +8484,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 9817,
+      "tid": 22764,
+      "ts": 8979,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -8496,9 +8496,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 9834,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 8993,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8510,9 +8510,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 9841,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 8998,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8524,9 +8524,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 9858,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 9013,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8538,9 +8538,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 9864,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 9018,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8552,9 +8552,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 9881,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 9032,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8566,9 +8566,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 9887,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 9038,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8580,8 +8580,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 9909,
+      "tid": 22764,
+      "ts": 9058,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -8592,8 +8592,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 9925,
+      "tid": 22764,
+      "ts": 9073,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -8604,8 +8604,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 9947,
+      "tid": 22764,
+      "ts": 9089,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -8616,8 +8616,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 9963,
+      "tid": 22764,
+      "ts": 9105,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -8628,8 +8628,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 9980,
+      "tid": 22764,
+      "ts": 9121,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -8640,8 +8640,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 9996,
+      "tid": 22764,
+      "ts": 9136,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -8652,8 +8652,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 10013,
+      "tid": 22764,
+      "ts": 9152,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -8664,8 +8664,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 10029,
+      "tid": 22764,
+      "ts": 9171,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -8676,68 +8676,1029 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
+      "tid": 22764,
+      "ts": 9187,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 9202,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 9217,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 9233,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 9242,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 9261,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 9263,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 9267,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 9282,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 9288,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 9309,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 9321,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 9326,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 9341,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 9346,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 9367,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 9378,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 9384,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 9398,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 9404,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 9425,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 9436,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 9453,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 9469,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 9474,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 9495,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 9507,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 9512,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 9526,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 9532,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 9552,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 9564,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 9569,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 9584,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 9589,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 9610,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 9621,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 9626,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 9640,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 9646,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 9667,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 9678,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 9683,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 9698,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 9703,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 9724,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 9735,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 9740,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 9755,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 9760,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 9781,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 9792,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 9797,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 9812,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 9817,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 9838,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 9849,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 9855,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 9869,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 9874,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 9895,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 9906,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 9912,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 9926,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 9932,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 9952,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 9964,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 9969,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 9983,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 9989,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 10009,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 10021,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 10026,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 10040,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715320",
+      "tid": 22764,
       "ts": 10046,
       "pid": "GPGMM",
       "args": {
-        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
-        "ID": 0
+        "snapshot": {
+          "PoolSize": 0
+        }
       }
     },
     {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 10062,
+      "tid": 22764,
+      "ts": 10066,
       "pid": "GPGMM",
       "args": {
-        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
-        "ID": 0
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
       }
     },
     {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "i",
-      "tid": 16484,
+      "ph": "O",
+      "id": "0x15aff53d258",
+      "tid": 22764,
       "ts": 10078,
       "pid": "GPGMM",
       "args": {
-        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 10095,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 10101,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 10122,
-      "pid": "GPGMM",
-      "args": {
         "snapshot": {
           "PoolSize": 0
         }
@@ -8746,19 +9707,10 @@
     {
       "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "N",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 10125,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
       "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 10130,
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 10083,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8770,9 +9722,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 10147,
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 10098,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8784,9 +9736,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 10154,
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 10103,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8798,8 +9750,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 10177,
+      "tid": 22764,
+      "ts": 10124,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -8810,9 +9762,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 10190,
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 10142,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8824,9 +9776,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 10196,
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 10148,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8838,9 +9790,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 10213,
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 10162,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8852,9 +9804,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 10219,
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 10168,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8866,8 +9818,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 10242,
+      "tid": 22764,
+      "ts": 10189,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -8878,9 +9830,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 10255,
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 10200,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8892,8 +9844,62 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 10205,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 10220,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 10225,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 10246,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d258",
+      "tid": 22764,
       "ts": 10261,
       "pid": "GPGMM",
       "args": {
@@ -8906,9 +9912,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 10277,
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 10266,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8920,9 +9926,23 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 10283,
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 10281,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 10286,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8934,11 +9954,11 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 10306,
+      "tid": 22764,
+      "ts": 10307,
       "pid": "GPGMM",
       "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
         "ID": 1
       }
     },
@@ -8946,9 +9966,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 10319,
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 10322,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8960,9 +9980,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 10325,
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 10328,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8974,9 +9994,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 10341,
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 10342,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8988,8 +10008,8 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
+      "id": "0x15aff715320",
+      "tid": 22764,
       "ts": 10348,
       "pid": "GPGMM",
       "args": {
@@ -9002,11 +10022,11 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 10370,
+      "tid": 22764,
+      "ts": 10369,
       "pid": "GPGMM",
       "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
         "ID": 1
       }
     },
@@ -9014,8 +10034,8 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
+      "id": "0x15aff53d258",
+      "tid": 22764,
       "ts": 10383,
       "pid": "GPGMM",
       "args": {
@@ -9028,9 +10048,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 10389,
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 10388,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9042,9 +10062,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 10406,
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 10403,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9056,9 +10076,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 10412,
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 10408,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9070,11 +10090,11 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 10434,
+      "tid": 22764,
+      "ts": 10429,
       "pid": "GPGMM",
       "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
         "ID": 1
       }
     },
@@ -9082,9 +10102,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 10447,
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 10444,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9096,9 +10116,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 10453,
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 10450,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9110,8 +10130,22 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 10464,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715320",
+      "tid": 22764,
       "ts": 10470,
       "pid": "GPGMM",
       "args": {
@@ -9121,12 +10155,24 @@
       }
     },
     {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 10491,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 10476,
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 10506,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9135,23 +10181,11 @@
       }
     },
     {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 10499,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
+      "id": "0x15aff715320",
+      "tid": 22764,
       "ts": 10512,
       "pid": "GPGMM",
       "args": {
@@ -9164,9 +10198,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 10519,
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 10526,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9178,23 +10212,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 10535,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 10541,
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 10531,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9206,1028 +10226,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 10564,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 10577,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 10583,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 10600,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 10606,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 10629,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 10642,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 10648,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 10665,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 10671,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 10694,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 10707,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 10713,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 10730,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 10736,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 10758,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 10771,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 10777,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 10794,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 10800,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 10823,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 10836,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 10842,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 10859,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 10865,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 10887,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 10901,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 10907,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 10923,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 10929,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 10952,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 10970,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 10977,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 10993,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 10999,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 11022,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 11035,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 11041,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 11058,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 11064,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 11087,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 11100,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 11106,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 11122,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 11128,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 11151,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 11164,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 11170,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 11186,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 11192,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 11215,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 11232,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 11239,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 11255,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 11261,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 11284,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 11302,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 11308,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 11325,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 11332,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 11355,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 11371,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 11378,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 11395,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 11408,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 11432,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 11448,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 11454,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 11471,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 11477,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 11505,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 11523,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 11530,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 11546,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 11552,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 11575,
+      "tid": 22764,
+      "ts": 10552,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -10238,9 +10238,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 11591,
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 10566,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10252,8 +10252,1166 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 10572,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 10586,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 10592,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 10606,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 10611,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 10632,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 10647,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 10663,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 10678,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 10694,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 10709,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 10725,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 10740,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 10756,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 10771,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 10787,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 10802,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 10808,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 10826,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 10828,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 10832,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 10847,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 10852,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 10874,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 10885,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 10891,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 10905,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 10910,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 10931,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 10942,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 10948,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 10962,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 10967,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 10988,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 10999,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 11005,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 11019,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 11025,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 11045,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 11057,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 11062,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 11076,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 11082,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 11102,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 11114,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 11119,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 11134,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 11139,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 11160,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 11171,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 11177,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 11191,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 11196,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 11217,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 11228,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 11233,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 11248,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 11253,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 11274,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 11285,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 11291,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 11305,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 11310,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 11331,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 11342,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 11347,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 11362,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 11367,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 11388,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 11399,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 11405,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 11419,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 11425,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 11447,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 11458,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 11464,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 11478,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 11484,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 11504,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 11515,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 11521,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 11535,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 11541,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 11562,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 11573,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 11578,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 11593,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715950",
+      "tid": 22764,
       "ts": 11598,
       "pid": "GPGMM",
       "args": {
@@ -10263,12 +11421,24 @@
       }
     },
     {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 11619,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 11614,
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 11630,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10280,9 +11450,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 11621,
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 11636,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10294,9 +11464,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 11638,
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 11650,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10308,227 +11478,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 11644,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 11666,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 11683,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 11700,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 11716,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 11732,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 11749,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 11765,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 11781,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 11798,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 11814,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 11831,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 11847,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 11857,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 11882,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 11884,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 11889,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 11907,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 11913,
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 11655,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10540,8 +11492,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 11936,
+      "tid": 22764,
+      "ts": 11676,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -10552,9 +11504,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 11949,
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 11687,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10566,9 +11518,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 11956,
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 11693,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10580,9 +11532,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 11972,
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 12232,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10594,9 +11546,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 11978,
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 12238,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10608,8 +11560,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 12001,
+      "tid": 22764,
+      "ts": 12260,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -10620,280 +11572,8 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 12014,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 12020,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 12037,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 12043,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 12065,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 12078,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 12084,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 12101,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 12107,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 12129,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 12142,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 12149,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 12165,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 12171,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 12194,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 12207,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 12213,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 12229,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 12235,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 12258,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
+      "id": "0x15aff53c958",
+      "tid": 22764,
       "ts": 12271,
       "pid": "GPGMM",
       "args": {
@@ -10906,8 +11586,8 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
+      "id": "0x15aff715950",
+      "tid": 22764,
       "ts": 12277,
       "pid": "GPGMM",
       "args": {
@@ -10920,9 +11600,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 12294,
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 12291,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10934,77 +11614,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 12300,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 12322,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 12335,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 12342,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 12358,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 12364,
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 12296,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11016,8 +11628,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 12387,
+      "tid": 22764,
+      "ts": 12317,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -11028,9 +11640,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 12400,
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 12332,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11042,9 +11654,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 12406,
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 12338,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11056,9 +11668,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 12423,
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 12352,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11070,9 +11682,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 12429,
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 12357,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11084,11 +11696,11 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 12451,
+      "tid": 22764,
+      "ts": 12378,
       "pid": "GPGMM",
       "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
         "ID": 1
       }
     },
@@ -11096,9 +11708,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 12464,
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 12394,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11110,9 +11722,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 12470,
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 12399,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11124,9 +11736,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 12487,
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 12414,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11138,9 +11750,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 12493,
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 12419,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11152,11 +11764,11 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 12515,
+      "tid": 22764,
+      "ts": 12442,
       "pid": "GPGMM",
       "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
         "ID": 1
       }
     },
@@ -11164,9 +11776,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 12528,
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 12456,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11178,9 +11790,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 12535,
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 12462,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11192,8 +11804,90 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 12476,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 12482,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 12503,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 12525,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 12531,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 12545,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715950",
+      "tid": 22764,
       "ts": 12551,
       "pid": "GPGMM",
       "args": {
@@ -11203,12 +11897,24 @@
       }
     },
     {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 12572,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 12557,
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 12587,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11217,23 +11923,11 @@
       }
     },
     {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 12580,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
+      "id": "0x15aff715950",
+      "tid": 22764,
       "ts": 12593,
       "pid": "GPGMM",
       "args": {
@@ -11246,9 +11940,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 12599,
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 12607,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11260,23 +11954,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 12615,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 12623,
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 12613,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11288,688 +11968,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 12646,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 12659,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 12665,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 12681,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 12687,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 12710,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 12723,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 12729,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 12745,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 12752,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 12774,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 12787,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 12793,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 12810,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 12816,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 12838,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 12851,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 12857,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 13439,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 13445,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 13469,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 13482,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 13488,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 13505,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 13511,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 13534,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 13551,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 13557,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 13574,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 13580,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 13603,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 13622,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 13628,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 13645,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 13651,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 13722,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 13753,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 13760,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 13778,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 13784,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 13807,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 13824,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 13830,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 13847,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 13853,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 13876,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 13894,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 13900,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 13917,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 13923,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 13946,
+      "tid": 22764,
+      "ts": 12634,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -11980,9 +11980,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 13962,
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 12648,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11994,9 +11994,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 13968,
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 12654,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12008,9 +12008,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 13985,
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 12668,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12022,227 +12022,1437 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 12674,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 12688,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 12694,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 12717,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 12734,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 12751,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 12767,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 12783,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 12799,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 12816,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 12832,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 12848,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 12865,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 12881,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 12897,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 12904,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 12924,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 12926,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 12931,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 12946,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 12951,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 12973,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 12984,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 12990,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 13004,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 13009,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 13030,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 13042,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 13047,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 13061,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 13067,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 13088,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 13099,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 13104,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 13119,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 13124,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 13145,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 13156,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 13161,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 13176,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 13181,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 13202,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 13213,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 13218,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 13233,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 13238,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 13259,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 13270,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 13275,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 13290,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 13295,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 13316,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 13327,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 13333,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 13347,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 13353,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 13373,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 13385,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 13390,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 13405,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 13410,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 13431,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 13455,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 13461,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 13476,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 13492,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 13513,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 13525,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 13530,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 13544,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 13550,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 13571,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 13583,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 13589,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 13603,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 13609,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 13629,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 13640,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 13646,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 13660,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 13666,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 13686,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 13697,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 13703,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 13717,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 13723,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 13744,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 13755,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 13761,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 13775,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 13781,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 13801,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 13813,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 13818,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 13832,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 13838,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 13858,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 13881,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 13887,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 13902,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 13907,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 13928,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 13943,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 13949,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 13964,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 13969,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
       "ts": 13991,
       "pid": "GPGMM",
       "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
       }
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 14008,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 14014,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 14036,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 14053,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 14070,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 14086,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 14103,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 14120,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 14137,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 14153,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 14179,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 14195,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 14212,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 14228,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
-        "ID": 0
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 14235,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 14258,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 14260,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 14265,
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 14007,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12254,8 +13464,308 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 14012,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 14027,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 14033,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 14054,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 14069,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 14074,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 14089,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 14095,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 14116,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 14131,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 14136,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 14151,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 14157,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 14178,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 14194,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 14200,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 14215,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 14220,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 14242,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 14256,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 14262,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 14277,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
       "ts": 14282,
       "pid": "GPGMM",
       "args": {
@@ -12268,9 +13778,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 14289,
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 14297,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12279,1522 +13789,12 @@
       }
     },
     {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 14312,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 14325,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 14332,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 14348,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 14354,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 14377,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 14401,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 14407,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 14438,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 14445,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 14467,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 14480,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 14486,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 14503,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 14509,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 14532,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 14545,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 14551,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 14581,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 14588,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 14612,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 14625,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 14631,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 14648,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 14654,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 14677,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 14690,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 14696,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 14712,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 14719,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 14741,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 14754,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 14760,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 14777,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 14783,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 14806,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 14819,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 14825,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 14842,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 14847,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 14870,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 14888,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 14894,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 14911,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 14917,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 14939,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 14953,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 14959,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 14975,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 14981,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 15004,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 15017,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 15023,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 15039,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 15045,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 15068,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 15081,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 15087,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 15103,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 15110,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 15132,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 15145,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 15151,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 15168,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 15174,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 15196,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 15209,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 15215,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 15232,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 15238,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 15260,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 15273,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 15279,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 15296,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 15302,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 15324,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 15337,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 15343,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 15360,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 15366,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 15388,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 15405,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 15411,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 15428,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 15434,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 15457,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 15474,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 15480,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 15497,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 15503,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 15526,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 15542,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 15548,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 15565,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 15571,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 15594,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 15610,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 15617,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 15634,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 15640,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 15662,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 15712,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 15719,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 15735,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 15741,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "SlabBlockAllocator.AllocateBlock",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 15764,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
-        "ID": 1
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 15780,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 15787,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 15803,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 15809,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 15826,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 0
-        }
-      }
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 15832,
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 14302,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13806,8 +13806,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 15854,
+      "tid": 22764,
+      "ts": 14323,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -13818,8 +13818,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 15871,
+      "tid": 22764,
+      "ts": 14339,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -13830,8 +13830,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 15888,
+      "tid": 22764,
+      "ts": 14355,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -13842,8 +13842,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 15905,
+      "tid": 22764,
+      "ts": 14371,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -13854,8 +13854,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 15921,
+      "tid": 22764,
+      "ts": 14387,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -13866,8 +13866,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 15937,
+      "tid": 22764,
+      "ts": 14403,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -13878,8 +13878,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 15954,
+      "tid": 22764,
+      "ts": 14419,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -13890,8 +13890,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 15970,
+      "tid": 22764,
+      "ts": 14436,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -13902,8 +13902,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 15987,
+      "tid": 22764,
+      "ts": 14452,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -13914,8 +13914,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 16003,
+      "tid": 22764,
+      "ts": 14468,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -13926,8 +13926,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 16020,
+      "tid": 22764,
+      "ts": 14484,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -13938,8 +13938,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 16036,
+      "tid": 22764,
+      "ts": 14500,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -13950,13 +13950,13 @@
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 16067,
+      "tid": 22764,
+      "ts": 14529,
       "pid": "GPGMM",
       "args": {
         "Flags": 1,
         "RecordOptions": {
-          "Flags": 6
+          "Flags": 3
         },
         "IsUMA": 1,
         "ResourceHeapTier": 2,
@@ -13971,8 +13971,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 16129,
+      "tid": 22764,
+      "ts": 14590,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -14002,18 +14002,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadec020",
-      "tid": 16484,
-      "ts": 17275,
+      "id": "0x15aff2bdc40",
+      "tid": 22764,
+      "ts": 15980,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadec020",
-      "tid": 16484,
-      "ts": 17298,
+      "id": "0x15aff2bdc40",
+      "tid": 22764,
+      "ts": 16003,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14028,9 +14028,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadec020",
-      "tid": 16484,
-      "ts": 17319,
+      "id": "0x15aff2bdc40",
+      "tid": 22764,
+      "ts": 16023,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14045,18 +14045,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ab65c9a20",
-      "tid": 16484,
-      "ts": 17321,
+      "id": "0x15aff8cb6b0",
+      "tid": 22764,
+      "ts": 16026,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65c9a20",
-      "tid": 16484,
-      "ts": 17337,
+      "id": "0x15aff8cb6b0",
+      "tid": 22764,
+      "ts": 16041,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14065,7 +14065,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x22abadec020"
+            "id_ref": "0x15aff2bdc40"
           }
         }
       }
@@ -14074,8 +14074,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 17428,
+      "tid": 22764,
+      "ts": 16123,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -14105,18 +14105,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadeb2a0",
-      "tid": 16484,
-      "ts": 18467,
+      "id": "0x15aff2be9c0",
+      "tid": 22764,
+      "ts": 17106,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeb2a0",
-      "tid": 16484,
-      "ts": 18498,
+      "id": "0x15aff2be9c0",
+      "tid": 22764,
+      "ts": 17126,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14131,9 +14131,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeb2a0",
-      "tid": 16484,
-      "ts": 18516,
+      "id": "0x15aff2be9c0",
+      "tid": 22764,
+      "ts": 17142,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14148,18 +14148,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ab65cb020",
-      "tid": 16484,
-      "ts": 18518,
+      "id": "0x15aff8ca8f0",
+      "tid": 22764,
+      "ts": 17145,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65cb020",
-      "tid": 16484,
-      "ts": 18533,
+      "id": "0x15aff8ca8f0",
+      "tid": 22764,
+      "ts": 17160,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14168,7 +14168,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x22abadeb2a0"
+            "id_ref": "0x15aff2be9c0"
           }
         }
       }
@@ -14177,8 +14177,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 18630,
+      "tid": 22764,
+      "ts": 17231,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -14208,18 +14208,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadea490",
-      "tid": 16484,
-      "ts": 19674,
+      "id": "0x15aff2bd580",
+      "tid": 22764,
+      "ts": 18225,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadea490",
-      "tid": 16484,
-      "ts": 19710,
+      "id": "0x15aff2bd580",
+      "tid": 22764,
+      "ts": 18246,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14234,9 +14234,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadea490",
-      "tid": 16484,
-      "ts": 19727,
+      "id": "0x15aff2bd580",
+      "tid": 22764,
+      "ts": 18266,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14251,18 +14251,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ab65cb7b0",
-      "tid": 16484,
-      "ts": 19730,
+      "id": "0x15aff8cbce0",
+      "tid": 22764,
+      "ts": 18268,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65cb7b0",
-      "tid": 16484,
-      "ts": 19745,
+      "id": "0x15aff8cbce0",
+      "tid": 22764,
+      "ts": 18286,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14271,7 +14271,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x22abadea490"
+            "id_ref": "0x15aff2bd580"
           }
         }
       }
@@ -14280,8 +14280,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 19831,
+      "tid": 22764,
+      "ts": 18369,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -14311,18 +14311,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadebf90",
-      "tid": 16484,
-      "ts": 20037,
+      "id": "0x15aff2be390",
+      "tid": 22764,
+      "ts": 18586,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadebf90",
-      "tid": 16484,
-      "ts": 20068,
+      "id": "0x15aff2be390",
+      "tid": 22764,
+      "ts": 18632,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14337,9 +14337,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadebf90",
-      "tid": 16484,
-      "ts": 20085,
+      "id": "0x15aff2be390",
+      "tid": 22764,
+      "ts": 18649,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14354,18 +14354,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ab65c9fa0",
-      "tid": 16484,
-      "ts": 20088,
+      "id": "0x15aff8caf20",
+      "tid": 22764,
+      "ts": 18651,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65c9fa0",
-      "tid": 16484,
-      "ts": 20103,
+      "id": "0x15aff8caf20",
+      "tid": 22764,
+      "ts": 18666,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14374,7 +14374,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x22abadebf90"
+            "id_ref": "0x15aff2be390"
           }
         }
       }
@@ -14383,225 +14383,225 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadec020",
-      "tid": 16484,
-      "ts": 20154,
+      "id": "0x15aff2bdc40",
+      "tid": 22764,
+      "ts": 18709,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ab65c9a20",
-      "tid": 16484,
-      "ts": 20360,
+      "id": "0x15aff8cb6b0",
+      "tid": 22764,
+      "ts": 18851,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadebf90",
-      "tid": 16484,
-      "ts": 20397,
+      "id": "0x15aff2be390",
+      "tid": 22764,
+      "ts": 18869,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ab65c9fa0",
-      "tid": 16484,
-      "ts": 20582,
+      "id": "0x15aff8caf20",
+      "tid": 22764,
+      "ts": 18984,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadeb2a0",
-      "tid": 16484,
-      "ts": 20609,
+      "id": "0x15aff2be9c0",
+      "tid": 22764,
+      "ts": 19002,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ab65cb020",
-      "tid": 16484,
-      "ts": 20765,
+      "id": "0x15aff8ca8f0",
+      "tid": 22764,
+      "ts": 19125,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadea490",
-      "tid": 16484,
-      "ts": 20788,
+      "id": "0x15aff2bd580",
+      "tid": 22764,
+      "ts": 19142,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ab65cb7b0",
-      "tid": 16484,
-      "ts": 20998,
+      "id": "0x15aff8cbce0",
+      "tid": 22764,
+      "ts": 19251,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abaccf880",
-      "tid": 16484,
-      "ts": 21023,
+      "id": "0x15afcc5c650",
+      "tid": 22764,
+      "ts": 19261,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ab6567f58",
-      "tid": 16484,
-      "ts": 21038,
+      "id": "0x15aff53df58",
+      "tid": 22764,
+      "ts": 19277,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abab3d2d0",
-      "tid": 16484,
-      "ts": 21042,
+      "id": "0x15aff714630",
+      "tid": 22764,
+      "ts": 19281,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ab6568558",
-      "tid": 16484,
-      "ts": 21074,
+      "id": "0x15aff53d158",
+      "tid": 22764,
+      "ts": 19302,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abab3d480",
-      "tid": 16484,
-      "ts": 21076,
+      "id": "0x15aff7150e0",
+      "tid": 22764,
+      "ts": 19303,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ab6567458",
-      "tid": 16484,
-      "ts": 21095,
+      "id": "0x15aff53c858",
+      "tid": 22764,
+      "ts": 19322,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abab3d900",
-      "tid": 16484,
-      "ts": 21096,
+      "id": "0x15aff715440",
+      "tid": 22764,
+      "ts": 19323,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ab6568658",
-      "tid": 16484,
-      "ts": 21115,
+      "id": "0x15aff53cf58",
+      "tid": 22764,
+      "ts": 19339,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abab3d990",
-      "tid": 16484,
-      "ts": 21116,
+      "id": "0x15aff714870",
+      "tid": 22764,
+      "ts": 19340,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ab6567358",
-      "tid": 16484,
-      "ts": 21135,
+      "id": "0x15aff53e058",
+      "tid": 22764,
+      "ts": 19357,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abab3cdc0",
-      "tid": 16484,
-      "ts": 21136,
+      "id": "0x15aff715e60",
+      "tid": 22764,
+      "ts": 19358,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ab6568758",
-      "tid": 16484,
-      "ts": 21165,
+      "id": "0x15aff53d258",
+      "tid": 22764,
+      "ts": 19374,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abab3caf0",
-      "tid": 16484,
-      "ts": 21166,
+      "id": "0x15aff715320",
+      "tid": 22764,
+      "ts": 19376,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ab6567558",
-      "tid": 16484,
-      "ts": 21184,
+      "id": "0x15aff53c958",
+      "tid": 22764,
+      "ts": 19392,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadeb690",
-      "tid": 16484,
-      "ts": 21185,
+      "id": "0x15aff715950",
+      "tid": 22764,
+      "ts": 19393,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ab6568b58",
-      "tid": 16484,
-      "ts": 21202,
+      "id": "0x15aff53d458",
+      "tid": 22764,
+      "ts": 19410,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadeb180",
-      "tid": 16484,
-      "ts": 21203,
+      "id": "0x15aff2be0c0",
+      "tid": 22764,
+      "ts": 19411,
       "pid": "GPGMM"
     }
   ]

--- a/src/tests/capture_replay_tests/traces/directml_samples_directmlxsuperresolution.json
+++ b/src/tests/capture_replay_tests/traces/directml_samples_directmlxsuperresolution.json
@@ -5,27 +5,27 @@
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacb4800",
-      "tid": 16484,
-      "ts": 174281,
+      "id": "0x15afcc5bed0",
+      "tid": 22764,
+      "ts": 195824,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 174292,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 195837,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 174365,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 195911,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -37,9 +37,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 174417,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 195931,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -51,8 +51,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 174446,
+      "tid": 22764,
+      "ts": 195960,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -63,9 +63,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 174460,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 195972,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -77,9 +77,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 174476,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 195987,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -91,8 +91,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 174503,
+      "tid": 22764,
+      "ts": 196013,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -103,9 +103,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 174516,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196024,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -117,9 +117,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 174533,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196038,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -131,8 +131,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 174555,
+      "tid": 22764,
+      "ts": 196059,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -143,9 +143,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 174567,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196070,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -157,9 +157,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 174595,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196090,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -171,8 +171,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 174617,
+      "tid": 22764,
+      "ts": 196111,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -183,9 +183,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 174630,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196122,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -197,9 +197,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 174646,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196136,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -211,8 +211,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 174668,
+      "tid": 22764,
+      "ts": 196157,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -223,9 +223,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 174686,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196168,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -237,9 +237,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 174702,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196182,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -251,8 +251,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 174724,
+      "tid": 22764,
+      "ts": 196202,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -263,9 +263,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 174737,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196213,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -277,9 +277,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 174753,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196228,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -291,8 +291,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 174792,
+      "tid": 22764,
+      "ts": 196258,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -303,9 +303,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 174805,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196274,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -317,9 +317,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 174822,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196288,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -331,8 +331,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 174844,
+      "tid": 22764,
+      "ts": 196309,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -343,9 +343,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 174856,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196320,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -357,9 +357,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 174872,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196335,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -371,8 +371,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 174894,
+      "tid": 22764,
+      "ts": 196368,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -383,9 +383,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 174907,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196390,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -397,9 +397,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 174923,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196404,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -411,8 +411,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 174945,
+      "tid": 22764,
+      "ts": 196425,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -423,9 +423,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 174958,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196436,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -437,9 +437,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 174974,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196450,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -451,8 +451,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 174995,
+      "tid": 22764,
+      "ts": 196470,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -463,9 +463,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 175008,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196481,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -477,9 +477,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 175024,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196495,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -491,8 +491,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 175046,
+      "tid": 22764,
+      "ts": 196515,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -503,9 +503,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 175064,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196527,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -517,9 +517,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 175083,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196541,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -531,8 +531,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 175107,
+      "tid": 22764,
+      "ts": 196561,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -543,9 +543,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 175121,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196573,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -557,9 +557,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 175159,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196606,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -571,8 +571,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 175184,
+      "tid": 22764,
+      "ts": 196626,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -583,9 +583,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 175198,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196638,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -597,9 +597,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 175217,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196652,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -611,8 +611,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 175241,
+      "tid": 22764,
+      "ts": 196672,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -623,9 +623,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 175255,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196683,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -637,9 +637,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 175273,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196697,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -651,8 +651,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 175297,
+      "tid": 22764,
+      "ts": 196718,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -663,9 +663,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 175311,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196729,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -677,9 +677,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 175329,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196743,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -691,8 +691,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 175353,
+      "tid": 22764,
+      "ts": 196763,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -703,9 +703,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 175372,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196779,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -717,9 +717,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 175390,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196793,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -731,8 +731,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 175414,
+      "tid": 22764,
+      "ts": 196813,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -743,9 +743,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 175434,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196829,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -757,9 +757,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 175452,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196843,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -771,8 +771,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 175476,
+      "tid": 22764,
+      "ts": 196864,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -783,9 +783,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 175494,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196878,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -797,9 +797,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 175512,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196892,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -811,8 +811,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 175536,
+      "tid": 22764,
+      "ts": 196913,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -823,9 +823,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 175554,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196927,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -837,9 +837,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 175572,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196941,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -851,8 +851,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 175596,
+      "tid": 22764,
+      "ts": 196962,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -863,9 +863,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 175615,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196977,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -877,9 +877,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 175633,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 196991,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -891,8 +891,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 175657,
+      "tid": 22764,
+      "ts": 197012,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -903,9 +903,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 175675,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 197026,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -917,9 +917,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 175693,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 197040,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -931,9 +931,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 175710,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 197054,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -945,8 +945,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 175734,
+      "tid": 22764,
+      "ts": 197075,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -957,8 +957,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 175753,
+      "tid": 22764,
+      "ts": 197091,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -969,8 +969,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 175771,
+      "tid": 22764,
+      "ts": 197107,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -981,8 +981,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 175790,
+      "tid": 22764,
+      "ts": 197122,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -993,8 +993,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 175808,
+      "tid": 22764,
+      "ts": 197138,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -1005,8 +1005,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 175826,
+      "tid": 22764,
+      "ts": 197153,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -1017,8 +1017,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 175844,
+      "tid": 22764,
+      "ts": 197169,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -1029,8 +1029,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 175862,
+      "tid": 22764,
+      "ts": 197184,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -1041,8 +1041,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 175880,
+      "tid": 22764,
+      "ts": 197200,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -1053,8 +1053,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 175898,
+      "tid": 22764,
+      "ts": 197215,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -1065,8 +1065,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 175916,
+      "tid": 22764,
+      "ts": 197231,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -1077,8 +1077,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 175935,
+      "tid": 22764,
+      "ts": 197246,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -1089,18 +1089,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 175941,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 197252,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 175964,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 197270,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1112,9 +1112,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 175984,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 197285,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1126,8 +1126,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 176009,
+      "tid": 22764,
+      "ts": 197306,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1138,9 +1138,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176023,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 197318,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1152,9 +1152,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176042,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 197333,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1166,8 +1166,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 176109,
+      "tid": 22764,
+      "ts": 197402,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1178,9 +1178,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176124,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 197415,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1192,9 +1192,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176142,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 197430,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1206,8 +1206,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 176166,
+      "tid": 22764,
+      "ts": 197451,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1218,9 +1218,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176181,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 197462,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1232,9 +1232,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176199,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 197477,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1246,8 +1246,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 176223,
+      "tid": 22764,
+      "ts": 197497,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1258,9 +1258,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176237,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 197509,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1272,9 +1272,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176255,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 197523,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1286,8 +1286,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 176279,
+      "tid": 22764,
+      "ts": 197544,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1298,9 +1298,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176294,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 197555,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1312,9 +1312,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176312,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 197570,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1326,8 +1326,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 176336,
+      "tid": 22764,
+      "ts": 197591,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1338,9 +1338,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176350,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 197603,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1352,9 +1352,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176368,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 197617,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1366,8 +1366,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 176392,
+      "tid": 22764,
+      "ts": 197638,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1378,9 +1378,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176406,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 197650,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1392,9 +1392,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176424,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 197664,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1406,8 +1406,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 176448,
+      "tid": 22764,
+      "ts": 197685,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1418,9 +1418,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176463,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 197696,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1432,9 +1432,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176480,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 197711,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1446,8 +1446,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 176504,
+      "tid": 22764,
+      "ts": 197732,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1458,9 +1458,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176519,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 197743,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1472,9 +1472,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176537,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 197758,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1486,8 +1486,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 176560,
+      "tid": 22764,
+      "ts": 197779,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1498,9 +1498,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176575,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 197790,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1512,9 +1512,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176593,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 197805,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1526,8 +1526,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 176617,
+      "tid": 22764,
+      "ts": 197825,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1538,9 +1538,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176631,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 197837,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1552,9 +1552,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176649,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 197851,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1566,8 +1566,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 176673,
+      "tid": 22764,
+      "ts": 197872,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1578,9 +1578,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176687,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 197883,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1592,9 +1592,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176705,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 197898,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1606,8 +1606,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 176729,
+      "tid": 22764,
+      "ts": 197918,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1618,9 +1618,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176743,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 197930,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1632,9 +1632,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176761,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 197944,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1646,8 +1646,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 176785,
+      "tid": 22764,
+      "ts": 197965,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1658,9 +1658,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176800,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 197977,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1672,9 +1672,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176818,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 197991,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1686,8 +1686,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 176842,
+      "tid": 22764,
+      "ts": 198012,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1698,9 +1698,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176856,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 198023,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1712,9 +1712,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176874,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 198039,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1726,8 +1726,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 176898,
+      "tid": 22764,
+      "ts": 198060,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1738,9 +1738,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176912,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 198071,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1752,9 +1752,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176930,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 198086,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1766,8 +1766,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 176954,
+      "tid": 22764,
+      "ts": 198107,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1778,9 +1778,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176972,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 198122,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1792,9 +1792,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 176990,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 198137,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1806,8 +1806,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 177014,
+      "tid": 22764,
+      "ts": 198158,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -1818,9 +1818,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 177033,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 198175,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1832,9 +1832,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 177054,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 198189,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1846,8 +1846,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 177079,
+      "tid": 22764,
+      "ts": 198211,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -1858,9 +1858,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 177097,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 198226,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1872,9 +1872,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 177115,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 198241,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1886,8 +1886,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 177139,
+      "tid": 22764,
+      "ts": 198261,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -1898,9 +1898,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 177157,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 198276,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1912,9 +1912,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 177175,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 198291,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1926,8 +1926,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 177199,
+      "tid": 22764,
+      "ts": 198311,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -1938,9 +1938,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 177218,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 198327,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1952,9 +1952,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 177236,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 198343,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1966,8 +1966,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 177261,
+      "tid": 22764,
+      "ts": 198364,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -1978,9 +1978,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 177278,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 198384,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1992,9 +1992,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 177296,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 198423,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2006,9 +2006,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 177315,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 198441,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2020,8 +2020,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 177338,
+      "tid": 22764,
+      "ts": 198463,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -2032,8 +2032,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 177357,
+      "tid": 22764,
+      "ts": 198480,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -2044,8 +2044,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 177375,
+      "tid": 22764,
+      "ts": 198496,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -2056,8 +2056,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 177393,
+      "tid": 22764,
+      "ts": 198512,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -2068,8 +2068,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 177411,
+      "tid": 22764,
+      "ts": 198528,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -2080,8 +2080,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 177429,
+      "tid": 22764,
+      "ts": 198544,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -2092,8 +2092,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 177447,
+      "tid": 22764,
+      "ts": 198561,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -2104,8 +2104,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 177465,
+      "tid": 22764,
+      "ts": 198577,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -2116,8 +2116,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 177483,
+      "tid": 22764,
+      "ts": 198592,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -2128,8 +2128,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 177501,
+      "tid": 22764,
+      "ts": 198608,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -2140,8 +2140,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 177519,
+      "tid": 22764,
+      "ts": 198624,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -2152,8 +2152,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 177537,
+      "tid": 22764,
+      "ts": 198640,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -2164,18 +2164,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 177544,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 198647,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 177567,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 198667,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2187,9 +2187,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 177587,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 198682,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2201,8 +2201,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 177612,
+      "tid": 22764,
+      "ts": 198715,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2213,9 +2213,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 177630,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 198727,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2227,9 +2227,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 177647,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 198741,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2241,8 +2241,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 177669,
+      "tid": 22764,
+      "ts": 198761,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2253,9 +2253,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 177682,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 198773,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2267,9 +2267,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 177698,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 198787,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2281,8 +2281,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 177720,
+      "tid": 22764,
+      "ts": 198807,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2293,9 +2293,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 177733,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 198820,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2307,9 +2307,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 177749,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 198834,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2321,8 +2321,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 177840,
+      "tid": 22764,
+      "ts": 198930,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2333,9 +2333,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 177854,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 198942,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2347,9 +2347,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 177870,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 198957,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2361,8 +2361,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 177892,
+      "tid": 22764,
+      "ts": 198977,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2373,9 +2373,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 177904,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 198988,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2387,9 +2387,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 177920,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199002,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2401,8 +2401,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 177942,
+      "tid": 22764,
+      "ts": 199023,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2413,9 +2413,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 177955,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199034,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2427,9 +2427,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 177971,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199048,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2441,8 +2441,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 177993,
+      "tid": 22764,
+      "ts": 199068,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2453,9 +2453,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 178006,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199080,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2467,9 +2467,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 178022,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199094,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2481,8 +2481,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 178044,
+      "tid": 22764,
+      "ts": 199114,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2493,9 +2493,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 178061,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199125,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2507,9 +2507,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 178080,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199140,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2521,8 +2521,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 178104,
+      "tid": 22764,
+      "ts": 199160,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2533,9 +2533,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 178118,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199171,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2547,9 +2547,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 178136,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199186,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2561,8 +2561,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 178160,
+      "tid": 22764,
+      "ts": 199206,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2573,9 +2573,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 178175,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199217,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2587,9 +2587,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 178193,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199231,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2601,8 +2601,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 178217,
+      "tid": 22764,
+      "ts": 199252,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2613,9 +2613,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 178231,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199263,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2627,9 +2627,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 178249,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199277,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2641,8 +2641,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 178273,
+      "tid": 22764,
+      "ts": 199297,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2653,9 +2653,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 178287,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199309,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2667,9 +2667,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 178305,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199323,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2681,8 +2681,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 178329,
+      "tid": 22764,
+      "ts": 199345,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2693,9 +2693,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 178344,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199357,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2707,9 +2707,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 178362,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199371,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2721,8 +2721,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 178386,
+      "tid": 22764,
+      "ts": 199391,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2733,9 +2733,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 178400,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199403,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2747,9 +2747,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 178418,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199417,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2761,8 +2761,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 178442,
+      "tid": 22764,
+      "ts": 199437,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2773,9 +2773,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 178457,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199448,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2787,9 +2787,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 178475,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199462,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2801,8 +2801,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 178499,
+      "tid": 22764,
+      "ts": 199483,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2813,9 +2813,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 178513,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199494,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2827,9 +2827,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 178531,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199519,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2841,8 +2841,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 178555,
+      "tid": 22764,
+      "ts": 199540,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2853,9 +2853,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 178574,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199557,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2867,9 +2867,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 178593,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199572,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2881,8 +2881,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 178617,
+      "tid": 22764,
+      "ts": 199592,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -2893,9 +2893,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 178636,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199608,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2907,9 +2907,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 178654,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199623,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2921,8 +2921,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 178678,
+      "tid": 22764,
+      "ts": 199644,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -2933,9 +2933,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 178696,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199670,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2947,9 +2947,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 178714,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199684,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2961,8 +2961,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 178738,
+      "tid": 22764,
+      "ts": 199705,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -2973,9 +2973,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 178756,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199719,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2987,9 +2987,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 178774,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199733,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3001,8 +3001,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 178798,
+      "tid": 22764,
+      "ts": 199753,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -3013,9 +3013,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 178817,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199768,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3027,9 +3027,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 178835,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199782,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3041,8 +3041,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 178859,
+      "tid": 22764,
+      "ts": 199803,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -3053,9 +3053,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 178876,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199817,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3067,9 +3067,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 178894,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199831,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3081,9 +3081,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 178912,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 199845,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3095,8 +3095,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 178935,
+      "tid": 22764,
+      "ts": 199866,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -3107,8 +3107,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 178954,
+      "tid": 22764,
+      "ts": 199883,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -3119,8 +3119,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 178972,
+      "tid": 22764,
+      "ts": 199898,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -3131,8 +3131,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 178990,
+      "tid": 22764,
+      "ts": 199914,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -3143,8 +3143,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 179008,
+      "tid": 22764,
+      "ts": 199930,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -3155,8 +3155,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 179026,
+      "tid": 22764,
+      "ts": 199945,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -3167,8 +3167,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 179045,
+      "tid": 22764,
+      "ts": 199960,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -3179,8 +3179,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 179078,
+      "tid": 22764,
+      "ts": 199976,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -3191,8 +3191,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 179095,
+      "tid": 22764,
+      "ts": 199991,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -3203,8 +3203,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 179111,
+      "tid": 22764,
+      "ts": 200007,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -3215,8 +3215,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 179127,
+      "tid": 22764,
+      "ts": 200022,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -3227,8 +3227,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 179143,
+      "tid": 22764,
+      "ts": 200038,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -3239,18 +3239,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179149,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200043,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179170,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200062,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3262,9 +3262,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179188,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200077,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3276,8 +3276,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 179210,
+      "tid": 22764,
+      "ts": 200098,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3288,9 +3288,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179223,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200120,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3302,9 +3302,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179239,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200135,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3316,8 +3316,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 179261,
+      "tid": 22764,
+      "ts": 200155,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3328,9 +3328,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179274,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200167,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3342,9 +3342,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179290,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200181,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3356,8 +3356,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 179312,
+      "tid": 22764,
+      "ts": 200202,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3368,9 +3368,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179325,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200213,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3382,9 +3382,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179341,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200228,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3396,8 +3396,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 179364,
+      "tid": 22764,
+      "ts": 200249,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3408,9 +3408,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179376,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200261,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3422,9 +3422,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179392,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200275,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3436,8 +3436,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 179414,
+      "tid": 22764,
+      "ts": 200295,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3448,9 +3448,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179427,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200307,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3462,9 +3462,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179443,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200322,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3476,8 +3476,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 179465,
+      "tid": 22764,
+      "ts": 200344,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3488,9 +3488,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179477,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200355,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3502,9 +3502,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179494,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200370,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3516,8 +3516,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 179516,
+      "tid": 22764,
+      "ts": 200391,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3528,9 +3528,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179528,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200402,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3542,9 +3542,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179544,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200417,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3556,8 +3556,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 179566,
+      "tid": 22764,
+      "ts": 200438,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3568,9 +3568,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179579,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200449,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3582,9 +3582,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179595,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200464,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3596,8 +3596,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 179616,
+      "tid": 22764,
+      "ts": 200485,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3608,9 +3608,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179629,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200496,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3622,9 +3622,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179645,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200510,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3636,8 +3636,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 179667,
+      "tid": 22764,
+      "ts": 200531,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3648,9 +3648,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179679,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200543,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3662,9 +3662,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179696,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200557,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3676,8 +3676,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 179717,
+      "tid": 22764,
+      "ts": 200578,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3688,9 +3688,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179730,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200589,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3702,9 +3702,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179746,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200604,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3716,8 +3716,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 179768,
+      "tid": 22764,
+      "ts": 200635,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3728,9 +3728,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179780,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200647,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3742,9 +3742,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179796,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200661,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3756,8 +3756,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 179818,
+      "tid": 22764,
+      "ts": 200681,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3768,9 +3768,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179830,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200693,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3782,9 +3782,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179846,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200707,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3796,8 +3796,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 179868,
+      "tid": 22764,
+      "ts": 200739,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3808,9 +3808,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179881,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200750,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3822,9 +3822,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179897,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200765,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3836,8 +3836,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 179918,
+      "tid": 22764,
+      "ts": 200812,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3848,9 +3848,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179931,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200823,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3862,9 +3862,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179947,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200837,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3876,8 +3876,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 179969,
+      "tid": 22764,
+      "ts": 200858,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3888,9 +3888,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179982,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200870,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3902,9 +3902,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 179998,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200884,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3916,8 +3916,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 180020,
+      "tid": 22764,
+      "ts": 200905,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3928,9 +3928,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 180036,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200920,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3942,9 +3942,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 180058,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200935,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3956,8 +3956,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 180083,
+      "tid": 22764,
+      "ts": 200956,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -3968,9 +3968,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 180102,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200972,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3982,9 +3982,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 180120,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 200987,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3996,8 +3996,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 180145,
+      "tid": 22764,
+      "ts": 201008,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -4008,9 +4008,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 180163,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 201022,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4022,9 +4022,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 180181,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 201037,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4036,8 +4036,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 180205,
+      "tid": 22764,
+      "ts": 201058,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -4048,9 +4048,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 180226,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 201073,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4062,9 +4062,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 180242,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 201088,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4076,8 +4076,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 180264,
+      "tid": 22764,
+      "ts": 201109,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -4088,9 +4088,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 180281,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 201125,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4102,9 +4102,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 180298,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 201150,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4116,8 +4116,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 180320,
+      "tid": 22764,
+      "ts": 201187,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -4128,9 +4128,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 180335,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 201204,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4142,9 +4142,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 180351,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 201219,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4156,9 +4156,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 180367,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 201246,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4170,8 +4170,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 180388,
+      "tid": 22764,
+      "ts": 201289,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -4182,8 +4182,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 180405,
+      "tid": 22764,
+      "ts": 201306,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -4194,8 +4194,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 180425,
+      "tid": 22764,
+      "ts": 201322,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -4206,8 +4206,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 180450,
+      "tid": 22764,
+      "ts": 201340,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -4218,8 +4218,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 180475,
+      "tid": 22764,
+      "ts": 201356,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -4230,8 +4230,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 180499,
+      "tid": 22764,
+      "ts": 201371,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -4242,8 +4242,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 180525,
+      "tid": 22764,
+      "ts": 201398,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -4254,8 +4254,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 180545,
+      "tid": 22764,
+      "ts": 201414,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -4266,8 +4266,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 180561,
+      "tid": 22764,
+      "ts": 201430,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -4278,8 +4278,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 180589,
+      "tid": 22764,
+      "ts": 201472,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -4290,8 +4290,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 180605,
+      "tid": 22764,
+      "ts": 201488,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -4302,8 +4302,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 180632,
+      "tid": 22764,
+      "ts": 201516,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -4314,18 +4314,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 180639,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 201522,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 180661,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 201544,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4337,9 +4337,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 180678,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 201559,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4351,8 +4351,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 180701,
+      "tid": 22764,
+      "ts": 201580,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4363,9 +4363,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 180714,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 201591,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4377,9 +4377,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 180730,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 201606,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4391,8 +4391,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 180752,
+      "tid": 22764,
+      "ts": 201626,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4403,9 +4403,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 180765,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 201637,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4417,9 +4417,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 180781,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 201651,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4431,8 +4431,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 180803,
+      "tid": 22764,
+      "ts": 201671,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4443,9 +4443,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 180816,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 201683,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4457,9 +4457,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 180832,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 201697,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4471,8 +4471,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 180853,
+      "tid": 22764,
+      "ts": 201717,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4483,9 +4483,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 180866,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 201728,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4497,9 +4497,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 180882,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 201742,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4511,8 +4511,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 180904,
+      "tid": 22764,
+      "ts": 201762,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4523,9 +4523,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 180917,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 201773,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4537,9 +4537,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 180933,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 201787,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4551,8 +4551,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 180955,
+      "tid": 22764,
+      "ts": 201807,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4563,9 +4563,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 180967,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 201819,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4577,9 +4577,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 180983,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 201833,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4591,8 +4591,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 181005,
+      "tid": 22764,
+      "ts": 201853,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4603,9 +4603,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 181018,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 201864,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4617,9 +4617,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 181439,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 202191,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4631,8 +4631,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 181482,
+      "tid": 22764,
+      "ts": 202214,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4643,9 +4643,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 181496,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 202237,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4657,9 +4657,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 181512,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 202251,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4671,8 +4671,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 181534,
+      "tid": 22764,
+      "ts": 202272,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4683,9 +4683,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 181547,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 202283,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4697,9 +4697,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 181563,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 202309,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4711,8 +4711,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 181585,
+      "tid": 22764,
+      "ts": 202330,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4723,9 +4723,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 181598,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 202342,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4737,9 +4737,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 181614,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 202356,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4751,8 +4751,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 181636,
+      "tid": 22764,
+      "ts": 202376,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4763,9 +4763,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 181648,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 202387,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4777,9 +4777,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 181665,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 202414,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4791,8 +4791,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 181698,
+      "tid": 22764,
+      "ts": 202435,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4803,9 +4803,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 181711,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 202447,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4817,9 +4817,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 181738,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 202461,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4831,8 +4831,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 181772,
+      "tid": 22764,
+      "ts": 202493,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4843,9 +4843,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 181785,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 202519,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4857,9 +4857,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 181813,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 202545,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4871,8 +4871,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 181847,
+      "tid": 22764,
+      "ts": 202565,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4883,9 +4883,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 181860,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 202576,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4897,9 +4897,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 181887,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 202590,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4911,8 +4911,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 181909,
+      "tid": 22764,
+      "ts": 202610,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4923,9 +4923,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 181921,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 202621,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4937,9 +4937,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 181937,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 202635,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4951,8 +4951,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 181986,
+      "tid": 22764,
+      "ts": 202655,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4963,9 +4963,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 181999,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 202666,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4977,9 +4977,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 182027,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 202681,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4991,8 +4991,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 182082,
+      "tid": 22764,
+      "ts": 202701,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5003,9 +5003,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 182111,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 202716,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5017,9 +5017,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 182127,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 202730,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5031,8 +5031,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 182149,
+      "tid": 22764,
+      "ts": 202750,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -5043,9 +5043,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 182167,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 202766,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5057,9 +5057,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 182183,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 202780,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5071,8 +5071,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 182205,
+      "tid": 22764,
+      "ts": 202803,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -5083,9 +5083,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 182220,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 202818,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5097,9 +5097,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 182237,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 202832,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5111,8 +5111,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 182259,
+      "tid": 22764,
+      "ts": 202853,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -5123,9 +5123,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 182286,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 202868,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5137,9 +5137,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 182303,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 202883,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5151,8 +5151,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 182353,
+      "tid": 22764,
+      "ts": 202903,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -5163,9 +5163,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 182372,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 202919,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5177,9 +5177,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 182417,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 202933,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5191,8 +5191,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 182449,
+      "tid": 22764,
+      "ts": 202953,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -5203,9 +5203,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 182479,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 202967,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5217,9 +5217,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 182496,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 202982,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5231,9 +5231,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 182526,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 202995,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5245,8 +5245,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 182587,
+      "tid": 22764,
+      "ts": 203015,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -5257,8 +5257,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 182617,
+      "tid": 22764,
+      "ts": 203031,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -5269,8 +5269,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 182634,
+      "tid": 22764,
+      "ts": 203047,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -5281,8 +5281,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 182650,
+      "tid": 22764,
+      "ts": 203063,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -5293,8 +5293,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 182666,
+      "tid": 22764,
+      "ts": 203080,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -5305,8 +5305,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 182682,
+      "tid": 22764,
+      "ts": 203095,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -5317,8 +5317,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 182698,
+      "tid": 22764,
+      "ts": 203111,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -5329,8 +5329,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 182714,
+      "tid": 22764,
+      "ts": 203126,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -5341,8 +5341,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 182730,
+      "tid": 22764,
+      "ts": 203141,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -5353,8 +5353,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 182746,
+      "tid": 22764,
+      "ts": 203157,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -5365,8 +5365,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 182762,
+      "tid": 22764,
+      "ts": 203172,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -5377,8 +5377,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 182778,
+      "tid": 22764,
+      "ts": 203188,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -5389,18 +5389,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 182785,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203195,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 182806,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203213,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5412,9 +5412,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 182824,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203228,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5426,8 +5426,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 182847,
+      "tid": 22764,
+      "ts": 203249,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5438,9 +5438,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 182859,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203260,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5452,9 +5452,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 182875,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203275,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5466,8 +5466,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 182897,
+      "tid": 22764,
+      "ts": 203295,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5478,9 +5478,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 182910,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203306,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5492,9 +5492,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 182926,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203320,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5506,8 +5506,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 182948,
+      "tid": 22764,
+      "ts": 203341,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5518,9 +5518,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 182960,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203353,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5532,9 +5532,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 182976,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203367,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5546,8 +5546,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 182998,
+      "tid": 22764,
+      "ts": 203387,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5558,9 +5558,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183011,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203398,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5572,9 +5572,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183028,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203412,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5586,8 +5586,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 183054,
+      "tid": 22764,
+      "ts": 203432,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5598,9 +5598,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183067,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203443,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5612,9 +5612,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183083,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203457,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5626,8 +5626,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 183105,
+      "tid": 22764,
+      "ts": 203478,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5638,9 +5638,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183118,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203489,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5652,9 +5652,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183134,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203503,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5666,8 +5666,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 183156,
+      "tid": 22764,
+      "ts": 203523,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5678,9 +5678,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183168,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203534,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5692,9 +5692,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183185,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203548,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5706,8 +5706,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 183206,
+      "tid": 22764,
+      "ts": 203568,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5718,9 +5718,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183219,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203579,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5732,9 +5732,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183235,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203593,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5746,8 +5746,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 183257,
+      "tid": 22764,
+      "ts": 203613,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5758,9 +5758,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183269,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203624,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5772,9 +5772,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183285,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203639,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5786,8 +5786,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 183307,
+      "tid": 22764,
+      "ts": 203659,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5798,9 +5798,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183320,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203670,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5812,9 +5812,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183336,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203684,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5826,8 +5826,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 183358,
+      "tid": 22764,
+      "ts": 203704,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5838,9 +5838,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183370,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203715,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5852,9 +5852,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183386,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203729,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5866,8 +5866,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 183408,
+      "tid": 22764,
+      "ts": 203750,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5878,9 +5878,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183421,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203761,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5892,9 +5892,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183437,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203775,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5906,8 +5906,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 183459,
+      "tid": 22764,
+      "ts": 203795,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5918,9 +5918,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183472,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203806,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5932,9 +5932,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183488,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203820,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5946,8 +5946,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 183510,
+      "tid": 22764,
+      "ts": 203840,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5958,9 +5958,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183522,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203852,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5972,9 +5972,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183538,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203866,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5986,8 +5986,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 183560,
+      "tid": 22764,
+      "ts": 203887,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5998,9 +5998,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183573,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203898,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6012,9 +6012,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183589,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203912,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6026,8 +6026,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 183611,
+      "tid": 22764,
+      "ts": 203932,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6038,9 +6038,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183629,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203943,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6052,9 +6052,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183645,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203957,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6066,8 +6066,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 183667,
+      "tid": 22764,
+      "ts": 203978,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6078,9 +6078,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183683,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 203992,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6092,9 +6092,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183699,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 204007,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6106,8 +6106,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 183721,
+      "tid": 22764,
+      "ts": 204027,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -6118,9 +6118,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183738,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 204045,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6132,9 +6132,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183755,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 204059,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6146,8 +6146,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 183776,
+      "tid": 22764,
+      "ts": 204079,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -6158,9 +6158,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183792,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 204093,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6172,9 +6172,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183809,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 204108,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6186,8 +6186,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 183831,
+      "tid": 22764,
+      "ts": 204128,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -6198,9 +6198,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183846,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 204142,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6212,9 +6212,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183863,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 204156,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6226,8 +6226,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 183885,
+      "tid": 22764,
+      "ts": 204176,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -6238,9 +6238,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183901,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 204192,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6252,9 +6252,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183918,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 204206,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6266,8 +6266,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 183941,
+      "tid": 22764,
+      "ts": 204227,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -6278,9 +6278,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183958,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 204241,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6292,9 +6292,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183974,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 204255,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6306,9 +6306,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 183990,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 204269,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6320,8 +6320,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 184012,
+      "tid": 22764,
+      "ts": 204289,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -6332,8 +6332,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 184028,
+      "tid": 22764,
+      "ts": 204304,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -6344,8 +6344,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 184047,
+      "tid": 22764,
+      "ts": 204320,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -6356,8 +6356,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 184066,
+      "tid": 22764,
+      "ts": 204352,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -6368,8 +6368,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 184084,
+      "tid": 22764,
+      "ts": 204368,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -6380,8 +6380,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 184103,
+      "tid": 22764,
+      "ts": 204384,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -6392,8 +6392,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 184121,
+      "tid": 22764,
+      "ts": 204399,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -6404,8 +6404,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 184139,
+      "tid": 22764,
+      "ts": 204414,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -6416,8 +6416,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 184157,
+      "tid": 22764,
+      "ts": 204430,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -6428,8 +6428,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 184175,
+      "tid": 22764,
+      "ts": 204445,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -6440,8 +6440,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 184193,
+      "tid": 22764,
+      "ts": 204460,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -6452,8 +6452,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 184211,
+      "tid": 22764,
+      "ts": 204476,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -6464,18 +6464,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 184219,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 204482,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 184243,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 204500,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6487,9 +6487,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 184262,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 204516,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6501,8 +6501,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 184287,
+      "tid": 22764,
+      "ts": 204537,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6513,9 +6513,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 184301,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 204548,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6527,9 +6527,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 184319,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 204562,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6541,8 +6541,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 184343,
+      "tid": 22764,
+      "ts": 204583,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6553,9 +6553,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 184357,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 204594,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6567,9 +6567,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 184375,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 204608,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6581,8 +6581,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 184399,
+      "tid": 22764,
+      "ts": 204628,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6593,9 +6593,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 184414,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 204639,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6607,9 +6607,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 184432,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 204654,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6621,8 +6621,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 184456,
+      "tid": 22764,
+      "ts": 204674,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6633,9 +6633,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 184470,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 204685,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6647,9 +6647,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 184488,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 204699,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6661,8 +6661,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 184512,
+      "tid": 22764,
+      "ts": 204719,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6673,9 +6673,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 184526,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 204730,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6687,9 +6687,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 184544,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 204744,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6701,8 +6701,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 184568,
+      "tid": 22764,
+      "ts": 204765,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6713,9 +6713,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 184582,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 204776,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6727,9 +6727,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 184600,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 204790,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6741,8 +6741,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 184624,
+      "tid": 22764,
+      "ts": 204810,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6753,9 +6753,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 184639,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 204821,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6767,9 +6767,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 184657,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 204835,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6781,8 +6781,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 184681,
+      "tid": 22764,
+      "ts": 204855,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6793,9 +6793,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 184695,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 204867,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6807,9 +6807,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 184713,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 204881,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6821,8 +6821,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 184737,
+      "tid": 22764,
+      "ts": 204901,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6833,9 +6833,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 184751,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 204912,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6847,9 +6847,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 184769,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 204926,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6861,8 +6861,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 184793,
+      "tid": 22764,
+      "ts": 204946,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6873,9 +6873,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 184807,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 204957,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6887,9 +6887,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 184825,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 204971,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6901,8 +6901,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 184849,
+      "tid": 22764,
+      "ts": 204991,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6913,9 +6913,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 184863,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 205003,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6927,9 +6927,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 184881,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 205017,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6941,8 +6941,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 184905,
+      "tid": 22764,
+      "ts": 205037,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6953,9 +6953,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 184919,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 205048,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6967,9 +6967,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 184937,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 205062,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6981,8 +6981,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 184961,
+      "tid": 22764,
+      "ts": 205082,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6993,9 +6993,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 184975,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 205093,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7007,9 +7007,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 184993,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 205107,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7021,8 +7021,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 185017,
+      "tid": 22764,
+      "ts": 205127,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7033,9 +7033,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 185032,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 205138,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7047,9 +7047,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 185053,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 205152,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7061,8 +7061,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 185078,
+      "tid": 22764,
+      "ts": 205172,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7073,9 +7073,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 185092,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 205184,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7087,9 +7087,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 185110,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 205198,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7101,8 +7101,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 185135,
+      "tid": 22764,
+      "ts": 205218,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7113,9 +7113,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 185149,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 205229,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7127,9 +7127,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 185167,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 205243,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7141,8 +7141,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 185191,
+      "tid": 22764,
+      "ts": 205263,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7153,9 +7153,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 185210,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 205277,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7167,9 +7167,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 185228,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 205291,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7181,8 +7181,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 185252,
+      "tid": 22764,
+      "ts": 205312,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -7193,9 +7193,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 185270,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 205328,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7207,9 +7207,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 185288,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 205343,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7221,8 +7221,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 185313,
+      "tid": 22764,
+      "ts": 205363,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -7233,9 +7233,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 185330,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 205377,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7247,9 +7247,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 185349,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 205392,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7261,8 +7261,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 185373,
+      "tid": 22764,
+      "ts": 205412,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -7273,9 +7273,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 185392,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 205428,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7287,9 +7287,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 185411,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 205442,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7301,8 +7301,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 185435,
+      "tid": 22764,
+      "ts": 205463,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -7313,9 +7313,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 185454,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 205478,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7327,9 +7327,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 185472,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 205492,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7341,8 +7341,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 185496,
+      "tid": 22764,
+      "ts": 205512,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -7353,9 +7353,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 185513,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 205526,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7367,9 +7367,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 185531,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 205541,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7381,9 +7381,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 185549,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 205554,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7395,8 +7395,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 185572,
+      "tid": 22764,
+      "ts": 205575,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -7407,8 +7407,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 185591,
+      "tid": 22764,
+      "ts": 205590,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -7419,8 +7419,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 185609,
+      "tid": 22764,
+      "ts": 205606,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -7431,8 +7431,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 185627,
+      "tid": 22764,
+      "ts": 205621,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -7443,8 +7443,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 185646,
+      "tid": 22764,
+      "ts": 205637,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -7455,8 +7455,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 185665,
+      "tid": 22764,
+      "ts": 205652,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -7467,8 +7467,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 185684,
+      "tid": 22764,
+      "ts": 205668,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -7479,8 +7479,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 185702,
+      "tid": 22764,
+      "ts": 205683,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -7491,8 +7491,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 185720,
+      "tid": 22764,
+      "ts": 205699,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -7503,8 +7503,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 185738,
+      "tid": 22764,
+      "ts": 205714,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -7515,8 +7515,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 185756,
+      "tid": 22764,
+      "ts": 205731,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -7527,8 +7527,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 185774,
+      "tid": 22764,
+      "ts": 205747,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -7539,18 +7539,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 185780,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 205753,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 185802,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 205771,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7562,9 +7562,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 185821,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 205786,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7576,8 +7576,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 185846,
+      "tid": 22764,
+      "ts": 205808,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7588,9 +7588,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 185860,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 205819,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7602,9 +7602,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 185878,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 205833,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7616,8 +7616,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 185903,
+      "tid": 22764,
+      "ts": 205854,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7628,9 +7628,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 185917,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 205866,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7642,9 +7642,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 185935,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 205880,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7656,8 +7656,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 185959,
+      "tid": 22764,
+      "ts": 205901,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7668,9 +7668,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 185973,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 205912,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7682,9 +7682,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 185991,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 205926,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7696,8 +7696,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 186015,
+      "tid": 22764,
+      "ts": 205947,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7708,9 +7708,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186029,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 205958,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7722,9 +7722,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186050,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 205972,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7736,8 +7736,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 186075,
+      "tid": 22764,
+      "ts": 205993,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7748,9 +7748,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186089,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206004,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7762,9 +7762,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186107,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206018,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7776,8 +7776,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 186131,
+      "tid": 22764,
+      "ts": 206039,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7788,9 +7788,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186146,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206050,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7802,9 +7802,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186164,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206065,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7816,8 +7816,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 186188,
+      "tid": 22764,
+      "ts": 206086,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7828,9 +7828,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186202,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206097,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7842,9 +7842,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186220,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206111,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7856,8 +7856,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 186244,
+      "tid": 22764,
+      "ts": 206132,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7868,9 +7868,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186258,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206143,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7882,9 +7882,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186276,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206157,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7896,8 +7896,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 186301,
+      "tid": 22764,
+      "ts": 206178,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7908,9 +7908,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186315,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206189,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7922,9 +7922,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186333,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206203,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7936,8 +7936,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 186357,
+      "tid": 22764,
+      "ts": 206224,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7948,9 +7948,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186371,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206235,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7962,9 +7962,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186389,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206249,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7976,8 +7976,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 186413,
+      "tid": 22764,
+      "ts": 206270,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7988,9 +7988,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186428,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206281,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8002,9 +8002,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186446,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206296,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8016,8 +8016,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 186470,
+      "tid": 22764,
+      "ts": 206316,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -8028,9 +8028,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186486,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206329,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8042,9 +8042,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186504,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206343,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8056,8 +8056,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 186528,
+      "tid": 22764,
+      "ts": 206364,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -8068,9 +8068,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186542,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206376,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8082,9 +8082,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186561,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206390,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8096,8 +8096,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 186585,
+      "tid": 22764,
+      "ts": 206411,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -8108,9 +8108,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186599,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206422,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8122,9 +8122,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186617,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206437,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8136,8 +8136,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 186641,
+      "tid": 22764,
+      "ts": 206458,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -8148,9 +8148,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186656,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206470,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8162,9 +8162,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186674,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206484,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8176,8 +8176,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 186698,
+      "tid": 22764,
+      "ts": 206505,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -8188,9 +8188,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186712,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206516,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8202,9 +8202,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186730,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206530,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8216,8 +8216,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 186754,
+      "tid": 22764,
+      "ts": 206551,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -8228,9 +8228,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186772,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206567,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8242,9 +8242,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186790,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206581,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8256,8 +8256,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 186814,
+      "tid": 22764,
+      "ts": 206601,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -8268,9 +8268,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186833,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206616,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8282,9 +8282,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186851,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206631,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8296,8 +8296,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 186875,
+      "tid": 22764,
+      "ts": 206651,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -8308,9 +8308,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186893,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206665,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8322,9 +8322,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186911,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206679,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8336,8 +8336,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 186935,
+      "tid": 22764,
+      "ts": 206699,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -8348,9 +8348,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186952,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206713,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8362,9 +8362,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 186970,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206728,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8376,8 +8376,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 186995,
+      "tid": 22764,
+      "ts": 206748,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -8388,9 +8388,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 187014,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206763,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8402,9 +8402,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 187033,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206777,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8416,8 +8416,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 187060,
+      "tid": 22764,
+      "ts": 206798,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -8428,9 +8428,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 187078,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206812,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8442,9 +8442,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 187096,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206826,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8456,9 +8456,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 187114,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 206840,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8470,8 +8470,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 187138,
+      "tid": 22764,
+      "ts": 206860,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -8482,8 +8482,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 187156,
+      "tid": 22764,
+      "ts": 206876,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -8494,8 +8494,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 187174,
+      "tid": 22764,
+      "ts": 206891,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -8506,8 +8506,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 187192,
+      "tid": 22764,
+      "ts": 206907,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -8518,8 +8518,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 187211,
+      "tid": 22764,
+      "ts": 206922,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -8530,8 +8530,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 187229,
+      "tid": 22764,
+      "ts": 206938,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -8542,8 +8542,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 187247,
+      "tid": 22764,
+      "ts": 206953,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -8554,8 +8554,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 187265,
+      "tid": 22764,
+      "ts": 206969,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -8566,8 +8566,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 187283,
+      "tid": 22764,
+      "ts": 206984,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -8578,8 +8578,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 187301,
+      "tid": 22764,
+      "ts": 207000,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -8590,8 +8590,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 187319,
+      "tid": 22764,
+      "ts": 207015,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -8602,8 +8602,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 187337,
+      "tid": 22764,
+      "ts": 207030,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -8614,13 +8614,13 @@
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 187374,
+      "tid": 22764,
+      "ts": 207066,
       "pid": "GPGMM",
       "args": {
         "Flags": 0,
         "RecordOptions": {
-          "Flags": 6
+          "Flags": 3
         },
         "IsUMA": 1,
         "ResourceHeapTier": 2,
@@ -8635,8 +8635,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 187435,
+      "tid": 22764,
+      "ts": 207126,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -8666,9 +8666,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 187451,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 207141,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8680,18 +8680,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 187861,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 207575,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 187896,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 207607,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8706,9 +8706,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 187916,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 207626,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8723,9 +8723,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 187926,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 207635,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8737,9 +8737,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 187945,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 207653,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8754,9 +8754,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 188029,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 207733,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8771,18 +8771,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacd3690",
-      "tid": 16484,
-      "ts": 188032,
+      "id": "0x15aff2ca390",
+      "tid": 22764,
+      "ts": 207736,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacd3690",
-      "tid": 16484,
-      "ts": 188050,
+      "id": "0x15aff2ca390",
+      "tid": 22764,
+      "ts": 207750,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8791,7 +8791,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacc9a50"
+            "id_ref": "0x15aff2ce010"
           }
         }
       }
@@ -8800,8 +8800,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 188170,
+      "tid": 22764,
+      "ts": 207840,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -8831,9 +8831,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 188193,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 207861,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8848,9 +8848,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 188267,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 207935,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8865,18 +8865,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacd3740",
-      "tid": 16484,
-      "ts": 188269,
+      "id": "0x15aff2cb2b0",
+      "tid": 22764,
+      "ts": 207938,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacd3740",
-      "tid": 16484,
-      "ts": 188284,
+      "id": "0x15aff2cb2b0",
+      "tid": 22764,
+      "ts": 207952,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8885,7 +8885,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacc9a50"
+            "id_ref": "0x15aff2ce010"
           }
         }
       }
@@ -8894,8 +8894,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 188366,
+      "tid": 22764,
+      "ts": 208014,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -8925,9 +8925,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 188387,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 208034,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8942,9 +8942,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 188460,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 208106,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8959,18 +8959,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacd37f0",
-      "tid": 16484,
-      "ts": 188463,
+      "id": "0x15aff2ca910",
+      "tid": 22764,
+      "ts": 208109,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacd37f0",
-      "tid": 16484,
-      "ts": 188477,
+      "id": "0x15aff2ca910",
+      "tid": 22764,
+      "ts": 208123,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8979,7 +8979,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacc9a50"
+            "id_ref": "0x15aff2ce010"
           }
         }
       }
@@ -8988,8 +8988,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 188581,
+      "tid": 22764,
+      "ts": 208206,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -9027,8 +9027,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 188619,
+      "tid": 22764,
+      "ts": 208241,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8323072 vs 4194304 bytes).",
@@ -9039,8 +9039,8 @@
       "name": "ResourceAllocator.TryAllocateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 188633,
+      "tid": 22764,
+      "ts": 208255,
       "pid": "GPGMM",
       "args": {
         "Description": "Resource memory could not be allocated.",
@@ -9048,37 +9048,25 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 188650,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Heap size is not a multiple of the alignment (8323072 vs 4194304 bytes).",
-        "ID": 2
-      }
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacca350",
-      "tid": 16484,
-      "ts": 189267,
+      "id": "0x15aff2ce490",
+      "tid": 22764,
+      "ts": 208807,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca350",
-      "tid": 16484,
-      "ts": 189286,
+      "id": "0x15aff2ce490",
+      "tid": 22764,
+      "ts": 208827,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "Size": 8323072,
+          "Size": 8388608,
           "IsResident": 0,
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0
@@ -9089,13 +9077,13 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca350",
-      "tid": 16484,
-      "ts": 189304,
+      "id": "0x15aff2ce490",
+      "tid": 22764,
+      "ts": 208843,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "Size": 8323072,
+          "Size": 8388608,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0
@@ -9106,13 +9094,13 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca350",
-      "tid": 16484,
-      "ts": 189319,
+      "id": "0x15aff2ce490",
+      "tid": 22764,
+      "ts": 208857,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "Size": 8323072,
+          "Size": 8388608,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0
@@ -9123,13 +9111,13 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca350",
-      "tid": 16484,
-      "ts": 189397,
+      "id": "0x15aff2ce490",
+      "tid": 22764,
+      "ts": 208935,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "Size": 8323072,
+          "Size": 8388608,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0
@@ -9140,27 +9128,27 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacd4240",
-      "tid": 16484,
-      "ts": 189400,
+      "id": "0x15aff2caa70",
+      "tid": 22764,
+      "ts": 208937,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacd4240",
-      "tid": 16484,
-      "ts": 189415,
+      "id": "0x15aff2caa70",
+      "tid": 22764,
+      "ts": 208952,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "Size": 8323072,
+          "Size": 8388608,
           "HeapOffset": 0,
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x22abacca350"
+            "id_ref": "0x15aff2ce490"
           }
         }
       }
@@ -9169,8 +9157,20 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 189520,
+      "tid": 22764,
+      "ts": 208969,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Resource allocation size is larger then the resource size (8388608 vs 8323072 bytes).",
+        "ID": 4
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 209056,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -9200,9 +9200,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 189538,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 209072,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9214,18 +9214,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacca470",
-      "tid": 16484,
-      "ts": 190584,
+      "id": "0x15aff2cd9e0",
+      "tid": 22764,
+      "ts": 210175,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca470",
-      "tid": 16484,
-      "ts": 190603,
+      "id": "0x15aff2cd9e0",
+      "tid": 22764,
+      "ts": 210195,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9240,9 +9240,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca470",
-      "tid": 16484,
-      "ts": 190621,
+      "id": "0x15aff2cd9e0",
+      "tid": 22764,
+      "ts": 210211,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9257,9 +9257,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 190631,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 210220,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9271,9 +9271,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca470",
-      "tid": 16484,
-      "ts": 190650,
+      "id": "0x15aff2cd9e0",
+      "tid": 22764,
+      "ts": 210237,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9288,9 +9288,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca470",
-      "tid": 16484,
-      "ts": 190720,
+      "id": "0x15aff2cd9e0",
+      "tid": 22764,
+      "ts": 210321,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9305,18 +9305,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacdc5e0",
-      "tid": 16484,
-      "ts": 190723,
+      "id": "0x15aff2caf40",
+      "tid": 22764,
+      "ts": 210324,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacdc5e0",
-      "tid": 16484,
-      "ts": 190738,
+      "id": "0x15aff2caf40",
+      "tid": 22764,
+      "ts": 210339,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9325,7 +9325,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacca470"
+            "id_ref": "0x15aff2cd9e0"
           }
         }
       }
@@ -9334,8 +9334,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 190852,
+      "tid": 22764,
+      "ts": 210423,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -9365,9 +9365,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca470",
-      "tid": 16484,
-      "ts": 190874,
+      "id": "0x15aff2cd9e0",
+      "tid": 22764,
+      "ts": 210444,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9382,9 +9382,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca470",
-      "tid": 16484,
-      "ts": 190943,
+      "id": "0x15aff2cd9e0",
+      "tid": 22764,
+      "ts": 210515,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9399,18 +9399,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacdbb90",
-      "tid": 16484,
-      "ts": 190946,
+      "id": "0x15aff2c01f0",
+      "tid": 22764,
+      "ts": 210518,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacdbb90",
-      "tid": 16484,
-      "ts": 190960,
+      "id": "0x15aff2c01f0",
+      "tid": 22764,
+      "ts": 210532,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9419,7 +9419,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacca470"
+            "id_ref": "0x15aff2cd9e0"
           }
         }
       }
@@ -9428,8 +9428,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 191044,
+      "tid": 22764,
+      "ts": 210599,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -9459,9 +9459,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 191065,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 210618,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9476,9 +9476,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 191134,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 210689,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9493,18 +9493,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacda9b0",
-      "tid": 16484,
-      "ts": 191137,
+      "id": "0x15aff2d71a0",
+      "tid": 22764,
+      "ts": 210692,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacda9b0",
-      "tid": 16484,
-      "ts": 191151,
+      "id": "0x15aff2d71a0",
+      "tid": 22764,
+      "ts": 210706,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9513,7 +9513,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacc9a50"
+            "id_ref": "0x15aff2ce010"
           }
         }
       }
@@ -9522,8 +9522,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 191232,
+      "tid": 22764,
+      "ts": 210767,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -9553,9 +9553,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 191253,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 210785,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9570,9 +9570,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 191321,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 210854,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9587,18 +9587,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacda850",
-      "tid": 16484,
-      "ts": 191324,
+      "id": "0x15aff2d6750",
+      "tid": 22764,
+      "ts": 210857,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacda850",
-      "tid": 16484,
-      "ts": 191339,
+      "id": "0x15aff2d6750",
+      "tid": 22764,
+      "ts": 210870,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9607,7 +9607,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacc9a50"
+            "id_ref": "0x15aff2ce010"
           }
         }
       }
@@ -9616,8 +9616,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 191421,
+      "tid": 22764,
+      "ts": 210933,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -9647,9 +9647,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca470",
-      "tid": 16484,
-      "ts": 191441,
+      "id": "0x15aff2cd9e0",
+      "tid": 22764,
+      "ts": 210952,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9664,9 +9664,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca470",
-      "tid": 16484,
-      "ts": 191509,
+      "id": "0x15aff2cd9e0",
+      "tid": 22764,
+      "ts": 211021,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9681,18 +9681,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacdac70",
-      "tid": 16484,
-      "ts": 191512,
+      "id": "0x15aff2d7460",
+      "tid": 22764,
+      "ts": 211023,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacdac70",
-      "tid": 16484,
-      "ts": 191526,
+      "id": "0x15aff2d7460",
+      "tid": 22764,
+      "ts": 211037,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9701,7 +9701,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacca470"
+            "id_ref": "0x15aff2cd9e0"
           }
         }
       }
@@ -9710,8 +9710,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 191614,
+      "tid": 22764,
+      "ts": 211099,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -9741,9 +9741,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca470",
-      "tid": 16484,
-      "ts": 191634,
+      "id": "0x15aff2cd9e0",
+      "tid": 22764,
+      "ts": 211118,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9758,9 +9758,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca470",
-      "tid": 16484,
-      "ts": 191704,
+      "id": "0x15aff2cd9e0",
+      "tid": 22764,
+      "ts": 211187,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9775,18 +9775,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacdaa60",
-      "tid": 16484,
-      "ts": 191706,
+      "id": "0x15aff2d6960",
+      "tid": 22764,
+      "ts": 211190,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacdaa60",
-      "tid": 16484,
-      "ts": 191721,
+      "id": "0x15aff2d6960",
+      "tid": 22764,
+      "ts": 211204,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9795,7 +9795,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacca470"
+            "id_ref": "0x15aff2cd9e0"
           }
         }
       }
@@ -9804,8 +9804,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 191799,
+      "tid": 22764,
+      "ts": 211265,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -9835,9 +9835,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 191819,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 211283,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9852,9 +9852,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 191886,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 211364,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9869,18 +9869,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacdafe0",
-      "tid": 16484,
-      "ts": 191889,
+      "id": "0x15aff2d5db0",
+      "tid": 22764,
+      "ts": 211366,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacdafe0",
-      "tid": 16484,
-      "ts": 191904,
+      "id": "0x15aff2d5db0",
+      "tid": 22764,
+      "ts": 211391,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9889,7 +9889,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacc9a50"
+            "id_ref": "0x15aff2ce010"
           }
         }
       }
@@ -9898,8 +9898,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 191981,
+      "tid": 22764,
+      "ts": 211451,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -9929,9 +9929,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 192000,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 211470,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9946,9 +9946,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 192068,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 211538,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9963,18 +9963,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacdb090",
-      "tid": 16484,
-      "ts": 192071,
+      "id": "0x15aff2d65f0",
+      "tid": 22764,
+      "ts": 211541,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacdb090",
-      "tid": 16484,
-      "ts": 192085,
+      "id": "0x15aff2d65f0",
+      "tid": 22764,
+      "ts": 211554,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9983,7 +9983,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacc9a50"
+            "id_ref": "0x15aff2ce010"
           }
         }
       }
@@ -9992,8 +9992,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 192171,
+      "tid": 22764,
+      "ts": 211621,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -10023,9 +10023,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 192185,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 211635,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10037,18 +10037,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacca620",
-      "tid": 16484,
-      "ts": 193200,
+      "id": "0x15aff2ce880",
+      "tid": 22764,
+      "ts": 212809,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca620",
-      "tid": 16484,
-      "ts": 193220,
+      "id": "0x15aff2ce880",
+      "tid": 22764,
+      "ts": 212829,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10063,9 +10063,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca620",
-      "tid": 16484,
-      "ts": 193238,
+      "id": "0x15aff2ce880",
+      "tid": 22764,
+      "ts": 212846,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10080,9 +10080,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 193248,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 212855,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10094,9 +10094,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca620",
-      "tid": 16484,
-      "ts": 193267,
+      "id": "0x15aff2ce880",
+      "tid": 22764,
+      "ts": 212873,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10111,9 +10111,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca620",
-      "tid": 16484,
-      "ts": 193338,
+      "id": "0x15aff2ce880",
+      "tid": 22764,
+      "ts": 212945,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10128,18 +10128,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacdbe50",
-      "tid": 16484,
-      "ts": 193341,
+      "id": "0x15aff2d7040",
+      "tid": 22764,
+      "ts": 212948,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacdbe50",
-      "tid": 16484,
-      "ts": 193356,
+      "id": "0x15aff2d7040",
+      "tid": 22764,
+      "ts": 212962,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10148,7 +10148,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacca620"
+            "id_ref": "0x15aff2ce880"
           }
         }
       }
@@ -10157,8 +10157,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 193467,
+      "tid": 22764,
+      "ts": 213040,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -10188,9 +10188,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca470",
-      "tid": 16484,
-      "ts": 193487,
+      "id": "0x15aff2cd9e0",
+      "tid": 22764,
+      "ts": 213060,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10205,9 +10205,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca470",
-      "tid": 16484,
-      "ts": 193558,
+      "id": "0x15aff2cd9e0",
+      "tid": 22764,
+      "ts": 213129,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10222,18 +10222,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacdc3d0",
-      "tid": 16484,
-      "ts": 193560,
+      "id": "0x15aff2d6f90",
+      "tid": 22764,
+      "ts": 213132,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacdc3d0",
-      "tid": 16484,
-      "ts": 193591,
+      "id": "0x15aff2d6f90",
+      "tid": 22764,
+      "ts": 213145,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10242,7 +10242,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacca470"
+            "id_ref": "0x15aff2cd9e0"
           }
         }
       }
@@ -10251,8 +10251,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 193672,
+      "tid": 22764,
+      "ts": 213206,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -10282,9 +10282,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 193688,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 213218,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10296,18 +10296,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacebb00",
-      "tid": 16484,
-      "ts": 194708,
+      "id": "0x15aff2ceac0",
+      "tid": 22764,
+      "ts": 214242,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacebb00",
-      "tid": 16484,
-      "ts": 194728,
+      "id": "0x15aff2ceac0",
+      "tid": 22764,
+      "ts": 214261,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10322,9 +10322,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacebb00",
-      "tid": 16484,
-      "ts": 194744,
+      "id": "0x15aff2ceac0",
+      "tid": 22764,
+      "ts": 214278,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10339,9 +10339,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 194754,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 214287,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10353,9 +10353,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacebb00",
-      "tid": 16484,
-      "ts": 194772,
+      "id": "0x15aff2ceac0",
+      "tid": 22764,
+      "ts": 214305,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10370,9 +10370,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacebb00",
-      "tid": 16484,
-      "ts": 194841,
+      "id": "0x15aff2ceac0",
+      "tid": 22764,
+      "ts": 214395,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10387,18 +10387,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacdb6c0",
-      "tid": 16484,
-      "ts": 194844,
+      "id": "0x15aff2d5830",
+      "tid": 22764,
+      "ts": 214398,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacdb6c0",
-      "tid": 16484,
-      "ts": 194859,
+      "id": "0x15aff2d5830",
+      "tid": 22764,
+      "ts": 214412,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10407,7 +10407,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacebb00"
+            "id_ref": "0x15aff2ceac0"
           }
         }
       }
@@ -10416,8 +10416,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 194970,
+      "tid": 22764,
+      "ts": 214498,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -10447,9 +10447,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 194990,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 214518,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10464,9 +10464,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 195059,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 214591,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10481,18 +10481,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacdab10",
-      "tid": 16484,
-      "ts": 195062,
+      "id": "0x15aff2d6cd0",
+      "tid": 22764,
+      "ts": 214594,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacdab10",
-      "tid": 16484,
-      "ts": 195076,
+      "id": "0x15aff2d6cd0",
+      "tid": 22764,
+      "ts": 214609,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10501,7 +10501,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacc9a50"
+            "id_ref": "0x15aff2ce010"
           }
         }
       }
@@ -10510,8 +10510,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 195156,
+      "tid": 22764,
+      "ts": 214682,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -10541,9 +10541,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca620",
-      "tid": 16484,
-      "ts": 195175,
+      "id": "0x15aff2ce880",
+      "tid": 22764,
+      "ts": 214702,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10558,9 +10558,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca620",
-      "tid": 16484,
-      "ts": 195244,
+      "id": "0x15aff2ce880",
+      "tid": 22764,
+      "ts": 214776,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10575,18 +10575,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacdb8d0",
-      "tid": 16484,
-      "ts": 195247,
+      "id": "0x15aff2d5e60",
+      "tid": 22764,
+      "ts": 214779,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacdb8d0",
-      "tid": 16484,
-      "ts": 195262,
+      "id": "0x15aff2d5e60",
+      "tid": 22764,
+      "ts": 214793,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10595,7 +10595,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacca620"
+            "id_ref": "0x15aff2ce880"
           }
         }
       }
@@ -10604,8 +10604,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 195340,
+      "tid": 22764,
+      "ts": 214858,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -10635,9 +10635,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca470",
-      "tid": 16484,
-      "ts": 195360,
+      "id": "0x15aff2cd9e0",
+      "tid": 22764,
+      "ts": 214877,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10652,9 +10652,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca470",
-      "tid": 16484,
-      "ts": 195433,
+      "id": "0x15aff2cd9e0",
+      "tid": 22764,
+      "ts": 214951,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10669,18 +10669,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacefe00",
-      "tid": 16484,
-      "ts": 195435,
+      "id": "0x15aff2d5f10",
+      "tid": 22764,
+      "ts": 214954,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacefe00",
-      "tid": 16484,
-      "ts": 195450,
+      "id": "0x15aff2d5f10",
+      "tid": 22764,
+      "ts": 214968,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10689,7 +10689,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacca470"
+            "id_ref": "0x15aff2cd9e0"
           }
         }
       }
@@ -10698,8 +10698,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 195528,
+      "tid": 22764,
+      "ts": 215031,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -10729,9 +10729,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacebb00",
-      "tid": 16484,
-      "ts": 195548,
+      "id": "0x15aff2ceac0",
+      "tid": 22764,
+      "ts": 215051,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10746,9 +10746,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacebb00",
-      "tid": 16484,
-      "ts": 195622,
+      "id": "0x15aff2ceac0",
+      "tid": 22764,
+      "ts": 215122,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10763,18 +10763,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacee8b0",
-      "tid": 16484,
-      "ts": 195625,
+      "id": "0x15aff2d6330",
+      "tid": 22764,
+      "ts": 215125,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacee8b0",
-      "tid": 16484,
-      "ts": 196139,
+      "id": "0x15aff2d6330",
+      "tid": 22764,
+      "ts": 215705,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10783,7 +10783,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacebb00"
+            "id_ref": "0x15aff2ceac0"
           }
         }
       }
@@ -10792,8 +10792,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 196220,
+      "tid": 22764,
+      "ts": 215769,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -10823,9 +10823,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 196240,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 215789,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10840,9 +10840,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 196311,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 215866,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10857,18 +10857,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacef9e0",
-      "tid": 16484,
-      "ts": 196314,
+      "id": "0x15aff2ef510",
+      "tid": 22764,
+      "ts": 215868,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacef9e0",
-      "tid": 16484,
-      "ts": 196328,
+      "id": "0x15aff2ef510",
+      "tid": 22764,
+      "ts": 215882,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10877,7 +10877,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacc9a50"
+            "id_ref": "0x15aff2ce010"
           }
         }
       }
@@ -10886,8 +10886,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 196406,
+      "tid": 22764,
+      "ts": 215944,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -10917,9 +10917,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca470",
-      "tid": 16484,
-      "ts": 196426,
+      "id": "0x15aff2cd9e0",
+      "tid": 22764,
+      "ts": 215963,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10934,9 +10934,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca470",
-      "tid": 16484,
-      "ts": 196494,
+      "id": "0x15aff2cd9e0",
+      "tid": 22764,
+      "ts": 216034,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10951,18 +10951,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abaceeac0",
-      "tid": 16484,
-      "ts": 196497,
+      "id": "0x15aff2eecd0",
+      "tid": 22764,
+      "ts": 216037,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abaceeac0",
-      "tid": 16484,
-      "ts": 196511,
+      "id": "0x15aff2eecd0",
+      "tid": 22764,
+      "ts": 216050,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10971,7 +10971,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacca470"
+            "id_ref": "0x15aff2cd9e0"
           }
         }
       }
@@ -10980,8 +10980,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 196592,
+      "tid": 22764,
+      "ts": 216112,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -11011,9 +11011,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca470",
-      "tid": 16484,
-      "ts": 196611,
+      "id": "0x15aff2cd9e0",
+      "tid": 22764,
+      "ts": 216131,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11028,9 +11028,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca470",
-      "tid": 16484,
-      "ts": 196679,
+      "id": "0x15aff2cd9e0",
+      "tid": 22764,
+      "ts": 216212,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11045,18 +11045,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abaceed80",
-      "tid": 16484,
-      "ts": 196682,
+      "id": "0x15aff2ef880",
+      "tid": 22764,
+      "ts": 216214,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abaceed80",
-      "tid": 16484,
-      "ts": 196697,
+      "id": "0x15aff2ef880",
+      "tid": 22764,
+      "ts": 216228,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11065,7 +11065,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacca470"
+            "id_ref": "0x15aff2cd9e0"
           }
         }
       }
@@ -11074,8 +11074,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 196775,
+      "tid": 22764,
+      "ts": 216291,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -11105,9 +11105,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 196794,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 216310,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11122,9 +11122,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 196863,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 216383,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11139,18 +11139,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacf02d0",
-      "tid": 16484,
-      "ts": 196865,
+      "id": "0x15aff2f0590",
+      "tid": 22764,
+      "ts": 216386,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacf02d0",
-      "tid": 16484,
-      "ts": 196880,
+      "id": "0x15aff2f0590",
+      "tid": 22764,
+      "ts": 216400,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11159,7 +11159,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacc9a50"
+            "id_ref": "0x15aff2ce010"
           }
         }
       }
@@ -11168,8 +11168,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 196958,
+      "tid": 22764,
+      "ts": 216464,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -11199,9 +11199,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 196978,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 216484,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11216,9 +11216,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 197045,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 216554,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11233,18 +11233,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacefb40",
-      "tid": 16484,
-      "ts": 197048,
+      "id": "0x15aff2ee960",
+      "tid": 22764,
+      "ts": 216557,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacefb40",
-      "tid": 16484,
-      "ts": 197062,
+      "id": "0x15aff2ee960",
+      "tid": 22764,
+      "ts": 216571,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11253,7 +11253,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacc9a50"
+            "id_ref": "0x15aff2ce010"
           }
         }
       }
@@ -11262,8 +11262,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 197147,
+      "tid": 22764,
+      "ts": 216642,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -11293,9 +11293,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca470",
-      "tid": 16484,
-      "ts": 197166,
+      "id": "0x15aff2cd9e0",
+      "tid": 22764,
+      "ts": 216661,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11310,9 +11310,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca470",
-      "tid": 16484,
-      "ts": 197247,
+      "id": "0x15aff2cd9e0",
+      "tid": 22764,
+      "ts": 216742,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11327,18 +11327,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacf0430",
-      "tid": 16484,
-      "ts": 197249,
+      "id": "0x15aff2eff60",
+      "tid": 22764,
+      "ts": 216745,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacf0430",
-      "tid": 16484,
-      "ts": 197264,
+      "id": "0x15aff2eff60",
+      "tid": 22764,
+      "ts": 216758,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11347,7 +11347,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacca470"
+            "id_ref": "0x15aff2cd9e0"
           }
         }
       }
@@ -11356,8 +11356,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 197345,
+      "tid": 22764,
+      "ts": 216832,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -11387,9 +11387,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca470",
-      "tid": 16484,
-      "ts": 197365,
+      "id": "0x15aff2cd9e0",
+      "tid": 22764,
+      "ts": 216851,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11404,9 +11404,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca470",
-      "tid": 16484,
-      "ts": 197435,
+      "id": "0x15aff2cd9e0",
+      "tid": 22764,
+      "ts": 216948,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11421,18 +11421,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacf0640",
-      "tid": 16484,
-      "ts": 197438,
+      "id": "0x15aff2ef250",
+      "tid": 22764,
+      "ts": 216951,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacf0640",
-      "tid": 16484,
-      "ts": 197453,
+      "id": "0x15aff2ef250",
+      "tid": 22764,
+      "ts": 216965,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11441,7 +11441,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacca470"
+            "id_ref": "0x15aff2cd9e0"
           }
         }
       }
@@ -11450,8 +11450,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 197533,
+      "tid": 22764,
+      "ts": 217027,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -11481,9 +11481,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 197553,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 217047,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11498,9 +11498,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 197679,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 217120,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11515,18 +11515,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacef250",
-      "tid": 16484,
-      "ts": 197682,
+      "id": "0x15aff2ee8b0",
+      "tid": 22764,
+      "ts": 217123,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacef250",
-      "tid": 16484,
-      "ts": 197699,
+      "id": "0x15aff2ee8b0",
+      "tid": 22764,
+      "ts": 217137,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11535,7 +11535,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacc9a50"
+            "id_ref": "0x15aff2ce010"
           }
         }
       }
@@ -11544,8 +11544,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 197802,
+      "tid": 22764,
+      "ts": 217200,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -11575,9 +11575,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 197836,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 217231,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11592,9 +11592,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 197932,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 217336,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11609,18 +11609,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacef1a0",
-      "tid": 16484,
-      "ts": 197934,
+      "id": "0x15aff2ee750",
+      "tid": 22764,
+      "ts": 217340,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacef1a0",
-      "tid": 16484,
-      "ts": 197960,
+      "id": "0x15aff2ee750",
+      "tid": 22764,
+      "ts": 217369,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11629,7 +11629,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacc9a50"
+            "id_ref": "0x15aff2ce010"
           }
         }
       }
@@ -11638,8 +11638,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 198052,
+      "tid": 22764,
+      "ts": 217437,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -11669,9 +11669,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca470",
-      "tid": 16484,
-      "ts": 198072,
+      "id": "0x15aff2cd9e0",
+      "tid": 22764,
+      "ts": 217470,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11686,9 +11686,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacca470",
-      "tid": 16484,
-      "ts": 198141,
+      "id": "0x15aff2cd9e0",
+      "tid": 22764,
+      "ts": 217555,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11703,18 +11703,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacef880",
-      "tid": 16484,
-      "ts": 198144,
+      "id": "0x15aff2ef670",
+      "tid": 22764,
+      "ts": 217558,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacef880",
-      "tid": 16484,
-      "ts": 198158,
+      "id": "0x15aff2ef670",
+      "tid": 22764,
+      "ts": 217572,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11723,7 +11723,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacca470"
+            "id_ref": "0x15aff2cd9e0"
           }
         }
       }
@@ -11732,8 +11732,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 198238,
+      "tid": 22764,
+      "ts": 217633,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -11763,9 +11763,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 198258,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 217653,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11780,9 +11780,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 198326,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 217722,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11797,18 +11797,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacef720",
-      "tid": 16484,
-      "ts": 198329,
+      "id": "0x15aff2efe00",
+      "tid": 22764,
+      "ts": 217725,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacef720",
-      "tid": 16484,
-      "ts": 198343,
+      "id": "0x15aff2efe00",
+      "tid": 22764,
+      "ts": 217739,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11817,7 +11817,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacc9a50"
+            "id_ref": "0x15aff2ce010"
           }
         }
       }
@@ -11826,63 +11826,63 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacda9b0",
-      "tid": 16484,
-      "ts": 198462,
+      "id": "0x15aff2d71a0",
+      "tid": 22764,
+      "ts": 217829,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacda850",
-      "tid": 16484,
-      "ts": 198539,
+      "id": "0x15aff2d6750",
+      "tid": 22764,
+      "ts": 217885,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacdafe0",
-      "tid": 16484,
-      "ts": 198615,
+      "id": "0x15aff2d5db0",
+      "tid": 22764,
+      "ts": 217950,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacdb090",
-      "tid": 16484,
-      "ts": 198686,
+      "id": "0x15aff2d65f0",
+      "tid": 22764,
+      "ts": 218042,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacdb6c0",
-      "tid": 16484,
-      "ts": 198757,
+      "id": "0x15aff2d5830",
+      "tid": 22764,
+      "ts": 218094,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacdab10",
-      "tid": 16484,
-      "ts": 198829,
+      "id": "0x15aff2d6cd0",
+      "tid": 22764,
+      "ts": 218146,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 198884,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 218176,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11894,80 +11894,80 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacebb00",
-      "tid": 16484,
-      "ts": 198887,
+      "id": "0x15aff2ceac0",
+      "tid": 22764,
+      "ts": 218179,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacee8b0",
-      "tid": 16484,
-      "ts": 199100,
+      "id": "0x15aff2d6330",
+      "tid": 22764,
+      "ts": 218392,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacef9e0",
-      "tid": 16484,
-      "ts": 199180,
+      "id": "0x15aff2ef510",
+      "tid": 22764,
+      "ts": 218454,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacf02d0",
-      "tid": 16484,
-      "ts": 199253,
+      "id": "0x15aff2f0590",
+      "tid": 22764,
+      "ts": 218507,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacefb40",
-      "tid": 16484,
-      "ts": 199335,
+      "id": "0x15aff2ee960",
+      "tid": 22764,
+      "ts": 218558,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacef250",
-      "tid": 16484,
-      "ts": 199408,
+      "id": "0x15aff2ee8b0",
+      "tid": 22764,
+      "ts": 218609,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacef1a0",
-      "tid": 16484,
-      "ts": 199481,
+      "id": "0x15aff2ee750",
+      "tid": 22764,
+      "ts": 218660,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacef720",
-      "tid": 16484,
-      "ts": 199554,
+      "id": "0x15aff2efe00",
+      "tid": 22764,
+      "ts": 218710,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 199633,
+      "tid": 22764,
+      "ts": 218759,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -11997,9 +11997,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 199667,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 218781,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12011,18 +12011,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abaceae10",
-      "tid": 16484,
-      "ts": 200016,
+      "id": "0x15aff2e9200",
+      "tid": 22764,
+      "ts": 219143,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abaceae10",
-      "tid": 16484,
-      "ts": 200046,
+      "id": "0x15aff2e9200",
+      "tid": 22764,
+      "ts": 219163,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12037,9 +12037,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abaceae10",
-      "tid": 16484,
-      "ts": 200064,
+      "id": "0x15aff2e9200",
+      "tid": 22764,
+      "ts": 219180,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12054,9 +12054,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 200073,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 219189,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12068,9 +12068,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abaceae10",
-      "tid": 16484,
-      "ts": 200092,
+      "id": "0x15aff2e9200",
+      "tid": 22764,
+      "ts": 219206,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12085,9 +12085,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abaceae10",
-      "tid": 16484,
-      "ts": 200184,
+      "id": "0x15aff2e9200",
+      "tid": 22764,
+      "ts": 219277,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12102,18 +12102,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacef250",
-      "tid": 16484,
-      "ts": 200187,
+      "id": "0x15aff2f0170",
+      "tid": 22764,
+      "ts": 219280,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacef250",
-      "tid": 16484,
-      "ts": 200203,
+      "id": "0x15aff2f0170",
+      "tid": 22764,
+      "ts": 219294,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12122,7 +12122,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abaceae10"
+            "id_ref": "0x15aff2e9200"
           }
         }
       }
@@ -12131,8 +12131,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 200353,
+      "tid": 22764,
+      "ts": 219389,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -12162,8 +12162,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 200386,
+      "tid": 22764,
+      "ts": 219409,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (12451840 vs 4194304 bytes).",
@@ -12174,8 +12174,8 @@
       "name": "ResourceAllocator.TryAllocateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 200400,
+      "tid": 22764,
+      "ts": 219423,
       "pid": "GPGMM",
       "args": {
         "Description": "Resource memory could not be allocated.",
@@ -12183,37 +12183,25 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 200428,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Heap size is not a multiple of the alignment (12451840 vs 4194304 bytes).",
-        "ID": 2
-      }
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abaceba70",
-      "tid": 16484,
-      "ts": 203411,
+      "id": "0x15aff2e79d0",
+      "tid": 22764,
+      "ts": 222344,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abaceba70",
-      "tid": 16484,
-      "ts": 203431,
+      "id": "0x15aff2e79d0",
+      "tid": 22764,
+      "ts": 222362,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "Size": 12451840,
+          "Size": 12582912,
           "IsResident": 0,
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0
@@ -12224,13 +12212,13 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abaceba70",
-      "tid": 16484,
-      "ts": 203448,
+      "id": "0x15aff2e79d0",
+      "tid": 22764,
+      "ts": 222378,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "Size": 12451840,
+          "Size": 12582912,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0
@@ -12241,13 +12229,13 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abaceba70",
-      "tid": 16484,
-      "ts": 203464,
+      "id": "0x15aff2e79d0",
+      "tid": 22764,
+      "ts": 222392,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "Size": 12451840,
+          "Size": 12582912,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0
@@ -12258,13 +12246,13 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abaceba70",
-      "tid": 16484,
-      "ts": 203534,
+      "id": "0x15aff2e79d0",
+      "tid": 22764,
+      "ts": 222460,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "Size": 12451840,
+          "Size": 12582912,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0
@@ -12275,27 +12263,27 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacefb40",
-      "tid": 16484,
-      "ts": 203536,
+      "id": "0x15aff2eec20",
+      "tid": 22764,
+      "ts": 222463,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacefb40",
-      "tid": 16484,
-      "ts": 203551,
+      "id": "0x15aff2eec20",
+      "tid": 22764,
+      "ts": 222477,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "Size": 12451840,
+          "Size": 12582912,
           "HeapOffset": 0,
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x22abaceba70"
+            "id_ref": "0x15aff2e79d0"
           }
         }
       }
@@ -12304,8 +12292,20 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 203665,
+      "tid": 22764,
+      "ts": 222495,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Resource allocation size is larger then the resource size (12582912 vs 12451840 bytes).",
+        "ID": 4
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 222583,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -12335,9 +12335,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 203683,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 222599,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12349,18 +12349,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacea7e0",
-      "tid": 16484,
-      "ts": 204701,
+      "id": "0x15aff2e9440",
+      "tid": 22764,
+      "ts": 223601,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacea7e0",
-      "tid": 16484,
-      "ts": 204722,
+      "id": "0x15aff2e9440",
+      "tid": 22764,
+      "ts": 223619,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12375,9 +12375,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacea7e0",
-      "tid": 16484,
-      "ts": 204739,
+      "id": "0x15aff2e9440",
+      "tid": 22764,
+      "ts": 223635,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12392,9 +12392,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 204748,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 223643,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12406,9 +12406,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacea7e0",
-      "tid": 16484,
-      "ts": 204767,
+      "id": "0x15aff2e9440",
+      "tid": 22764,
+      "ts": 223660,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12423,9 +12423,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacea7e0",
-      "tid": 16484,
-      "ts": 204839,
+      "id": "0x15aff2e9440",
+      "tid": 22764,
+      "ts": 223728,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12440,18 +12440,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacdbf00",
-      "tid": 16484,
-      "ts": 204842,
+      "id": "0x15aff2ee750",
+      "tid": 22764,
+      "ts": 223731,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacdbf00",
-      "tid": 16484,
-      "ts": 204858,
+      "id": "0x15aff2ee750",
+      "tid": 22764,
+      "ts": 223745,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12460,7 +12460,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacea7e0"
+            "id_ref": "0x15aff2e9440"
           }
         }
       }
@@ -12469,8 +12469,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 204972,
+      "tid": 22764,
+      "ts": 223825,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -12500,8 +12500,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 204992,
+      "tid": 22764,
+      "ts": 223845,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (709230592 vs 4194304 bytes).",
@@ -12512,8 +12512,8 @@
       "name": "ResourceAllocator.TryAllocateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 205010,
+      "tid": 22764,
+      "ts": 223859,
       "pid": "GPGMM",
       "args": {
         "Description": "Resource memory could not be allocated.",
@@ -12521,37 +12521,25 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "i",
-      "tid": 16484,
-      "ts": 205028,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Heap size is not a multiple of the alignment (709230592 vs 4194304 bytes).",
-        "ID": 2
-      }
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abaceb7a0",
-      "tid": 16484,
-      "ts": 205817,
+      "id": "0x15aff2e90e0",
+      "tid": 22764,
+      "ts": 224766,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abaceb7a0",
-      "tid": 16484,
-      "ts": 205837,
+      "id": "0x15aff2e90e0",
+      "tid": 22764,
+      "ts": 224787,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "Size": 709230592,
+          "Size": 713031680,
           "IsResident": 0,
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0
@@ -12562,13 +12550,13 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abaceb7a0",
-      "tid": 16484,
-      "ts": 205855,
+      "id": "0x15aff2e90e0",
+      "tid": 22764,
+      "ts": 224804,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "Size": 709230592,
+          "Size": 713031680,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0
@@ -12579,13 +12567,13 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abaceb7a0",
-      "tid": 16484,
-      "ts": 205871,
+      "id": "0x15aff2e90e0",
+      "tid": 22764,
+      "ts": 224820,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "Size": 709230592,
+          "Size": 713031680,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0
@@ -12596,13 +12584,13 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abaceb7a0",
-      "tid": 16484,
-      "ts": 205941,
+      "id": "0x15aff2e90e0",
+      "tid": 22764,
+      "ts": 224892,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "Size": 709230592,
+          "Size": 713031680,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0
@@ -12613,92 +12601,104 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abad05d10",
-      "tid": 16484,
-      "ts": 205944,
+      "id": "0x15aff2d6330",
+      "tid": 22764,
+      "ts": 224895,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abad05d10",
-      "tid": 16484,
-      "ts": 205959,
+      "id": "0x15aff2d6330",
+      "tid": 22764,
+      "ts": 224910,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "Size": 709230592,
+          "Size": 713031680,
           "HeapOffset": 0,
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x22abaceb7a0"
+            "id_ref": "0x15aff2e90e0"
           }
         }
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "i",
+      "tid": 22764,
+      "ts": 224929,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Resource allocation size is larger then the resource size (713031680 vs 709230592 bytes).",
+        "ID": 4
       }
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacdc5e0",
-      "tid": 16484,
-      "ts": 206103,
+      "id": "0x15aff2caf40",
+      "tid": 22764,
+      "ts": 225038,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacdbb90",
-      "tid": 16484,
-      "ts": 206180,
+      "id": "0x15aff2c01f0",
+      "tid": 22764,
+      "ts": 225095,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacdac70",
-      "tid": 16484,
-      "ts": 206254,
+      "id": "0x15aff2d7460",
+      "tid": 22764,
+      "ts": 225150,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacdaa60",
-      "tid": 16484,
-      "ts": 206328,
+      "id": "0x15aff2d6960",
+      "tid": 22764,
+      "ts": 225204,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacdbe50",
-      "tid": 16484,
-      "ts": 206402,
+      "id": "0x15aff2d7040",
+      "tid": 22764,
+      "ts": 225259,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacdc3d0",
-      "tid": 16484,
-      "ts": 206475,
+      "id": "0x15aff2d6f90",
+      "tid": 22764,
+      "ts": 225312,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 206531,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 225345,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12710,72 +12710,72 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacca620",
-      "tid": 16484,
-      "ts": 206533,
+      "id": "0x15aff2ce880",
+      "tid": 22764,
+      "ts": 225347,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacdb8d0",
-      "tid": 16484,
-      "ts": 206700,
+      "id": "0x15aff2d5e60",
+      "tid": 22764,
+      "ts": 225503,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacefe00",
-      "tid": 16484,
-      "ts": 206782,
+      "id": "0x15aff2d5f10",
+      "tid": 22764,
+      "ts": 225565,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abaceeac0",
-      "tid": 16484,
-      "ts": 206856,
+      "id": "0x15aff2eecd0",
+      "tid": 22764,
+      "ts": 225618,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abaceed80",
-      "tid": 16484,
-      "ts": 206929,
+      "id": "0x15aff2ef880",
+      "tid": 22764,
+      "ts": 225670,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacf0430",
-      "tid": 16484,
-      "ts": 207000,
+      "id": "0x15aff2eff60",
+      "tid": 22764,
+      "ts": 225721,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacf0640",
-      "tid": 16484,
-      "ts": 207073,
+      "id": "0x15aff2ef250",
+      "tid": 22764,
+      "ts": 225771,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 207129,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 225801,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12787,26 +12787,26 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacca470",
-      "tid": 16484,
-      "ts": 207131,
+      "id": "0x15aff2cd9e0",
+      "tid": 22764,
+      "ts": 225804,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacef880",
-      "tid": 16484,
-      "ts": 207279,
+      "id": "0x15aff2ef670",
+      "tid": 22764,
+      "ts": 225983,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 207337,
+      "tid": 22764,
+      "ts": 226051,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -12836,9 +12836,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 207351,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 226064,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12850,18 +12850,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacebcb0",
-      "tid": 16484,
-      "ts": 208433,
+      "id": "0x15aff2e78b0",
+      "tid": 22764,
+      "ts": 227132,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacebcb0",
-      "tid": 16484,
-      "ts": 208453,
+      "id": "0x15aff2e78b0",
+      "tid": 22764,
+      "ts": 227163,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12876,9 +12876,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacebcb0",
-      "tid": 16484,
-      "ts": 208470,
+      "id": "0x15aff2e78b0",
+      "tid": 22764,
+      "ts": 227179,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12893,9 +12893,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 208480,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 227188,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12907,9 +12907,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacebcb0",
-      "tid": 16484,
-      "ts": 208498,
+      "id": "0x15aff2e78b0",
+      "tid": 22764,
+      "ts": 227205,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12924,9 +12924,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacebcb0",
-      "tid": 16484,
-      "ts": 208576,
+      "id": "0x15aff2e78b0",
+      "tid": 22764,
+      "ts": 227276,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12941,18 +12941,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abad06fa0",
-      "tid": 16484,
-      "ts": 208579,
+      "id": "0x15aff2d7460",
+      "tid": 22764,
+      "ts": 227279,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abad06fa0",
-      "tid": 16484,
-      "ts": 208595,
+      "id": "0x15aff2d7460",
+      "tid": 22764,
+      "ts": 227293,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12961,7 +12961,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacebcb0"
+            "id_ref": "0x15aff2e78b0"
           }
         }
       }
@@ -12970,8 +12970,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 208709,
+      "tid": 22764,
+      "ts": 227402,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -13001,9 +13001,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 208732,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 227434,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13018,9 +13018,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 208804,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 227516,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13035,18 +13035,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abad06a20",
-      "tid": 16484,
-      "ts": 208806,
+      "id": "0x15aff2d6960",
+      "tid": 22764,
+      "ts": 227518,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abad06a20",
-      "tid": 16484,
-      "ts": 208822,
+      "id": "0x15aff2d6960",
+      "tid": 22764,
+      "ts": 227533,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13055,7 +13055,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacc9a50"
+            "id_ref": "0x15aff2ce010"
           }
         }
       }
@@ -13064,8 +13064,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 208903,
+      "tid": 22764,
+      "ts": 227620,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -13095,9 +13095,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 208923,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 227640,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13112,9 +13112,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 208994,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 227722,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13129,18 +13129,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abad075d0",
-      "tid": 16484,
-      "ts": 208996,
+      "id": "0x15aff2ef670",
+      "tid": 22764,
+      "ts": 227725,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abad075d0",
-      "tid": 16484,
-      "ts": 209011,
+      "id": "0x15aff2ef670",
+      "tid": 22764,
+      "ts": 227738,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13149,7 +13149,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacc9a50"
+            "id_ref": "0x15aff2ce010"
           }
         }
       }
@@ -13158,8 +13158,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 209092,
+      "tid": 22764,
+      "ts": 227801,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -13189,9 +13189,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 209112,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 227831,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13206,9 +13206,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 209181,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 227934,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13223,18 +13223,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abad07730",
-      "tid": 16484,
-      "ts": 209184,
+      "id": "0x15aff2c0fb0",
+      "tid": 22764,
+      "ts": 227937,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abad07730",
-      "tid": 16484,
-      "ts": 209199,
+      "id": "0x15aff2c0fb0",
+      "tid": 22764,
+      "ts": 227966,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13243,7 +13243,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacc9a50"
+            "id_ref": "0x15aff2ce010"
           }
         }
       }
@@ -13252,8 +13252,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 209279,
+      "tid": 22764,
+      "ts": 228038,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -13283,9 +13283,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 209299,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 228057,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13300,9 +13300,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 209369,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 228126,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13317,18 +13317,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abad06340",
-      "tid": 16484,
-      "ts": 209372,
+      "id": "0x15aff2ee8b0",
+      "tid": 22764,
+      "ts": 228129,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abad06340",
-      "tid": 16484,
-      "ts": 209387,
+      "id": "0x15aff2ee8b0",
+      "tid": 22764,
+      "ts": 228143,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13337,7 +13337,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacc9a50"
+            "id_ref": "0x15aff2ce010"
           }
         }
       }
@@ -13346,8 +13346,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 209466,
+      "tid": 22764,
+      "ts": 228204,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -13377,9 +13377,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 209486,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 228223,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13394,9 +13394,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 209558,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 228293,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13411,18 +13411,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abad05840",
-      "tid": 16484,
-      "ts": 209561,
+      "id": "0x15aff2f3690",
+      "tid": 22764,
+      "ts": 228296,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abad05840",
-      "tid": 16484,
-      "ts": 209576,
+      "id": "0x15aff2f3690",
+      "tid": 22764,
+      "ts": 228310,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13431,7 +13431,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacc9a50"
+            "id_ref": "0x15aff2ce010"
           }
         }
       }
@@ -13440,53 +13440,53 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abad06a20",
-      "tid": 16484,
-      "ts": 209687,
+      "id": "0x15aff2d6960",
+      "tid": 22764,
+      "ts": 228388,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abad075d0",
-      "tid": 16484,
-      "ts": 209761,
+      "id": "0x15aff2ef670",
+      "tid": 22764,
+      "ts": 228440,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abad07730",
-      "tid": 16484,
-      "ts": 209834,
+      "id": "0x15aff2c0fb0",
+      "tid": 22764,
+      "ts": 228491,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abad06340",
-      "tid": 16484,
-      "ts": 209906,
+      "id": "0x15aff2ee8b0",
+      "tid": 22764,
+      "ts": 228542,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abad05840",
-      "tid": 16484,
-      "ts": 209978,
+      "id": "0x15aff2f3690",
+      "tid": 22764,
+      "ts": 228592,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 210030,
+      "tid": 22764,
+      "ts": 228638,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -13516,9 +13516,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 210042,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 228649,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13530,18 +13530,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abaceb560",
-      "tid": 16484,
-      "ts": 210357,
+      "id": "0x15aff2e7a60",
+      "tid": 22764,
+      "ts": 228985,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abaceb560",
-      "tid": 16484,
-      "ts": 210376,
+      "id": "0x15aff2e7a60",
+      "tid": 22764,
+      "ts": 229015,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13556,9 +13556,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abaceb560",
-      "tid": 16484,
-      "ts": 210393,
+      "id": "0x15aff2e7a60",
+      "tid": 22764,
+      "ts": 229031,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13573,9 +13573,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 210402,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 229039,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13587,9 +13587,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abaceb560",
-      "tid": 16484,
-      "ts": 210421,
+      "id": "0x15aff2e7a60",
+      "tid": 22764,
+      "ts": 229056,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13604,9 +13604,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abaceb560",
-      "tid": 16484,
-      "ts": 210491,
+      "id": "0x15aff2e7a60",
+      "tid": 22764,
+      "ts": 229126,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13621,18 +13621,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abad07260",
-      "tid": 16484,
-      "ts": 210493,
+      "id": "0x15aff2f42f0",
+      "tid": 22764,
+      "ts": 229129,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abad07260",
-      "tid": 16484,
-      "ts": 210509,
+      "id": "0x15aff2f42f0",
+      "tid": 22764,
+      "ts": 229143,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13641,7 +13641,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abaceb560"
+            "id_ref": "0x15aff2e7a60"
           }
         }
       }
@@ -13650,8 +13650,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 210626,
+      "tid": 22764,
+      "ts": 229222,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -13681,9 +13681,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 210642,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 229236,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13695,18 +13695,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacec6d0",
-      "tid": 16484,
-      "ts": 210957,
+      "id": "0x15aff2e8c60",
+      "tid": 22764,
+      "ts": 229571,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacec6d0",
-      "tid": 16484,
-      "ts": 210976,
+      "id": "0x15aff2e8c60",
+      "tid": 22764,
+      "ts": 229600,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13721,9 +13721,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacec6d0",
-      "tid": 16484,
-      "ts": 210992,
+      "id": "0x15aff2e8c60",
+      "tid": 22764,
+      "ts": 229617,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13738,9 +13738,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 211001,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 229625,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13752,9 +13752,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacec6d0",
-      "tid": 16484,
-      "ts": 211020,
+      "id": "0x15aff2e8c60",
+      "tid": 22764,
+      "ts": 229642,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13769,9 +13769,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacec6d0",
-      "tid": 16484,
-      "ts": 211089,
+      "id": "0x15aff2e8c60",
+      "tid": 22764,
+      "ts": 229712,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13786,18 +13786,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abad06ad0",
-      "tid": 16484,
-      "ts": 211092,
+      "id": "0x15aff2f3480",
+      "tid": 22764,
+      "ts": 229714,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abad06ad0",
-      "tid": 16484,
-      "ts": 211107,
+      "id": "0x15aff2f3480",
+      "tid": 22764,
+      "ts": 229728,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13806,7 +13806,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacec6d0"
+            "id_ref": "0x15aff2e8c60"
           }
         }
       }
@@ -13815,8 +13815,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 211220,
+      "tid": 22764,
+      "ts": 229806,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -13846,9 +13846,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abaceb560",
-      "tid": 16484,
-      "ts": 211240,
+      "id": "0x15aff2e7a60",
+      "tid": 22764,
+      "ts": 229825,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13863,9 +13863,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abaceb560",
-      "tid": 16484,
-      "ts": 211310,
+      "id": "0x15aff2e7a60",
+      "tid": 22764,
+      "ts": 229894,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13880,18 +13880,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abad05840",
-      "tid": 16484,
-      "ts": 211313,
+      "id": "0x15aff2f3060",
+      "tid": 22764,
+      "ts": 229897,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abad05840",
-      "tid": 16484,
-      "ts": 211328,
+      "id": "0x15aff2f3060",
+      "tid": 22764,
+      "ts": 229911,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13900,7 +13900,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abaceb560"
+            "id_ref": "0x15aff2e7a60"
           }
         }
       }
@@ -13909,8 +13909,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 211408,
+      "tid": 22764,
+      "ts": 229970,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -13940,9 +13940,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacec6d0",
-      "tid": 16484,
-      "ts": 211428,
+      "id": "0x15aff2e8c60",
+      "tid": 22764,
+      "ts": 229989,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13957,9 +13957,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacec6d0",
-      "tid": 16484,
-      "ts": 211497,
+      "id": "0x15aff2e8c60",
+      "tid": 22764,
+      "ts": 230057,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13974,18 +13974,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abad06a20",
-      "tid": 16484,
-      "ts": 211500,
+      "id": "0x15aff2f43a0",
+      "tid": 22764,
+      "ts": 230060,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abad06a20",
-      "tid": 16484,
-      "ts": 211514,
+      "id": "0x15aff2f43a0",
+      "tid": 22764,
+      "ts": 230074,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13994,7 +13994,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacec6d0"
+            "id_ref": "0x15aff2e8c60"
           }
         }
       }
@@ -14003,8 +14003,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 211597,
+      "tid": 22764,
+      "ts": 230135,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -14034,9 +14034,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abaceb560",
-      "tid": 16484,
-      "ts": 211618,
+      "id": "0x15aff2e7a60",
+      "tid": 22764,
+      "ts": 230154,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14051,9 +14051,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abaceb560",
-      "tid": 16484,
-      "ts": 211688,
+      "id": "0x15aff2e7a60",
+      "tid": 22764,
+      "ts": 230222,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14068,18 +14068,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abad066b0",
-      "tid": 16484,
-      "ts": 211690,
+      "id": "0x15aff2f2f00",
+      "tid": 22764,
+      "ts": 230225,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abad066b0",
-      "tid": 16484,
-      "ts": 211705,
+      "id": "0x15aff2f2f00",
+      "tid": 22764,
+      "ts": 230238,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14088,7 +14088,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abaceb560"
+            "id_ref": "0x15aff2e7a60"
           }
         }
       }
@@ -14097,8 +14097,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 211785,
+      "tid": 22764,
+      "ts": 230298,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -14128,9 +14128,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacec6d0",
-      "tid": 16484,
-      "ts": 211805,
+      "id": "0x15aff2e8c60",
+      "tid": 22764,
+      "ts": 230330,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14145,9 +14145,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacec6d0",
-      "tid": 16484,
-      "ts": 211875,
+      "id": "0x15aff2e8c60",
+      "tid": 22764,
+      "ts": 230410,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14162,18 +14162,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacdc5e0",
-      "tid": 16484,
-      "ts": 211878,
+      "id": "0x15aff2f4190",
+      "tid": 22764,
+      "ts": 230413,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacdc5e0",
-      "tid": 16484,
-      "ts": 211892,
+      "id": "0x15aff2f4190",
+      "tid": 22764,
+      "ts": 230426,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14182,7 +14182,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abacec6d0"
+            "id_ref": "0x15aff2e8c60"
           }
         }
       }
@@ -14191,27 +14191,27 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abaceb7a0",
-      "tid": 16484,
-      "ts": 211947,
+      "id": "0x15aff2e90e0",
+      "tid": 22764,
+      "ts": 230459,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abad05d10",
-      "tid": 16484,
-      "ts": 217414,
+      "id": "0x15aff2d6330",
+      "tid": 22764,
+      "ts": 236054,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 217493,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 236118,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14223,45 +14223,45 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacea7e0",
-      "tid": 16484,
-      "ts": 217496,
+      "id": "0x15aff2e9440",
+      "tid": 22764,
+      "ts": 236122,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacdbf00",
-      "tid": 16484,
-      "ts": 217730,
+      "id": "0x15aff2ee750",
+      "tid": 22764,
+      "ts": 236366,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abaceba70",
-      "tid": 16484,
-      "ts": 217759,
+      "id": "0x15aff2e79d0",
+      "tid": 22764,
+      "ts": 236386,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacefb40",
-      "tid": 16484,
-      "ts": 217920,
+      "id": "0x15aff2eec20",
+      "tid": 22764,
+      "ts": 236564,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 217985,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 236600,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14273,63 +14273,63 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abaceae10",
-      "tid": 16484,
-      "ts": 217988,
+      "id": "0x15aff2e9200",
+      "tid": 22764,
+      "ts": 236603,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacef250",
-      "tid": 16484,
-      "ts": 218144,
+      "id": "0x15aff2f0170",
+      "tid": 22764,
+      "ts": 236783,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacd37f0",
-      "tid": 16484,
-      "ts": 218230,
+      "id": "0x15aff2ca910",
+      "tid": 22764,
+      "ts": 236847,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacd3690",
-      "tid": 16484,
-      "ts": 218307,
+      "id": "0x15aff2ca390",
+      "tid": 22764,
+      "ts": 236902,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacca350",
-      "tid": 16484,
-      "ts": 218329,
+      "id": "0x15aff2ce490",
+      "tid": 22764,
+      "ts": 236917,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacd4240",
-      "tid": 16484,
-      "ts": 218473,
+      "id": "0x15aff2caa70",
+      "tid": 22764,
+      "ts": 237086,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 218537,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 237123,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14341,27 +14341,27 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacebcb0",
-      "tid": 16484,
-      "ts": 218540,
+      "id": "0x15aff2e78b0",
+      "tid": 22764,
+      "ts": 237126,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abad06fa0",
-      "tid": 16484,
-      "ts": 218689,
+      "id": "0x15aff2d7460",
+      "tid": 22764,
+      "ts": 237301,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 218750,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 237335,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14373,45 +14373,45 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacc9a50",
-      "tid": 16484,
-      "ts": 218752,
+      "id": "0x15aff2ce010",
+      "tid": 22764,
+      "ts": 237337,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacd3740",
-      "tid": 16484,
-      "ts": 218900,
+      "id": "0x15aff2cb2b0",
+      "tid": 22764,
+      "ts": 237514,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abad066b0",
-      "tid": 16484,
-      "ts": 218982,
+      "id": "0x15aff2f2f00",
+      "tid": 22764,
+      "ts": 237576,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abad05840",
-      "tid": 16484,
-      "ts": 219056,
+      "id": "0x15aff2f3060",
+      "tid": 22764,
+      "ts": 237630,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 219113,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 237660,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14423,45 +14423,45 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abaceb560",
-      "tid": 16484,
-      "ts": 219115,
+      "id": "0x15aff2e7a60",
+      "tid": 22764,
+      "ts": 237662,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abad07260",
-      "tid": 16484,
-      "ts": 219259,
+      "id": "0x15aff2f42f0",
+      "tid": 22764,
+      "ts": 237834,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacdc5e0",
-      "tid": 16484,
-      "ts": 219340,
+      "id": "0x15aff2f4190",
+      "tid": 22764,
+      "ts": 237897,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abad06a20",
-      "tid": 16484,
-      "ts": 219415,
+      "id": "0x15aff2f43a0",
+      "tid": 22764,
+      "ts": 237951,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 219475,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 237984,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14473,99 +14473,99 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacec6d0",
-      "tid": 16484,
-      "ts": 219477,
+      "id": "0x15aff2e8c60",
+      "tid": 22764,
+      "ts": 237986,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abad06ad0",
-      "tid": 16484,
-      "ts": 219628,
+      "id": "0x15aff2f3480",
+      "tid": 22764,
+      "ts": 238162,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacb4800",
-      "tid": 16484,
-      "ts": 219643,
+      "id": "0x15afcc5bed0",
+      "tid": 22764,
+      "ts": 238173,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadfba48",
-      "tid": 16484,
-      "ts": 219659,
+      "id": "0x15aff5316a8",
+      "tid": 22764,
+      "ts": 238189,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadfbc48",
-      "tid": 16484,
-      "ts": 219681,
+      "id": "0x15aff5329a8",
+      "tid": 22764,
+      "ts": 238211,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 219702,
+      "id": "0x15aff5310a8",
+      "tid": 22764,
+      "ts": 238231,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadfb748",
-      "tid": 16484,
-      "ts": 219724,
+      "id": "0x15aff531ea8",
+      "tid": 22764,
+      "ts": 238251,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadfa748",
-      "tid": 16484,
-      "ts": 219742,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 238269,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadfb548",
-      "tid": 16484,
-      "ts": 219760,
+      "id": "0x15aff5311a8",
+      "tid": 22764,
+      "ts": 238286,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 219777,
+      "id": "0x15aff5322a8",
+      "tid": 22764,
+      "ts": 238303,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 219856,
+      "id": "0x15aff5327a8",
+      "tid": 22764,
+      "ts": 238322,
       "pid": "GPGMM"
     }
   ]

--- a/src/tests/capture_replay_tests/traces/webnn_end2end_mobilenetv2nchwtests_nchwtest0.json
+++ b/src/tests/capture_replay_tests/traces/webnn_end2end_mobilenetv2nchwtests_nchwtest0.json
@@ -5,27 +5,27 @@
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadf0600",
-      "tid": 16484,
-      "ts": 360853,
+      "id": "0x15afcc5c790",
+      "tid": 22764,
+      "ts": 417470,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 360866,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 417481,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 360928,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 417531,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -37,9 +37,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 360952,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 417553,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -51,8 +51,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 360983,
+      "tid": 22764,
+      "ts": 417583,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -63,9 +63,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 360997,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 417595,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -77,9 +77,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361014,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 417610,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -91,8 +91,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 361045,
+      "tid": 22764,
+      "ts": 417639,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -103,9 +103,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361065,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 417651,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -117,9 +117,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361082,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 417665,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -131,8 +131,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 361105,
+      "tid": 22764,
+      "ts": 417687,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -143,9 +143,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361118,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 417699,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -157,9 +157,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361145,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 417724,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -171,8 +171,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 361168,
+      "tid": 22764,
+      "ts": 417746,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -183,9 +183,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361181,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 417762,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -197,9 +197,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361197,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 417776,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -211,8 +211,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 361220,
+      "tid": 22764,
+      "ts": 417798,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -223,9 +223,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361233,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 417809,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -237,9 +237,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361250,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 417824,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -251,8 +251,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 361273,
+      "tid": 22764,
+      "ts": 417845,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -263,9 +263,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361286,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 417857,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -277,9 +277,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361302,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 417871,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -291,8 +291,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 361344,
+      "tid": 22764,
+      "ts": 417911,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -303,9 +303,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361357,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 417923,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -317,9 +317,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361374,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 417938,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -331,8 +331,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 361396,
+      "tid": 22764,
+      "ts": 417959,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -343,9 +343,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361409,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 417970,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -357,9 +357,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361426,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 417985,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -371,8 +371,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 361449,
+      "tid": 22764,
+      "ts": 418006,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -383,9 +383,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361461,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 418017,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -397,9 +397,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361483,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 418031,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -411,8 +411,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 361507,
+      "tid": 22764,
+      "ts": 418052,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -423,9 +423,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361520,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 418064,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -437,9 +437,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361536,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 418078,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -451,8 +451,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 361559,
+      "tid": 22764,
+      "ts": 418100,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -463,9 +463,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361571,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 418111,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -477,9 +477,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361588,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 418126,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -491,8 +491,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 361611,
+      "tid": 22764,
+      "ts": 418146,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -503,9 +503,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361624,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 418158,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -517,9 +517,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361640,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 418172,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -531,8 +531,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 361662,
+      "tid": 22764,
+      "ts": 418193,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -543,9 +543,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361676,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 418206,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -557,9 +557,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361728,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 418255,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -571,8 +571,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 361751,
+      "tid": 22764,
+      "ts": 418277,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -583,9 +583,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361764,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 418288,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -597,9 +597,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361781,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 418303,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -611,8 +611,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 361803,
+      "tid": 22764,
+      "ts": 418323,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -623,9 +623,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361816,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 418335,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -637,9 +637,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361833,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 418349,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -651,8 +651,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 361855,
+      "tid": 22764,
+      "ts": 418396,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -663,9 +663,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361868,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 418408,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -677,9 +677,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361884,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 418422,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -691,8 +691,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 361907,
+      "tid": 22764,
+      "ts": 418443,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -703,9 +703,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361924,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 418459,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -717,9 +717,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361941,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 418473,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -731,8 +731,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 361964,
+      "tid": 22764,
+      "ts": 418495,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -743,9 +743,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361982,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 418511,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -757,9 +757,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 361999,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 418526,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -771,8 +771,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 362021,
+      "tid": 22764,
+      "ts": 418558,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -783,9 +783,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 362038,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 418613,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -797,9 +797,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 362055,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 418631,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -811,8 +811,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 362077,
+      "tid": 22764,
+      "ts": 418654,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -823,9 +823,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 362093,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 418671,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -837,9 +837,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 362110,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 418686,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -851,8 +851,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 362132,
+      "tid": 22764,
+      "ts": 418708,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -863,9 +863,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 362150,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 418724,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -877,9 +877,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 362166,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 418739,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -891,8 +891,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 362189,
+      "tid": 22764,
+      "ts": 418760,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -903,9 +903,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 362205,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 418775,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -917,9 +917,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 362221,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 418789,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -931,9 +931,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 362238,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 418804,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -945,8 +945,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 362260,
+      "tid": 22764,
+      "ts": 418825,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -957,8 +957,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 362277,
+      "tid": 22764,
+      "ts": 418842,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -969,8 +969,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 362294,
+      "tid": 22764,
+      "ts": 418858,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -981,8 +981,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 362310,
+      "tid": 22764,
+      "ts": 418888,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -993,8 +993,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 362327,
+      "tid": 22764,
+      "ts": 418932,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -1005,8 +1005,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 362343,
+      "tid": 22764,
+      "ts": 418957,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -1017,8 +1017,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 362360,
+      "tid": 22764,
+      "ts": 418984,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -1029,8 +1029,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 362376,
+      "tid": 22764,
+      "ts": 419000,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -1041,8 +1041,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 362392,
+      "tid": 22764,
+      "ts": 419017,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -1053,8 +1053,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 362409,
+      "tid": 22764,
+      "ts": 419033,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -1065,8 +1065,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 362425,
+      "tid": 22764,
+      "ts": 419049,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -1077,8 +1077,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 362441,
+      "tid": 22764,
+      "ts": 419064,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -1089,18 +1089,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 362448,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419072,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 362471,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419094,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1112,9 +1112,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 362488,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419110,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1126,8 +1126,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 362512,
+      "tid": 22764,
+      "ts": 419132,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1138,9 +1138,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 362525,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419143,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1152,9 +1152,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 362542,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419158,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1166,8 +1166,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 362601,
+      "tid": 22764,
+      "ts": 419248,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1178,9 +1178,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 362615,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419261,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1192,9 +1192,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 362632,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419276,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1206,8 +1206,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 362654,
+      "tid": 22764,
+      "ts": 419297,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1218,9 +1218,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 362667,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419308,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1232,9 +1232,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 362684,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419323,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1246,8 +1246,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 362706,
+      "tid": 22764,
+      "ts": 419343,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1258,9 +1258,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 362719,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419355,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1272,9 +1272,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 362736,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419369,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1286,8 +1286,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 362758,
+      "tid": 22764,
+      "ts": 419390,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1298,9 +1298,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 362771,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419401,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1312,9 +1312,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 362788,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419427,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1326,8 +1326,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 362810,
+      "tid": 22764,
+      "ts": 419447,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1338,9 +1338,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 362823,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419458,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1352,9 +1352,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 362840,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419473,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1366,8 +1366,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 362862,
+      "tid": 22764,
+      "ts": 419493,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1378,9 +1378,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 362875,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419504,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1392,9 +1392,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 362892,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419518,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1406,8 +1406,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 362914,
+      "tid": 22764,
+      "ts": 419538,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1418,9 +1418,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 362927,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419549,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1432,9 +1432,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 362943,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419564,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1446,8 +1446,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 362966,
+      "tid": 22764,
+      "ts": 419584,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1458,9 +1458,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 362979,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419595,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1472,9 +1472,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 362995,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419609,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1486,8 +1486,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 363017,
+      "tid": 22764,
+      "ts": 419629,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1498,9 +1498,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 363030,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419641,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1512,9 +1512,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 363047,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419655,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1526,8 +1526,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 363069,
+      "tid": 22764,
+      "ts": 419675,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1538,9 +1538,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 363082,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419686,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1552,9 +1552,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 363099,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419700,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1566,8 +1566,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 363121,
+      "tid": 22764,
+      "ts": 419720,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1578,9 +1578,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 363134,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419732,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1592,9 +1592,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 363151,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419746,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1606,8 +1606,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 363173,
+      "tid": 22764,
+      "ts": 419766,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1618,9 +1618,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 363186,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419777,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1632,9 +1632,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 363203,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419791,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1646,8 +1646,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 363225,
+      "tid": 22764,
+      "ts": 419811,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1658,9 +1658,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 363238,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419823,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1672,9 +1672,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 363254,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419837,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1686,8 +1686,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 363277,
+      "tid": 22764,
+      "ts": 419857,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1698,9 +1698,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 363290,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419868,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1712,9 +1712,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 363306,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419882,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1726,8 +1726,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 363328,
+      "tid": 22764,
+      "ts": 419903,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1738,9 +1738,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 363341,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419914,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1752,9 +1752,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 363358,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419928,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1766,8 +1766,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 363380,
+      "tid": 22764,
+      "ts": 419948,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1778,9 +1778,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 363398,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419963,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1792,9 +1792,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 363414,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 419978,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1806,8 +1806,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 363437,
+      "tid": 22764,
+      "ts": 419998,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -1818,9 +1818,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 363454,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 420014,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1832,9 +1832,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 363472,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 420028,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1846,8 +1846,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 363495,
+      "tid": 22764,
+      "ts": 420049,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -1858,9 +1858,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 363511,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 420064,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1872,9 +1872,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 363528,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 420078,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1886,8 +1886,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 363550,
+      "tid": 22764,
+      "ts": 420098,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -1898,9 +1898,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 363567,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 420112,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1912,9 +1912,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 363583,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 420127,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1926,8 +1926,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 363606,
+      "tid": 22764,
+      "ts": 420147,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -1938,9 +1938,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 363625,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 420162,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1952,9 +1952,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 363642,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 420176,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1966,8 +1966,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 363664,
+      "tid": 22764,
+      "ts": 420197,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -1978,9 +1978,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 363680,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 420212,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1992,9 +1992,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 363697,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 420227,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2006,9 +2006,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 363713,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 420241,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2020,8 +2020,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 363735,
+      "tid": 22764,
+      "ts": 420261,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -2032,8 +2032,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 363752,
+      "tid": 22764,
+      "ts": 420276,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -2044,8 +2044,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 363769,
+      "tid": 22764,
+      "ts": 420292,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -2056,8 +2056,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 363785,
+      "tid": 22764,
+      "ts": 420307,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -2068,8 +2068,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 363802,
+      "tid": 22764,
+      "ts": 420323,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -2080,8 +2080,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 363818,
+      "tid": 22764,
+      "ts": 420338,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -2092,8 +2092,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 363834,
+      "tid": 22764,
+      "ts": 420354,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -2104,8 +2104,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 363851,
+      "tid": 22764,
+      "ts": 420369,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -2116,8 +2116,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 363867,
+      "tid": 22764,
+      "ts": 420384,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -2128,8 +2128,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 363884,
+      "tid": 22764,
+      "ts": 420400,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -2140,8 +2140,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 363900,
+      "tid": 22764,
+      "ts": 420415,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -2152,8 +2152,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 364054,
+      "tid": 22764,
+      "ts": 420430,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -2164,18 +2164,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 364062,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 420436,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 364099,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 420455,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2187,9 +2187,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 364117,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 420469,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2201,8 +2201,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 364142,
+      "tid": 22764,
+      "ts": 420491,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2213,9 +2213,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 364155,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 420504,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2227,9 +2227,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 364172,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 420518,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2241,8 +2241,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 364195,
+      "tid": 22764,
+      "ts": 420539,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2253,9 +2253,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 364208,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 420550,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2267,9 +2267,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 364224,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 420564,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2281,8 +2281,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 364247,
+      "tid": 22764,
+      "ts": 420584,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2293,9 +2293,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 364260,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 420595,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2307,9 +2307,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 364277,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 420610,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2321,8 +2321,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 364437,
+      "tid": 22764,
+      "ts": 420702,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2333,9 +2333,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 364451,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 420713,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2347,9 +2347,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 364470,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 420728,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2361,8 +2361,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 364533,
+      "tid": 22764,
+      "ts": 420748,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2373,9 +2373,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 364549,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 420759,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2387,9 +2387,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 364617,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 420773,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2401,8 +2401,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 364643,
+      "tid": 22764,
+      "ts": 420794,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2413,9 +2413,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 364667,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 420805,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2427,9 +2427,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 364695,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 420819,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2441,8 +2441,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 364767,
+      "tid": 22764,
+      "ts": 420839,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2453,9 +2453,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 364792,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 420850,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2467,9 +2467,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 364810,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 420864,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2481,8 +2481,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 364872,
+      "tid": 22764,
+      "ts": 420884,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2493,9 +2493,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 364887,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 420896,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2507,9 +2507,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 364903,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 420910,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2521,8 +2521,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 364926,
+      "tid": 22764,
+      "ts": 420930,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2533,9 +2533,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 364939,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 420941,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2547,9 +2547,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 364956,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 420955,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2561,8 +2561,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 364979,
+      "tid": 22764,
+      "ts": 420975,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2573,9 +2573,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 364992,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 420987,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2587,9 +2587,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 365008,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 421001,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2601,8 +2601,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 365031,
+      "tid": 22764,
+      "ts": 421021,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2613,9 +2613,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 365044,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 421033,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2627,9 +2627,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 365060,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 421046,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2641,8 +2641,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 365083,
+      "tid": 22764,
+      "ts": 421067,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2653,9 +2653,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 365096,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 421078,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2667,9 +2667,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 365112,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 421092,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2681,8 +2681,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 365135,
+      "tid": 22764,
+      "ts": 421112,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2693,9 +2693,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 365148,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 421123,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2707,9 +2707,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 365164,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 421137,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2721,8 +2721,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 365187,
+      "tid": 22764,
+      "ts": 421157,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2733,9 +2733,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 365200,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 421168,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2747,9 +2747,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 365217,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 421182,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2761,8 +2761,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 365239,
+      "tid": 22764,
+      "ts": 421204,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2773,9 +2773,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 365252,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 421215,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2787,9 +2787,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 365268,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 421229,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2801,8 +2801,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 365291,
+      "tid": 22764,
+      "ts": 421249,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2813,9 +2813,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 365304,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 421260,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2827,9 +2827,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 365320,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 421275,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2841,8 +2841,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 365343,
+      "tid": 22764,
+      "ts": 421295,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2853,9 +2853,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 365362,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 421310,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2867,9 +2867,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 365378,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 421324,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2881,8 +2881,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 365401,
+      "tid": 22764,
+      "ts": 421344,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -2893,9 +2893,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 365419,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 421360,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2907,9 +2907,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 365436,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 421374,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2921,8 +2921,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 365458,
+      "tid": 22764,
+      "ts": 421394,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -2933,9 +2933,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 365487,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 421408,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2947,9 +2947,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 365504,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 421422,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2961,8 +2961,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 365527,
+      "tid": 22764,
+      "ts": 421442,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -2973,9 +2973,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 365544,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 421456,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2987,9 +2987,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 365561,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 421471,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3001,8 +3001,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 365584,
+      "tid": 22764,
+      "ts": 421491,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -3013,9 +3013,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 365602,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 421506,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3027,9 +3027,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 365619,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 421521,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3041,8 +3041,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 365653,
+      "tid": 22764,
+      "ts": 421541,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -3053,9 +3053,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 365669,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 421556,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3067,9 +3067,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 365686,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 421570,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3081,9 +3081,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 365703,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 421584,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3095,8 +3095,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 365725,
+      "tid": 22764,
+      "ts": 421604,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -3107,8 +3107,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 365742,
+      "tid": 22764,
+      "ts": 421621,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -3119,8 +3119,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 365759,
+      "tid": 22764,
+      "ts": 421637,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -3131,8 +3131,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 365776,
+      "tid": 22764,
+      "ts": 421652,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -3143,8 +3143,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 365793,
+      "tid": 22764,
+      "ts": 421668,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -3155,8 +3155,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 365809,
+      "tid": 22764,
+      "ts": 421683,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -3167,8 +3167,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 365826,
+      "tid": 22764,
+      "ts": 421699,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -3179,8 +3179,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 365842,
+      "tid": 22764,
+      "ts": 421714,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -3191,8 +3191,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 365859,
+      "tid": 22764,
+      "ts": 421729,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -3203,8 +3203,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 365875,
+      "tid": 22764,
+      "ts": 421745,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -3215,8 +3215,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 365892,
+      "tid": 22764,
+      "ts": 421760,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -3227,8 +3227,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 365908,
+      "tid": 22764,
+      "ts": 421775,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -3239,18 +3239,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 365915,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 421781,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 365936,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 421799,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3262,9 +3262,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 365954,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 421814,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3276,8 +3276,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 365977,
+      "tid": 22764,
+      "ts": 421835,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3288,9 +3288,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 365991,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 421846,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3302,9 +3302,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366007,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 421860,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3316,8 +3316,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 366030,
+      "tid": 22764,
+      "ts": 421880,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3328,9 +3328,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366043,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 421892,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3342,9 +3342,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366060,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 421906,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3356,8 +3356,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 366083,
+      "tid": 22764,
+      "ts": 421926,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3368,9 +3368,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366096,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 421937,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3382,9 +3382,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366112,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 421952,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3396,8 +3396,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 366135,
+      "tid": 22764,
+      "ts": 421972,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3408,9 +3408,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366148,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 421983,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3422,9 +3422,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366164,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 421997,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3436,8 +3436,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 366187,
+      "tid": 22764,
+      "ts": 422017,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3448,9 +3448,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366200,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422028,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3462,9 +3462,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366216,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422042,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3476,8 +3476,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 366239,
+      "tid": 22764,
+      "ts": 422062,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3488,9 +3488,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366252,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422074,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3502,9 +3502,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366268,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422088,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3516,8 +3516,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 366291,
+      "tid": 22764,
+      "ts": 422108,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3528,9 +3528,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366303,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422119,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3542,9 +3542,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366320,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422133,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3556,8 +3556,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 366343,
+      "tid": 22764,
+      "ts": 422153,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3568,9 +3568,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366355,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422164,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3582,9 +3582,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366372,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422178,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3596,8 +3596,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 366394,
+      "tid": 22764,
+      "ts": 422198,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3608,9 +3608,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366407,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422211,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3622,9 +3622,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366424,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422225,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3636,8 +3636,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 366447,
+      "tid": 22764,
+      "ts": 422245,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3648,9 +3648,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366460,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422256,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3662,9 +3662,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366478,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422270,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3676,8 +3676,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 366500,
+      "tid": 22764,
+      "ts": 422290,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3688,9 +3688,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366513,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422301,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3702,9 +3702,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366530,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422315,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3716,8 +3716,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 366552,
+      "tid": 22764,
+      "ts": 422335,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3728,9 +3728,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366565,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422347,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3742,9 +3742,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366581,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422360,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3756,8 +3756,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 366604,
+      "tid": 22764,
+      "ts": 422381,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3768,9 +3768,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366617,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422392,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3782,9 +3782,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366634,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422406,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3796,8 +3796,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 366656,
+      "tid": 22764,
+      "ts": 422426,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3808,9 +3808,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366669,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422437,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3822,9 +3822,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366686,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422451,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3836,8 +3836,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 366708,
+      "tid": 22764,
+      "ts": 422471,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3848,9 +3848,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366721,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422482,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3862,9 +3862,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366738,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422496,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3876,8 +3876,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 366761,
+      "tid": 22764,
+      "ts": 422516,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3888,9 +3888,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366774,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422527,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3902,9 +3902,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366791,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422541,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3916,8 +3916,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 366813,
+      "tid": 22764,
+      "ts": 422562,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3928,9 +3928,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366832,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422576,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3942,9 +3942,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366849,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422590,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3956,8 +3956,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 366871,
+      "tid": 22764,
+      "ts": 422610,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -3968,9 +3968,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366889,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422626,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3982,9 +3982,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366906,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422640,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3996,8 +3996,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 366930,
+      "tid": 22764,
+      "ts": 422661,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -4008,9 +4008,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366947,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422677,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4022,9 +4022,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 366964,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422691,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4036,8 +4036,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 366987,
+      "tid": 22764,
+      "ts": 422711,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -4048,9 +4048,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 367004,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422725,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4062,9 +4062,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 367021,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422740,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4076,8 +4076,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 367044,
+      "tid": 22764,
+      "ts": 422760,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -4088,9 +4088,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 367061,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422775,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4102,9 +4102,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 367078,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422789,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4116,8 +4116,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 367151,
+      "tid": 22764,
+      "ts": 422810,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -4128,9 +4128,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 367171,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422824,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4142,9 +4142,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 367199,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422838,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4156,9 +4156,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 367216,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 422852,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4170,8 +4170,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 367238,
+      "tid": 22764,
+      "ts": 422872,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -4182,8 +4182,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 367255,
+      "tid": 22764,
+      "ts": 422887,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -4194,8 +4194,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 367272,
+      "tid": 22764,
+      "ts": 422903,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -4206,8 +4206,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 367289,
+      "tid": 22764,
+      "ts": 422918,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -4218,8 +4218,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 367305,
+      "tid": 22764,
+      "ts": 422934,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -4230,8 +4230,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 367322,
+      "tid": 22764,
+      "ts": 422949,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -4242,8 +4242,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 367338,
+      "tid": 22764,
+      "ts": 422965,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -4254,8 +4254,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 367355,
+      "tid": 22764,
+      "ts": 422980,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -4266,8 +4266,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 367371,
+      "tid": 22764,
+      "ts": 422995,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -4278,8 +4278,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 367387,
+      "tid": 22764,
+      "ts": 423011,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -4290,8 +4290,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 367404,
+      "tid": 22764,
+      "ts": 423026,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -4302,8 +4302,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 367420,
+      "tid": 22764,
+      "ts": 423042,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -4314,18 +4314,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 367427,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 423047,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 367448,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 423065,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4337,9 +4337,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 367467,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 423079,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4351,8 +4351,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 367490,
+      "tid": 22764,
+      "ts": 423100,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4363,9 +4363,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 367503,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 423112,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4377,9 +4377,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 367520,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 423126,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4391,8 +4391,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 367543,
+      "tid": 22764,
+      "ts": 423146,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4403,9 +4403,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 367556,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 423157,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4417,9 +4417,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 367572,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 423171,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4431,8 +4431,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 367595,
+      "tid": 22764,
+      "ts": 423191,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4443,9 +4443,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 367608,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 423204,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4457,9 +4457,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 367624,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 423218,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4471,8 +4471,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 367647,
+      "tid": 22764,
+      "ts": 423238,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4483,9 +4483,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 367660,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 423249,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4497,9 +4497,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 367676,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 423263,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4511,8 +4511,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 367699,
+      "tid": 22764,
+      "ts": 423283,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4523,9 +4523,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 367712,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 423294,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4537,9 +4537,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 367728,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 423308,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4551,8 +4551,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 367751,
+      "tid": 22764,
+      "ts": 423328,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4563,9 +4563,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 367764,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 423339,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4577,9 +4577,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 367780,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 423353,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4591,8 +4591,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 367803,
+      "tid": 22764,
+      "ts": 423374,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4603,9 +4603,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 367816,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 423385,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4617,9 +4617,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 368091,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 423645,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4631,8 +4631,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 368115,
+      "tid": 22764,
+      "ts": 423667,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4643,9 +4643,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 368129,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 423679,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4657,9 +4657,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 368145,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 423693,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4671,8 +4671,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 368168,
+      "tid": 22764,
+      "ts": 423713,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4683,9 +4683,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 368181,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 423724,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4697,9 +4697,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 368198,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 423738,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4711,8 +4711,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 368220,
+      "tid": 22764,
+      "ts": 423758,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4723,9 +4723,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 368233,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 423770,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4737,9 +4737,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 368249,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 423784,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4751,8 +4751,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 368272,
+      "tid": 22764,
+      "ts": 423804,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4763,9 +4763,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 368285,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 423815,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4777,9 +4777,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 368301,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 423829,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4791,8 +4791,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 368324,
+      "tid": 22764,
+      "ts": 423849,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4803,9 +4803,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 368337,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 423860,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4817,9 +4817,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 368354,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 423875,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4831,8 +4831,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 368376,
+      "tid": 22764,
+      "ts": 423895,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4843,9 +4843,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 368389,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 423906,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4857,9 +4857,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 368405,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 423920,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4871,8 +4871,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 368428,
+      "tid": 22764,
+      "ts": 423940,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4883,9 +4883,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 368441,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 423951,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4897,9 +4897,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 368458,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 423965,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4911,8 +4911,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 368481,
+      "tid": 22764,
+      "ts": 423985,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4923,9 +4923,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 368494,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 423996,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4937,9 +4937,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 368511,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 424010,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4951,8 +4951,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 368534,
+      "tid": 22764,
+      "ts": 424030,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4963,9 +4963,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 368546,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 424042,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4977,9 +4977,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 368563,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 424056,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4991,8 +4991,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 368585,
+      "tid": 22764,
+      "ts": 424076,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5003,9 +5003,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 368602,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 424091,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5017,9 +5017,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 368619,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 424106,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5031,8 +5031,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 368642,
+      "tid": 22764,
+      "ts": 424126,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -5043,9 +5043,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 368659,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 424142,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5057,9 +5057,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 368676,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 424156,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5071,8 +5071,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 368698,
+      "tid": 22764,
+      "ts": 424178,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -5083,9 +5083,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 368714,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 424193,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5097,9 +5097,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 368731,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 424209,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5111,8 +5111,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 368754,
+      "tid": 22764,
+      "ts": 424231,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -5123,9 +5123,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 368770,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 424246,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5137,9 +5137,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 368787,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 424260,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5151,8 +5151,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 368809,
+      "tid": 22764,
+      "ts": 424281,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -5163,9 +5163,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 368827,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 424296,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5177,9 +5177,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 368844,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 424310,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5191,8 +5191,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 368866,
+      "tid": 22764,
+      "ts": 424331,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -5203,9 +5203,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 368882,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 424345,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5217,9 +5217,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 368899,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 424359,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5231,9 +5231,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 368915,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 424373,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5245,8 +5245,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 368937,
+      "tid": 22764,
+      "ts": 424393,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -5257,8 +5257,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 368954,
+      "tid": 22764,
+      "ts": 424408,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -5269,8 +5269,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 368976,
+      "tid": 22764,
+      "ts": 424424,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -5281,8 +5281,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 368993,
+      "tid": 22764,
+      "ts": 424440,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -5293,8 +5293,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 369010,
+      "tid": 22764,
+      "ts": 424456,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -5305,8 +5305,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 369026,
+      "tid": 22764,
+      "ts": 424472,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -5317,8 +5317,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 369043,
+      "tid": 22764,
+      "ts": 424487,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -5329,8 +5329,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 369059,
+      "tid": 22764,
+      "ts": 424504,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -5341,8 +5341,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 369076,
+      "tid": 22764,
+      "ts": 424520,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -5353,8 +5353,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 369092,
+      "tid": 22764,
+      "ts": 424535,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -5365,8 +5365,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 369108,
+      "tid": 22764,
+      "ts": 424551,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -5377,8 +5377,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 369125,
+      "tid": 22764,
+      "ts": 424566,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -5389,18 +5389,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 369131,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 424573,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 369153,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 424591,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5412,9 +5412,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 369171,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 424606,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5426,8 +5426,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 369194,
+      "tid": 22764,
+      "ts": 424627,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5438,9 +5438,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 369207,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 424638,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5452,9 +5452,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 369224,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 424652,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5466,8 +5466,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 369247,
+      "tid": 22764,
+      "ts": 424672,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5478,9 +5478,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 369260,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 424683,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5492,9 +5492,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 369277,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 424697,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5506,8 +5506,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 369299,
+      "tid": 22764,
+      "ts": 424718,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5518,9 +5518,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 369312,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 424729,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5532,9 +5532,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 369329,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 424743,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5546,8 +5546,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 369352,
+      "tid": 22764,
+      "ts": 424763,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5558,9 +5558,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 369364,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 424774,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5572,9 +5572,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 369392,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 424788,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5586,8 +5586,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 369415,
+      "tid": 22764,
+      "ts": 424809,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5598,9 +5598,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 369429,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 424820,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5612,9 +5612,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 369446,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 424834,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5626,8 +5626,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 369470,
+      "tid": 22764,
+      "ts": 424854,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5638,9 +5638,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 369484,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 424865,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5652,9 +5652,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 369501,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 424879,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5666,8 +5666,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 369524,
+      "tid": 22764,
+      "ts": 424899,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5678,9 +5678,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 369537,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 424910,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5692,9 +5692,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 369554,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 424924,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5706,8 +5706,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 369577,
+      "tid": 22764,
+      "ts": 424945,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5718,9 +5718,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 369601,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 424956,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5732,9 +5732,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 369618,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 424970,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5746,8 +5746,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 369640,
+      "tid": 22764,
+      "ts": 424990,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5758,9 +5758,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 369653,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 425001,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5772,9 +5772,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 369670,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 425015,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5786,8 +5786,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 369692,
+      "tid": 22764,
+      "ts": 425035,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5798,9 +5798,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 369705,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 425046,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5812,9 +5812,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 369722,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 425060,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5826,8 +5826,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 369745,
+      "tid": 22764,
+      "ts": 425081,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5838,9 +5838,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 369757,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 425092,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5852,9 +5852,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 369774,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 425106,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5866,8 +5866,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 369797,
+      "tid": 22764,
+      "ts": 425126,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5878,9 +5878,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 369810,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 425138,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5892,9 +5892,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 369826,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 425152,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5906,8 +5906,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 369849,
+      "tid": 22764,
+      "ts": 425172,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5918,9 +5918,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 369867,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 425183,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5932,9 +5932,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 369884,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 425198,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5946,8 +5946,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 369907,
+      "tid": 22764,
+      "ts": 425220,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5958,9 +5958,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 369920,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 425231,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5972,9 +5972,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 369936,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 425245,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5986,8 +5986,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 369959,
+      "tid": 22764,
+      "ts": 425266,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5998,9 +5998,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 369972,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 425278,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6012,9 +6012,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 369988,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 425292,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6026,8 +6026,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 370011,
+      "tid": 22764,
+      "ts": 425313,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6038,9 +6038,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 370024,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 425324,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6052,9 +6052,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 370041,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 425338,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6066,8 +6066,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 370063,
+      "tid": 22764,
+      "ts": 425358,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6078,9 +6078,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 370080,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 425373,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6092,9 +6092,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 370097,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 425387,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6106,8 +6106,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 370120,
+      "tid": 22764,
+      "ts": 425407,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -6118,9 +6118,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 370137,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 425422,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6132,9 +6132,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 370154,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 425436,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6146,8 +6146,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 370177,
+      "tid": 22764,
+      "ts": 425457,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -6158,9 +6158,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 370193,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 425471,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6172,9 +6172,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 370210,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 425486,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6186,8 +6186,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 370233,
+      "tid": 22764,
+      "ts": 425506,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -6198,9 +6198,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 370249,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 425520,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6212,9 +6212,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 370266,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 425534,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6226,8 +6226,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 370289,
+      "tid": 22764,
+      "ts": 425554,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -6238,9 +6238,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 370306,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 425570,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6252,9 +6252,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 370322,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 425584,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6266,8 +6266,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 370345,
+      "tid": 22764,
+      "ts": 425604,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -6278,9 +6278,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 370361,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 425618,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6292,9 +6292,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 370377,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 425633,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6306,9 +6306,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 370394,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 425647,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6320,8 +6320,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 370420,
+      "tid": 22764,
+      "ts": 425666,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -6332,8 +6332,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 370438,
+      "tid": 22764,
+      "ts": 425682,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -6344,8 +6344,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 370456,
+      "tid": 22764,
+      "ts": 425698,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -6356,8 +6356,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 370474,
+      "tid": 22764,
+      "ts": 425713,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -6368,8 +6368,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 370492,
+      "tid": 22764,
+      "ts": 425729,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -6380,8 +6380,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 370509,
+      "tid": 22764,
+      "ts": 425744,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -6392,8 +6392,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 370526,
+      "tid": 22764,
+      "ts": 425759,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -6404,8 +6404,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 370543,
+      "tid": 22764,
+      "ts": 425775,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -6416,8 +6416,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 370560,
+      "tid": 22764,
+      "ts": 425790,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -6428,8 +6428,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 370577,
+      "tid": 22764,
+      "ts": 425805,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -6440,8 +6440,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 370606,
+      "tid": 22764,
+      "ts": 425820,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -6452,8 +6452,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 370624,
+      "tid": 22764,
+      "ts": 425836,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -6464,18 +6464,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 370631,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 425841,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 370655,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 425859,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6487,9 +6487,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 370673,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 425874,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6501,8 +6501,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 370698,
+      "tid": 22764,
+      "ts": 425895,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6513,9 +6513,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 370711,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 425906,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6527,9 +6527,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 370728,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 425920,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6541,8 +6541,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 370751,
+      "tid": 22764,
+      "ts": 425940,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6553,9 +6553,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 370765,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 425951,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6567,9 +6567,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 370782,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 425966,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6581,8 +6581,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 370805,
+      "tid": 22764,
+      "ts": 425986,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6593,9 +6593,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 370819,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 425997,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6607,9 +6607,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 370836,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426011,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6621,8 +6621,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 370859,
+      "tid": 22764,
+      "ts": 426031,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6633,9 +6633,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 370872,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426043,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6647,9 +6647,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 370889,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426057,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6661,8 +6661,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 370912,
+      "tid": 22764,
+      "ts": 426077,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6673,9 +6673,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 370925,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426088,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6687,9 +6687,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 370942,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426102,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6701,8 +6701,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 370966,
+      "tid": 22764,
+      "ts": 426122,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6713,9 +6713,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 370979,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426133,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6727,9 +6727,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 370996,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426147,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6741,8 +6741,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 371019,
+      "tid": 22764,
+      "ts": 426168,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6753,9 +6753,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 371033,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426179,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6767,9 +6767,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 371049,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426193,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6781,8 +6781,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 371072,
+      "tid": 22764,
+      "ts": 426215,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6793,9 +6793,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 371086,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426226,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6807,9 +6807,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 371103,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426240,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6821,8 +6821,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 371126,
+      "tid": 22764,
+      "ts": 426260,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6833,9 +6833,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 371139,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426271,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6847,9 +6847,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 371156,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426285,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6861,8 +6861,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 371179,
+      "tid": 22764,
+      "ts": 426305,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6873,9 +6873,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 371192,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426316,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6887,9 +6887,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 371209,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426330,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6901,8 +6901,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 371233,
+      "tid": 22764,
+      "ts": 426351,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6913,9 +6913,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 371246,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426362,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6927,9 +6927,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 371263,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426376,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6941,8 +6941,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 371286,
+      "tid": 22764,
+      "ts": 426396,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6953,9 +6953,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 371299,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426407,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6967,9 +6967,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 371327,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426421,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6981,8 +6981,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 371365,
+      "tid": 22764,
+      "ts": 426441,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6993,9 +6993,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 371378,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426452,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7007,9 +7007,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 371396,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426466,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7021,8 +7021,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 371419,
+      "tid": 22764,
+      "ts": 426487,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7033,9 +7033,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 371432,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426498,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7047,9 +7047,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 371449,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426512,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7061,8 +7061,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 371474,
+      "tid": 22764,
+      "ts": 426532,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7073,9 +7073,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 371488,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426543,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7087,9 +7087,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 371505,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426557,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7101,8 +7101,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 371528,
+      "tid": 22764,
+      "ts": 426577,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7113,9 +7113,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 371541,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426588,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7127,9 +7127,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 371558,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426602,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7141,8 +7141,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 371581,
+      "tid": 22764,
+      "ts": 426623,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7153,9 +7153,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 371598,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426637,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7167,9 +7167,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 371616,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426651,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7181,8 +7181,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 371639,
+      "tid": 22764,
+      "ts": 426672,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -7193,9 +7193,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 371667,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426687,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7207,9 +7207,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 371684,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426701,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7221,8 +7221,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 371719,
+      "tid": 22764,
+      "ts": 426722,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -7233,9 +7233,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 371736,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426736,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7247,9 +7247,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 371753,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426750,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7261,8 +7261,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 371802,
+      "tid": 22764,
+      "ts": 426770,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -7273,9 +7273,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 371820,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426786,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7287,9 +7287,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 371837,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426800,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7301,8 +7301,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 371860,
+      "tid": 22764,
+      "ts": 426820,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -7313,9 +7313,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 371878,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426835,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7327,9 +7327,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 371896,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426849,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7341,8 +7341,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 371919,
+      "tid": 22764,
+      "ts": 426870,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -7353,9 +7353,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 371936,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426884,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7367,9 +7367,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 371953,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426898,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7381,9 +7381,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 371970,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 426912,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7395,8 +7395,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 371992,
+      "tid": 22764,
+      "ts": 426932,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -7407,8 +7407,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 372009,
+      "tid": 22764,
+      "ts": 426948,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -7419,8 +7419,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 372027,
+      "tid": 22764,
+      "ts": 426963,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -7431,8 +7431,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 372043,
+      "tid": 22764,
+      "ts": 426978,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -7443,8 +7443,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 372061,
+      "tid": 22764,
+      "ts": 426994,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -7455,8 +7455,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 372078,
+      "tid": 22764,
+      "ts": 427009,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -7467,8 +7467,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 372096,
+      "tid": 22764,
+      "ts": 427025,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -7479,8 +7479,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 372113,
+      "tid": 22764,
+      "ts": 427040,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -7491,8 +7491,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 372132,
+      "tid": 22764,
+      "ts": 427055,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -7503,8 +7503,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 372149,
+      "tid": 22764,
+      "ts": 427071,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -7515,8 +7515,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 372177,
+      "tid": 22764,
+      "ts": 427086,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -7527,8 +7527,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 372209,
+      "tid": 22764,
+      "ts": 427102,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -7539,18 +7539,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 372216,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427108,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 372239,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427130,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7562,9 +7562,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 372268,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427145,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7576,8 +7576,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 372302,
+      "tid": 22764,
+      "ts": 427166,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7588,9 +7588,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 372316,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427177,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7602,9 +7602,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 372332,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427191,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7616,8 +7616,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 372355,
+      "tid": 22764,
+      "ts": 427213,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7628,9 +7628,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 372368,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427224,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7642,9 +7642,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 372385,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427238,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7656,8 +7656,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 372407,
+      "tid": 22764,
+      "ts": 427258,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7668,9 +7668,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 372421,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427270,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7682,9 +7682,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 372437,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427284,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7696,8 +7696,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 372460,
+      "tid": 22764,
+      "ts": 427304,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7708,9 +7708,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 372474,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427315,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7722,9 +7722,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 372491,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427329,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7736,8 +7736,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 372513,
+      "tid": 22764,
+      "ts": 427350,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7748,9 +7748,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 372527,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427361,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7762,9 +7762,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 372544,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427375,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7776,8 +7776,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 372566,
+      "tid": 22764,
+      "ts": 427395,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7788,9 +7788,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 372579,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427406,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7802,9 +7802,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 372596,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427420,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7816,8 +7816,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 372618,
+      "tid": 22764,
+      "ts": 427440,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7828,9 +7828,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 372631,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427452,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7842,9 +7842,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 372648,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427466,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7856,8 +7856,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 372671,
+      "tid": 22764,
+      "ts": 427487,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7868,9 +7868,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 372684,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427498,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7882,9 +7882,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 372739,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427512,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7896,8 +7896,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 372765,
+      "tid": 22764,
+      "ts": 427532,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7908,9 +7908,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 372783,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427544,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7922,9 +7922,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 372800,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427558,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7936,8 +7936,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 372823,
+      "tid": 22764,
+      "ts": 427578,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7948,9 +7948,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 372836,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427590,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7962,9 +7962,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 372853,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427603,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7976,8 +7976,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 372875,
+      "tid": 22764,
+      "ts": 427624,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7988,9 +7988,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 372888,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427640,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8002,9 +8002,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 372905,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427654,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8016,8 +8016,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 372928,
+      "tid": 22764,
+      "ts": 427674,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -8028,9 +8028,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 372941,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427685,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8042,9 +8042,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 372958,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427700,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8056,8 +8056,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 372980,
+      "tid": 22764,
+      "ts": 427720,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -8068,9 +8068,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 372993,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427732,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8082,9 +8082,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 373010,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427746,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8096,8 +8096,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 373032,
+      "tid": 22764,
+      "ts": 427766,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -8108,9 +8108,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 373045,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427777,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8122,9 +8122,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 373062,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427791,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8136,8 +8136,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 373085,
+      "tid": 22764,
+      "ts": 427811,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -8148,9 +8148,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 373098,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427823,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8162,9 +8162,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 373114,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427836,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8176,8 +8176,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 373136,
+      "tid": 22764,
+      "ts": 427857,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -8188,9 +8188,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 373149,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427868,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8202,9 +8202,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 373166,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427882,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8216,8 +8216,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 373189,
+      "tid": 22764,
+      "ts": 427902,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -8228,9 +8228,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 373206,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427917,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8242,9 +8242,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 373223,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427931,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8256,8 +8256,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 373245,
+      "tid": 22764,
+      "ts": 427952,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -8268,9 +8268,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 373263,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427967,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8282,9 +8282,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 373280,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 427981,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8296,8 +8296,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 373303,
+      "tid": 22764,
+      "ts": 428006,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -8308,9 +8308,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 373318,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 428021,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8322,9 +8322,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 373335,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 428036,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8336,8 +8336,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 373358,
+      "tid": 22764,
+      "ts": 428056,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -8348,9 +8348,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 373374,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 428070,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8362,9 +8362,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 373390,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 428084,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8376,8 +8376,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 373413,
+      "tid": 22764,
+      "ts": 428105,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -8388,9 +8388,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 373430,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 428120,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8402,9 +8402,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 373447,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 428134,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8416,8 +8416,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 373483,
+      "tid": 22764,
+      "ts": 428154,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -8428,9 +8428,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 373500,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 428169,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8442,9 +8442,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 373517,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 428183,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8456,9 +8456,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 373534,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 428197,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8470,8 +8470,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 373556,
+      "tid": 22764,
+      "ts": 428218,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -8482,8 +8482,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 373573,
+      "tid": 22764,
+      "ts": 428234,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -8494,8 +8494,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 373590,
+      "tid": 22764,
+      "ts": 428249,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -8506,8 +8506,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 373607,
+      "tid": 22764,
+      "ts": 428265,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -8518,8 +8518,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 373623,
+      "tid": 22764,
+      "ts": 428280,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -8530,8 +8530,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 373640,
+      "tid": 22764,
+      "ts": 428295,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -8542,8 +8542,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 373656,
+      "tid": 22764,
+      "ts": 428311,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -8554,8 +8554,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 373673,
+      "tid": 22764,
+      "ts": 428326,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -8566,8 +8566,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 373689,
+      "tid": 22764,
+      "ts": 428342,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -8578,8 +8578,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 373706,
+      "tid": 22764,
+      "ts": 428357,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -8590,8 +8590,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 373722,
+      "tid": 22764,
+      "ts": 428373,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -8602,8 +8602,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 373738,
+      "tid": 22764,
+      "ts": 428388,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -8614,13 +8614,13 @@
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 373767,
+      "tid": 22764,
+      "ts": 428417,
       "pid": "GPGMM",
       "args": {
         "Flags": 0,
         "RecordOptions": {
-          "Flags": 6
+          "Flags": 3
         },
         "IsUMA": 1,
         "ResourceHeapTier": 2,
@@ -8635,8 +8635,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 373829,
+      "tid": 22764,
+      "ts": 428474,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -8666,8 +8666,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 373848,
+      "tid": 22764,
+      "ts": 428491,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -8678,8 +8678,8 @@
       "name": "ResourceAllocator.TryAllocateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 373862,
+      "tid": 22764,
+      "ts": 428505,
       "pid": "GPGMM",
       "args": {
         "Description": "Resource memory could not be allocated.",
@@ -8690,18 +8690,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadcdd00",
-      "tid": 16484,
-      "ts": 374853,
+      "id": "0x15aff31e9c0",
+      "tid": 22764,
+      "ts": 429500,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadcdd00",
-      "tid": 16484,
-      "ts": 374876,
+      "id": "0x15aff31e9c0",
+      "tid": 22764,
+      "ts": 429532,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8716,9 +8716,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadcdd00",
-      "tid": 16484,
-      "ts": 374897,
+      "id": "0x15aff31e9c0",
+      "tid": 22764,
+      "ts": 429551,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8733,9 +8733,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadcdd00",
-      "tid": 16484,
-      "ts": 374913,
+      "id": "0x15aff31e9c0",
+      "tid": 22764,
+      "ts": 429566,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8750,9 +8750,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadcdd00",
-      "tid": 16484,
-      "ts": 374991,
+      "id": "0x15aff31e9c0",
+      "tid": 22764,
+      "ts": 429642,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8767,18 +8767,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadd27c0",
-      "tid": 16484,
-      "ts": 374994,
+      "id": "0x15aff319df0",
+      "tid": 22764,
+      "ts": 429645,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadd27c0",
-      "tid": 16484,
-      "ts": 375010,
+      "id": "0x15aff319df0",
+      "tid": 22764,
+      "ts": 429659,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8787,7 +8787,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x22abadcdd00"
+            "id_ref": "0x15aff31e9c0"
           }
         }
       }
@@ -8796,8 +8796,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 375123,
+      "tid": 22764,
+      "ts": 429749,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -8827,8 +8827,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 375142,
+      "tid": 22764,
+      "ts": 429768,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -8839,8 +8839,8 @@
       "name": "ResourceAllocator.TryAllocateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 375157,
+      "tid": 22764,
+      "ts": 429781,
       "pid": "GPGMM",
       "args": {
         "Description": "Resource memory could not be allocated.",
@@ -8851,18 +8851,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadcd9a0",
-      "tid": 16484,
-      "ts": 376063,
+      "id": "0x15aff31e4b0",
+      "tid": 22764,
+      "ts": 430721,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadcd9a0",
-      "tid": 16484,
-      "ts": 376083,
+      "id": "0x15aff31e4b0",
+      "tid": 22764,
+      "ts": 430751,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8877,9 +8877,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadcd9a0",
-      "tid": 16484,
-      "ts": 376101,
+      "id": "0x15aff31e4b0",
+      "tid": 22764,
+      "ts": 430767,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8894,9 +8894,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadcd9a0",
-      "tid": 16484,
-      "ts": 376117,
+      "id": "0x15aff31e4b0",
+      "tid": 22764,
+      "ts": 430782,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8911,9 +8911,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadcd9a0",
-      "tid": 16484,
-      "ts": 376189,
+      "id": "0x15aff31e4b0",
+      "tid": 22764,
+      "ts": 430852,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8928,18 +8928,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadd2240",
-      "tid": 16484,
-      "ts": 376191,
+      "id": "0x15aff31aa50",
+      "tid": 22764,
+      "ts": 430855,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadd2240",
-      "tid": 16484,
-      "ts": 376207,
+      "id": "0x15aff31aa50",
+      "tid": 22764,
+      "ts": 430869,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8948,7 +8948,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x22abadcd9a0"
+            "id_ref": "0x15aff31e4b0"
           }
         }
       }
@@ -8957,8 +8957,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 376312,
+      "tid": 22764,
+      "ts": 430964,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -8988,9 +8988,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 376327,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 430979,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9002,18 +9002,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadcd250",
-      "tid": 16484,
-      "ts": 376645,
+      "id": "0x15aff31d4f0",
+      "tid": 22764,
+      "ts": 431314,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadcd250",
-      "tid": 16484,
-      "ts": 376665,
+      "id": "0x15aff31d4f0",
+      "tid": 22764,
+      "ts": 431334,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9028,9 +9028,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadcd250",
-      "tid": 16484,
-      "ts": 376682,
+      "id": "0x15aff31d4f0",
+      "tid": 22764,
+      "ts": 431351,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9045,9 +9045,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 376691,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 431359,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9059,9 +9059,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadcd250",
-      "tid": 16484,
-      "ts": 376711,
+      "id": "0x15aff31d4f0",
+      "tid": 22764,
+      "ts": 431377,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9076,9 +9076,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadcd250",
-      "tid": 16484,
-      "ts": 376784,
+      "id": "0x15aff31d4f0",
+      "tid": 22764,
+      "ts": 431458,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9093,18 +9093,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadd3000",
-      "tid": 16484,
-      "ts": 376787,
+      "id": "0x15aff319660",
+      "tid": 22764,
+      "ts": 431461,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadd3000",
-      "tid": 16484,
-      "ts": 376802,
+      "id": "0x15aff319660",
+      "tid": 22764,
+      "ts": 431475,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9113,7 +9113,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abadcd250"
+            "id_ref": "0x15aff31d4f0"
           }
         }
       }
@@ -9122,8 +9122,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 376917,
+      "tid": 22764,
+      "ts": 431569,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -9153,8 +9153,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 376936,
+      "tid": 22764,
+      "ts": 431589,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -9165,8 +9165,8 @@
       "name": "ResourceAllocator.TryAllocateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 376951,
+      "tid": 22764,
+      "ts": 431605,
       "pid": "GPGMM",
       "args": {
         "Description": "Resource memory could not be allocated.",
@@ -9177,18 +9177,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadccdd0",
-      "tid": 16484,
-      "ts": 377102,
+      "id": "0x15aff31e300",
+      "tid": 22764,
+      "ts": 431763,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadccdd0",
-      "tid": 16484,
-      "ts": 377122,
+      "id": "0x15aff31e300",
+      "tid": 22764,
+      "ts": 431783,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9203,9 +9203,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadccdd0",
-      "tid": 16484,
-      "ts": 377140,
+      "id": "0x15aff31e300",
+      "tid": 22764,
+      "ts": 431799,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9220,9 +9220,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadccdd0",
-      "tid": 16484,
-      "ts": 377156,
+      "id": "0x15aff31e300",
+      "tid": 22764,
+      "ts": 431814,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9237,9 +9237,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadccdd0",
-      "tid": 16484,
-      "ts": 377226,
+      "id": "0x15aff31e300",
+      "tid": 22764,
+      "ts": 431895,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9254,18 +9254,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababc70e0",
-      "tid": 16484,
-      "ts": 377229,
+      "id": "0x15aff319a80",
+      "tid": 22764,
+      "ts": 431898,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc70e0",
-      "tid": 16484,
-      "ts": 377245,
+      "id": "0x15aff319a80",
+      "tid": 22764,
+      "ts": 431912,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9274,7 +9274,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x22abadccdd0"
+            "id_ref": "0x15aff31e300"
           }
         }
       }
@@ -9283,26 +9283,26 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadcdd00",
-      "tid": 16484,
-      "ts": 377320,
+      "id": "0x15aff31e9c0",
+      "tid": 22764,
+      "ts": 431966,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadd27c0",
-      "tid": 16484,
-      "ts": 377492,
+      "id": "0x15aff319df0",
+      "tid": 22764,
+      "ts": 432160,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 377549,
+      "tid": 22764,
+      "ts": 432226,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -9332,9 +9332,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 377566,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 432241,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9346,18 +9346,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadcd520",
-      "tid": 16484,
-      "ts": 377882,
+      "id": "0x15aff31dd60",
+      "tid": 22764,
+      "ts": 432604,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadcd520",
-      "tid": 16484,
-      "ts": 377902,
+      "id": "0x15aff31dd60",
+      "tid": 22764,
+      "ts": 432634,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9372,9 +9372,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadcd520",
-      "tid": 16484,
-      "ts": 377922,
+      "id": "0x15aff31dd60",
+      "tid": 22764,
+      "ts": 432650,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9389,9 +9389,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 377931,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 432660,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9403,9 +9403,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadcd520",
-      "tid": 16484,
-      "ts": 377950,
+      "id": "0x15aff31dd60",
+      "tid": 22764,
+      "ts": 432677,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9420,9 +9420,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadcd520",
-      "tid": 16484,
-      "ts": 378020,
+      "id": "0x15aff31dd60",
+      "tid": 22764,
+      "ts": 432748,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9437,18 +9437,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababb58f0",
-      "tid": 16484,
-      "ts": 378023,
+      "id": "0x15aff319df0",
+      "tid": 22764,
+      "ts": 432750,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb58f0",
-      "tid": 16484,
-      "ts": 378038,
+      "id": "0x15aff319df0",
+      "tid": 22764,
+      "ts": 432764,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9457,7 +9457,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abadcd520"
+            "id_ref": "0x15aff31dd60"
           }
         }
       }
@@ -9466,26 +9466,26 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadcd9a0",
-      "tid": 16484,
-      "ts": 378121,
+      "id": "0x15aff31e4b0",
+      "tid": 22764,
+      "ts": 432815,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadd2240",
-      "tid": 16484,
-      "ts": 378266,
+      "id": "0x15aff31aa50",
+      "tid": 22764,
+      "ts": 432993,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 378323,
+      "tid": 22764,
+      "ts": 433044,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -9515,9 +9515,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 378338,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 433057,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9529,18 +9529,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadccb00",
-      "tid": 16484,
-      "ts": 378651,
+      "id": "0x15aff31ee40",
+      "tid": 22764,
+      "ts": 433393,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadccb00",
-      "tid": 16484,
-      "ts": 378671,
+      "id": "0x15aff31ee40",
+      "tid": 22764,
+      "ts": 433423,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9555,9 +9555,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadccb00",
-      "tid": 16484,
-      "ts": 378688,
+      "id": "0x15aff31ee40",
+      "tid": 22764,
+      "ts": 433446,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9572,9 +9572,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 378697,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 433454,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9586,9 +9586,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadccb00",
-      "tid": 16484,
-      "ts": 378717,
+      "id": "0x15aff31ee40",
+      "tid": 22764,
+      "ts": 433472,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9603,9 +9603,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadccb00",
-      "tid": 16484,
-      "ts": 378787,
+      "id": "0x15aff31ee40",
+      "tid": 22764,
+      "ts": 433542,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9620,18 +9620,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababb5210",
-      "tid": 16484,
-      "ts": 378790,
+      "id": "0x15aff327560",
+      "tid": 22764,
+      "ts": 433545,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5210",
-      "tid": 16484,
-      "ts": 378805,
+      "id": "0x15aff327560",
+      "tid": 22764,
+      "ts": 433559,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9640,7 +9640,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abadccb00"
+            "id_ref": "0x15aff31ee40"
           }
         }
       }
@@ -9649,8 +9649,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 378916,
+      "tid": 22764,
+      "ts": 433640,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -9680,9 +9680,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 378934,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 433661,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9694,18 +9694,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadcc200",
-      "tid": 16484,
-      "ts": 379247,
+      "id": "0x15aff31df10",
+      "tid": 22764,
+      "ts": 434002,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadcc200",
-      "tid": 16484,
-      "ts": 379266,
+      "id": "0x15aff31df10",
+      "tid": 22764,
+      "ts": 434021,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9720,9 +9720,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadcc200",
-      "tid": 16484,
-      "ts": 379283,
+      "id": "0x15aff31df10",
+      "tid": 22764,
+      "ts": 434038,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9737,9 +9737,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 379292,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 434047,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9751,9 +9751,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadcc200",
-      "tid": 16484,
-      "ts": 379313,
+      "id": "0x15aff31df10",
+      "tid": 22764,
+      "ts": 434064,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9768,9 +9768,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadcc200",
-      "tid": 16484,
-      "ts": 379382,
+      "id": "0x15aff31df10",
+      "tid": 22764,
+      "ts": 434137,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9785,18 +9785,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababb5420",
-      "tid": 16484,
-      "ts": 379385,
+      "id": "0x15aff3285e0",
+      "tid": 22764,
+      "ts": 434139,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5420",
-      "tid": 16484,
-      "ts": 379400,
+      "id": "0x15aff3285e0",
+      "tid": 22764,
+      "ts": 434154,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9805,7 +9805,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abadcc200"
+            "id_ref": "0x15aff31df10"
           }
         }
       }
@@ -9814,8 +9814,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 379514,
+      "tid": 22764,
+      "ts": 434238,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -9845,9 +9845,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadcd250",
-      "tid": 16484,
-      "ts": 379535,
+      "id": "0x15aff31d4f0",
+      "tid": 22764,
+      "ts": 434259,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9862,9 +9862,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadcd250",
-      "tid": 16484,
-      "ts": 379606,
+      "id": "0x15aff31d4f0",
+      "tid": 22764,
+      "ts": 434330,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9879,18 +9879,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababb5580",
-      "tid": 16484,
-      "ts": 379608,
+      "id": "0x15aff328e20",
+      "tid": 22764,
+      "ts": 434344,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5580",
-      "tid": 16484,
-      "ts": 379623,
+      "id": "0x15aff328e20",
+      "tid": 22764,
+      "ts": 434358,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9899,7 +9899,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abadcd250"
+            "id_ref": "0x15aff31d4f0"
           }
         }
       }
@@ -9908,17 +9908,17 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadd3000",
-      "tid": 16484,
-      "ts": 379739,
+      "id": "0x15aff319660",
+      "tid": 22764,
+      "ts": 434458,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 379792,
+      "tid": 22764,
+      "ts": 434517,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -9948,8 +9948,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 379812,
+      "tid": 22764,
+      "ts": 434536,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -9960,8 +9960,8 @@
       "name": "ResourceAllocator.TryAllocateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 379826,
+      "tid": 22764,
+      "ts": 434550,
       "pid": "GPGMM",
       "args": {
         "Description": "Resource memory could not be allocated.",
@@ -9972,18 +9972,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadcd130",
-      "tid": 16484,
-      "ts": 380945,
+      "id": "0x15aff31e6f0",
+      "tid": 22764,
+      "ts": 435558,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadcd130",
-      "tid": 16484,
-      "ts": 380967,
+      "id": "0x15aff31e6f0",
+      "tid": 22764,
+      "ts": 435579,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9998,9 +9998,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadcd130",
-      "tid": 16484,
-      "ts": 380985,
+      "id": "0x15aff31e6f0",
+      "tid": 22764,
+      "ts": 435596,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10015,9 +10015,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadcd130",
-      "tid": 16484,
-      "ts": 381001,
+      "id": "0x15aff31e6f0",
+      "tid": 22764,
+      "ts": 435611,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10032,9 +10032,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadcd130",
-      "tid": 16484,
-      "ts": 381075,
+      "id": "0x15aff31e6f0",
+      "tid": 22764,
+      "ts": 435693,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10049,18 +10049,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababb5fd0",
-      "tid": 16484,
-      "ts": 381078,
+      "id": "0x15aff327cf0",
+      "tid": 22764,
+      "ts": 435696,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5fd0",
-      "tid": 16484,
-      "ts": 381094,
+      "id": "0x15aff327cf0",
+      "tid": 22764,
+      "ts": 435710,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10069,7 +10069,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x22abadcd130"
+            "id_ref": "0x15aff31e6f0"
           }
         }
       }
@@ -10078,45 +10078,45 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadccdd0",
-      "tid": 16484,
-      "ts": 381175,
+      "id": "0x15aff31e300",
+      "tid": 22764,
+      "ts": 435767,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababc70e0",
-      "tid": 16484,
-      "ts": 381401,
+      "id": "0x15aff319a80",
+      "tid": 22764,
+      "ts": 435950,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadcd130",
-      "tid": 16484,
-      "ts": 381427,
+      "id": "0x15aff31e6f0",
+      "tid": 22764,
+      "ts": 435968,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababb5fd0",
-      "tid": 16484,
-      "ts": 381589,
+      "id": "0x15aff327cf0",
+      "tid": 22764,
+      "ts": 436141,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 381665,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 436174,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10128,27 +10128,27 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadcd250",
-      "tid": 16484,
-      "ts": 381667,
+      "id": "0x15aff31d4f0",
+      "tid": 22764,
+      "ts": 436177,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababb5580",
-      "tid": 16484,
-      "ts": 381854,
+      "id": "0x15aff328e20",
+      "tid": 22764,
+      "ts": 436352,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 381916,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 436387,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10160,27 +10160,27 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadccb00",
-      "tid": 16484,
-      "ts": 381919,
+      "id": "0x15aff31ee40",
+      "tid": 22764,
+      "ts": 436390,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababb5210",
-      "tid": 16484,
-      "ts": 382083,
+      "id": "0x15aff327560",
+      "tid": 22764,
+      "ts": 436562,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 382148,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 436598,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10192,27 +10192,27 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadcc200",
-      "tid": 16484,
-      "ts": 382150,
+      "id": "0x15aff31df10",
+      "tid": 22764,
+      "ts": 436601,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababb5420",
-      "tid": 16484,
-      "ts": 382351,
+      "id": "0x15aff3285e0",
+      "tid": 22764,
+      "ts": 436774,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 382413,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 436809,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10224,99 +10224,99 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadcd520",
-      "tid": 16484,
-      "ts": 382416,
+      "id": "0x15aff31dd60",
+      "tid": 22764,
+      "ts": 436812,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababb58f0",
-      "tid": 16484,
-      "ts": 382586,
+      "id": "0x15aff319df0",
+      "tid": 22764,
+      "ts": 436988,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadf0600",
-      "tid": 16484,
-      "ts": 382601,
+      "id": "0x15afcc5c790",
+      "tid": 22764,
+      "ts": 436998,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadfa848",
-      "tid": 16484,
-      "ts": 382617,
+      "id": "0x15aff5315a8",
+      "tid": 22764,
+      "ts": 437012,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadfa348",
-      "tid": 16484,
-      "ts": 382641,
+      "id": "0x15aff5325a8",
+      "tid": 22764,
+      "ts": 437035,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadfa948",
-      "tid": 16484,
-      "ts": 382660,
+      "id": "0x15aff5328a8",
+      "tid": 22764,
+      "ts": 437053,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadfaa48",
-      "tid": 16484,
-      "ts": 382678,
+      "id": "0x15aff5326a8",
+      "tid": 22764,
+      "ts": 437070,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadfb048",
-      "tid": 16484,
-      "ts": 382695,
+      "id": "0x15aff531ca8",
+      "tid": 22764,
+      "ts": 437087,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadfb148",
-      "tid": 16484,
-      "ts": 382713,
+      "id": "0x15aff530ba8",
+      "tid": 22764,
+      "ts": 437104,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadfae48",
-      "tid": 16484,
-      "ts": 382730,
+      "id": "0x15aff530da8",
+      "tid": 22764,
+      "ts": 437121,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadfab48",
-      "tid": 16484,
-      "ts": 382747,
+      "id": "0x15aff531da8",
+      "tid": 22764,
+      "ts": 437138,
       "pid": "GPGMM"
     }
   ]

--- a/src/tests/capture_replay_tests/traces/webnn_mobilenetv2_nchw.json
+++ b/src/tests/capture_replay_tests/traces/webnn_mobilenetv2_nchw.json
@@ -5,27 +5,27 @@
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadf1280",
-      "tid": 16484,
-      "ts": 499841,
+      "id": "0x15afcc5bd90",
+      "tid": 22764,
+      "ts": 610258,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 499865,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 610279,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 499913,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 610346,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -37,18 +37,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 499917,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 610349,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 499924,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 610355,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -60,9 +60,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 499947,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 610374,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -74,9 +74,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 499957,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 610382,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -88,8 +88,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 499987,
+      "tid": 22764,
+      "ts": 610408,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -100,9 +100,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 500002,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 610420,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -114,9 +114,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 500013,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 610430,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -128,9 +128,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 500032,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 610444,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -142,9 +142,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 500039,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 610449,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -156,8 +156,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 500065,
+      "tid": 22764,
+      "ts": 610471,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -168,9 +168,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 500080,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 610482,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -182,9 +182,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 500087,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 610487,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -196,9 +196,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 500112,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 610510,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -210,9 +210,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 500119,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 610516,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -224,8 +224,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 500144,
+      "tid": 22764,
+      "ts": 610537,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -236,9 +236,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 500159,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 610553,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -250,9 +250,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 500166,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 610559,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -264,9 +264,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 500185,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 610573,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -278,9 +278,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 500192,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 610589,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -292,8 +292,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 500217,
+      "tid": 22764,
+      "ts": 610622,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -304,9 +304,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 500232,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 610648,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -318,9 +318,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 500239,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 610654,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -332,9 +332,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 500257,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 610668,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -346,9 +346,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 500265,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 610673,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -360,8 +360,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 500289,
+      "tid": 22764,
+      "ts": 610695,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -372,9 +372,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 500316,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 610736,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -386,9 +386,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 500324,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 610741,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -400,9 +400,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 500342,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 610756,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -414,9 +414,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 500350,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 610761,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -428,8 +428,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 500375,
+      "tid": 22764,
+      "ts": 610782,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -440,9 +440,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 500391,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 610793,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -454,9 +454,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 500397,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 610798,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -468,9 +468,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 500414,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 610812,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -482,9 +482,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 500420,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 610817,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -496,8 +496,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 500443,
+      "tid": 22764,
+      "ts": 610838,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -508,9 +508,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 500456,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 610853,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -522,9 +522,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 500463,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 610858,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -536,9 +536,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 500479,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 610872,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -550,9 +550,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 500485,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 610877,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -564,8 +564,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 500508,
+      "tid": 22764,
+      "ts": 610898,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -576,9 +576,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 500521,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 610909,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -590,9 +590,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 500527,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 610914,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -604,9 +604,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 500544,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 610928,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -618,9 +618,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 500550,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 610933,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -632,8 +632,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 500572,
+      "tid": 22764,
+      "ts": 610954,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -644,9 +644,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 500585,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 610965,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -658,9 +658,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 500591,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 610970,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -672,9 +672,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 500608,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 610984,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -686,9 +686,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 500614,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 610989,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -700,8 +700,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 500637,
+      "tid": 22764,
+      "ts": 611010,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -712,9 +712,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 500649,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 611021,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -726,9 +726,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 500675,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 611051,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -740,9 +740,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 500692,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 611066,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -754,9 +754,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 500698,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 611071,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -768,8 +768,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 500721,
+      "tid": 22764,
+      "ts": 611092,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -780,9 +780,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 500734,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 611115,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -794,9 +794,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 500740,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 611120,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -808,9 +808,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 500757,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 611146,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -822,9 +822,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 500763,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 611151,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -836,8 +836,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 500785,
+      "tid": 22764,
+      "ts": 611172,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -848,9 +848,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 500798,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 611183,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -862,9 +862,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 500804,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 611188,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -876,9 +876,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 500821,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 611202,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -890,9 +890,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 500827,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 611208,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -904,8 +904,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 500850,
+      "tid": 22764,
+      "ts": 611228,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -916,9 +916,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 500863,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 611239,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -930,9 +930,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 500869,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 611244,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -944,9 +944,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 500885,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 611258,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -958,9 +958,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 500891,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 611263,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -972,8 +972,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 500914,
+      "tid": 22764,
+      "ts": 611284,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -984,9 +984,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 500927,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 611295,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -998,9 +998,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 500933,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 611300,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1012,9 +1012,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 500949,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 611314,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1026,9 +1026,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 500956,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 611319,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1040,8 +1040,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 500978,
+      "tid": 22764,
+      "ts": 611340,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1052,9 +1052,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 500991,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 611351,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1066,9 +1066,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 500997,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 611356,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1080,9 +1080,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 501013,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 611370,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1094,9 +1094,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 501019,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 611375,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1108,8 +1108,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 501042,
+      "tid": 22764,
+      "ts": 611395,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1120,9 +1120,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 501055,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 611406,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1134,9 +1134,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 501061,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 611412,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1148,9 +1148,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 501077,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 611426,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1162,9 +1162,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 501083,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 611431,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1176,8 +1176,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 501106,
+      "tid": 22764,
+      "ts": 611451,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1188,9 +1188,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 501123,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 611466,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1202,9 +1202,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 501129,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 611472,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1216,9 +1216,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 501146,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 611486,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1230,9 +1230,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 501152,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 611491,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1244,8 +1244,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 501175,
+      "tid": 22764,
+      "ts": 611511,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -1256,9 +1256,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 501193,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 611527,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1270,9 +1270,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 501199,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 611533,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1284,9 +1284,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 501216,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 611547,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1298,9 +1298,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 501222,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 611552,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1312,8 +1312,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 501245,
+      "tid": 22764,
+      "ts": 611573,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -1324,9 +1324,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 501261,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 611587,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1338,9 +1338,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 501267,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 611592,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1352,9 +1352,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 501284,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 611607,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1366,9 +1366,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 501290,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 611612,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1380,8 +1380,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 501313,
+      "tid": 22764,
+      "ts": 611633,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -1392,9 +1392,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 501329,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 611646,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1406,9 +1406,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 501336,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 611652,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1420,9 +1420,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 501419,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 611702,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1434,9 +1434,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 501425,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 611707,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1448,8 +1448,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 501449,
+      "tid": 22764,
+      "ts": 611728,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -1460,9 +1460,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 501467,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 611744,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1474,9 +1474,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 501473,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 611750,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1488,9 +1488,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 501490,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 611764,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1502,9 +1502,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 501496,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 611769,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1516,8 +1516,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 501519,
+      "tid": 22764,
+      "ts": 611789,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -1528,9 +1528,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 501535,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 611803,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1542,9 +1542,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 501541,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 611809,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1556,9 +1556,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 501557,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 611823,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1570,9 +1570,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 501564,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 611828,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1584,9 +1584,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 501580,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 611842,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1598,9 +1598,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 501586,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 611847,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1612,8 +1612,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 501609,
+      "tid": 22764,
+      "ts": 611868,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -1624,8 +1624,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 501626,
+      "tid": 22764,
+      "ts": 611884,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -1636,8 +1636,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 501643,
+      "tid": 22764,
+      "ts": 611900,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -1648,8 +1648,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 501659,
+      "tid": 22764,
+      "ts": 611915,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -1660,8 +1660,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 501676,
+      "tid": 22764,
+      "ts": 611941,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -1672,8 +1672,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 501692,
+      "tid": 22764,
+      "ts": 611957,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -1684,8 +1684,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 501708,
+      "tid": 22764,
+      "ts": 611972,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -1696,8 +1696,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 501724,
+      "tid": 22764,
+      "ts": 611999,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -1708,8 +1708,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 501741,
+      "tid": 22764,
+      "ts": 612027,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -1720,8 +1720,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 501757,
+      "tid": 22764,
+      "ts": 612042,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -1732,8 +1732,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 501774,
+      "tid": 22764,
+      "ts": 612058,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -1744,8 +1744,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 501790,
+      "tid": 22764,
+      "ts": 612085,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -1756,18 +1756,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 501796,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 612091,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 501818,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 612112,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1779,18 +1779,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 501820,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 612114,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 501825,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 612118,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1802,9 +1802,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 501843,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 612134,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1816,9 +1816,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 501849,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 612150,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1830,8 +1830,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 501873,
+      "tid": 22764,
+      "ts": 612172,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1842,9 +1842,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 501886,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 612183,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1856,9 +1856,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 501892,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 612189,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1870,9 +1870,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 501908,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 612215,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1884,9 +1884,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 501915,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 612220,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1898,8 +1898,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 501937,
+      "tid": 22764,
+      "ts": 612241,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1910,9 +1910,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 501950,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 612253,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1924,9 +1924,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 501956,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 612259,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1938,9 +1938,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 501973,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 612284,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1952,9 +1952,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 501979,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 612289,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1966,8 +1966,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 502001,
+      "tid": 22764,
+      "ts": 612309,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1978,9 +1978,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 502014,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 612321,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1992,9 +1992,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 502020,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 612327,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2006,9 +2006,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 502037,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 612341,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2020,9 +2020,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 502043,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 612347,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2034,8 +2034,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 502066,
+      "tid": 22764,
+      "ts": 612379,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2046,9 +2046,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 502078,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 612391,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2060,9 +2060,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 502084,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 612396,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2074,9 +2074,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 502101,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 612422,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2088,9 +2088,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 502107,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 612427,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2102,8 +2102,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 502130,
+      "tid": 22764,
+      "ts": 612459,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2114,9 +2114,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 502143,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 612471,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2128,9 +2128,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 502149,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 612487,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2142,9 +2142,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 502165,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 612516,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2156,9 +2156,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 502172,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 612537,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2170,8 +2170,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 502194,
+      "tid": 22764,
+      "ts": 612571,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2182,9 +2182,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 502207,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 612582,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2196,9 +2196,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 502213,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 612587,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2210,9 +2210,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 502229,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 612601,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2224,9 +2224,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 502236,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 612606,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2238,8 +2238,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 502258,
+      "tid": 22764,
+      "ts": 612627,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2250,9 +2250,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 502271,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 612637,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2264,9 +2264,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 502277,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 612643,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2278,9 +2278,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 502294,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 612657,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2292,9 +2292,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 502300,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 612662,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2306,8 +2306,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 502322,
+      "tid": 22764,
+      "ts": 612682,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2318,9 +2318,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 502335,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 612693,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2332,9 +2332,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 502341,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 612698,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2346,9 +2346,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 502358,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 612712,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2360,9 +2360,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 502364,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 612717,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2374,8 +2374,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 502387,
+      "tid": 22764,
+      "ts": 612737,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2386,9 +2386,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 502401,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 612748,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2400,9 +2400,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 502408,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 612753,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2414,9 +2414,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 502424,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 612768,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2428,9 +2428,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 502430,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 612773,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2442,8 +2442,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 502453,
+      "tid": 22764,
+      "ts": 612793,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2454,9 +2454,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 502466,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 612804,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2468,9 +2468,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 502472,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 612809,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2482,9 +2482,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 502488,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 612823,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2496,9 +2496,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 502494,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 612829,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2510,8 +2510,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 502517,
+      "tid": 22764,
+      "ts": 612849,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2522,9 +2522,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 502530,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 612860,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2536,9 +2536,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 502536,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 612865,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2550,9 +2550,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 502553,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 612879,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2564,9 +2564,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 502559,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 612884,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2578,8 +2578,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 502581,
+      "tid": 22764,
+      "ts": 612904,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2590,9 +2590,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 502594,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 612915,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2604,9 +2604,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 502601,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 612921,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2618,9 +2618,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 502617,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 612934,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2632,9 +2632,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 502623,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 612940,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2646,8 +2646,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 502646,
+      "tid": 22764,
+      "ts": 612960,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2658,9 +2658,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 502659,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 612971,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2672,9 +2672,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 502665,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 612976,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2686,9 +2686,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 502681,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 612990,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2700,9 +2700,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 502687,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 612995,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2714,8 +2714,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 502710,
+      "tid": 22764,
+      "ts": 613015,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2726,9 +2726,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 502723,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 613026,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2740,9 +2740,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 502729,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 613032,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2754,9 +2754,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 502746,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 613045,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2768,9 +2768,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 502752,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 613051,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2782,8 +2782,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 502775,
+      "tid": 22764,
+      "ts": 613071,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2794,9 +2794,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 502787,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 613082,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2808,9 +2808,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 502793,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 613087,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2822,9 +2822,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 502810,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 613113,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2836,9 +2836,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 502816,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 613119,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2850,8 +2850,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 502839,
+      "tid": 22764,
+      "ts": 613150,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2862,9 +2862,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 502851,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 613161,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2876,9 +2876,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 502991,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 613237,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2890,9 +2890,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 503009,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 613252,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2904,9 +2904,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 503015,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 613257,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2918,8 +2918,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 503038,
+      "tid": 22764,
+      "ts": 613278,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2930,9 +2930,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 503055,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 613292,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2944,9 +2944,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 503062,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 613298,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2958,9 +2958,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 503079,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 613312,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2972,9 +2972,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 503085,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 613317,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2986,8 +2986,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 503108,
+      "tid": 22764,
+      "ts": 613337,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -2998,9 +2998,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 503125,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 613352,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3012,9 +3012,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 503132,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 613358,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3026,9 +3026,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 503148,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 613372,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3040,9 +3040,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 503154,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 613377,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3054,8 +3054,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 503177,
+      "tid": 22764,
+      "ts": 613398,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -3066,9 +3066,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 503193,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 613411,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3080,9 +3080,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 503200,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 613417,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3094,9 +3094,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 503216,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 613431,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3108,9 +3108,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 503222,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 613436,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3122,8 +3122,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 503245,
+      "tid": 22764,
+      "ts": 613456,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -3134,9 +3134,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 503262,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 613470,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3148,9 +3148,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 503268,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 613475,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3162,9 +3162,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 503284,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 613489,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3176,9 +3176,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 503302,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 613494,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3190,8 +3190,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 503325,
+      "tid": 22764,
+      "ts": 613514,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -3202,9 +3202,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 503343,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 613529,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3216,9 +3216,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 503349,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 613535,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3230,9 +3230,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 503366,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 613549,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3244,9 +3244,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 503373,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 613554,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3258,8 +3258,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 503397,
+      "tid": 22764,
+      "ts": 613575,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -3270,9 +3270,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 503414,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 613589,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3284,9 +3284,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 503421,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 613594,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3298,9 +3298,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 503438,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 613608,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3312,9 +3312,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 503444,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 613613,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3326,9 +3326,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 503461,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 613628,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3340,9 +3340,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 503468,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 613633,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3354,8 +3354,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 503491,
+      "tid": 22764,
+      "ts": 613653,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -3366,8 +3366,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 503508,
+      "tid": 22764,
+      "ts": 613668,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -3378,8 +3378,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 503525,
+      "tid": 22764,
+      "ts": 613683,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -3390,8 +3390,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 503542,
+      "tid": 22764,
+      "ts": 613699,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -3402,8 +3402,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 503559,
+      "tid": 22764,
+      "ts": 613714,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -3414,8 +3414,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 503586,
+      "tid": 22764,
+      "ts": 613729,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -3426,8 +3426,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 503603,
+      "tid": 22764,
+      "ts": 613744,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -3438,8 +3438,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 503619,
+      "tid": 22764,
+      "ts": 613759,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -3450,8 +3450,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 503636,
+      "tid": 22764,
+      "ts": 613774,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -3462,8 +3462,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 503652,
+      "tid": 22764,
+      "ts": 613789,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -3474,8 +3474,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 503668,
+      "tid": 22764,
+      "ts": 613804,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -3486,8 +3486,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 503685,
+      "tid": 22764,
+      "ts": 613819,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -3498,18 +3498,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 503691,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 613825,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 503714,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 613842,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3521,18 +3521,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 503716,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 613845,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 503721,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 613849,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3544,9 +3544,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 503739,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 613863,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3558,9 +3558,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 503745,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 613869,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3572,8 +3572,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 503768,
+      "tid": 22764,
+      "ts": 613890,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3584,9 +3584,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 503794,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 613901,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3598,9 +3598,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 503801,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 613906,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3612,9 +3612,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 503818,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 613920,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3626,9 +3626,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 503824,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 613925,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3640,8 +3640,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 503847,
+      "tid": 22764,
+      "ts": 613945,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3652,9 +3652,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 503860,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 613956,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3666,9 +3666,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 503867,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 613962,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3680,9 +3680,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 503884,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 613976,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3694,9 +3694,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 503890,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 613981,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3708,8 +3708,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 503913,
+      "tid": 22764,
+      "ts": 614001,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3720,9 +3720,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 503926,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 614014,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3734,9 +3734,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 503932,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 614019,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3748,9 +3748,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 503949,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 614033,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3762,9 +3762,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 503956,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 614038,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3776,8 +3776,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 503979,
+      "tid": 22764,
+      "ts": 614059,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3788,9 +3788,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 503992,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 614070,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3802,9 +3802,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 503999,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 614075,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3816,9 +3816,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 504015,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 614089,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3830,9 +3830,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 504022,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 614105,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3844,8 +3844,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 504045,
+      "tid": 22764,
+      "ts": 614140,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3856,9 +3856,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 504058,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 614164,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3870,9 +3870,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 504064,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 614185,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3884,9 +3884,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 504081,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 614199,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3898,9 +3898,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 504088,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 614205,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3912,8 +3912,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 504111,
+      "tid": 22764,
+      "ts": 614225,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3924,9 +3924,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 504124,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 614236,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3938,9 +3938,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 504130,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 614241,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3952,9 +3952,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 504147,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 614255,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3966,9 +3966,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 504153,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 614260,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3980,8 +3980,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 504176,
+      "tid": 22764,
+      "ts": 614281,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3992,9 +3992,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 504190,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 614291,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4006,9 +4006,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 504196,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 614297,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4020,9 +4020,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 504213,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 614311,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4034,9 +4034,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 504219,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 614316,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4048,8 +4048,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 504242,
+      "tid": 22764,
+      "ts": 614336,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4060,9 +4060,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 504255,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 614347,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4074,9 +4074,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 504262,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 614352,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4088,9 +4088,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 504278,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 614366,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4102,9 +4102,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 504285,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 614371,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4116,8 +4116,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 504308,
+      "tid": 22764,
+      "ts": 614392,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4128,9 +4128,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 504321,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 614402,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4142,9 +4142,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 504327,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 614408,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4156,9 +4156,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 504344,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 614422,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4170,9 +4170,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 504350,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 614427,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4184,8 +4184,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 504373,
+      "tid": 22764,
+      "ts": 614459,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4196,9 +4196,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 504388,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 614470,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4210,9 +4210,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 504394,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 614475,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4224,9 +4224,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 504411,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 614489,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4238,9 +4238,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 504417,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 614506,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4252,8 +4252,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 504441,
+      "tid": 22764,
+      "ts": 614528,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4264,9 +4264,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 504454,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 614539,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4278,9 +4278,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 504460,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 614556,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4292,9 +4292,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 504477,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 614570,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4306,9 +4306,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 504483,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 614575,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4320,8 +4320,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 504507,
+      "tid": 22764,
+      "ts": 614596,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4332,9 +4332,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 504531,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 614607,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4346,9 +4346,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 504553,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 614613,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4360,9 +4360,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 504570,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 614627,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4374,9 +4374,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 504576,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 614633,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4388,8 +4388,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 504610,
+      "tid": 22764,
+      "ts": 614653,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4400,9 +4400,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 504639,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 614664,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4414,9 +4414,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 504645,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 614670,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4428,9 +4428,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 504662,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 614684,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4442,9 +4442,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 504668,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 614690,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4456,8 +4456,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 504691,
+      "tid": 22764,
+      "ts": 614711,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4468,9 +4468,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 504705,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 614722,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4482,9 +4482,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 504711,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 614727,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4496,9 +4496,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 504728,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 614741,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4510,9 +4510,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 504734,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 614747,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4524,8 +4524,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 504757,
+      "tid": 22764,
+      "ts": 614768,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4536,9 +4536,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 504779,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 614779,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4550,9 +4550,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 504802,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 614784,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4564,9 +4564,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 504846,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 614799,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4578,9 +4578,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 504853,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 614804,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4592,8 +4592,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 504878,
+      "tid": 22764,
+      "ts": 614825,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4604,9 +4604,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 504891,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 614836,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4618,9 +4618,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 504897,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 614841,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4632,9 +4632,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 504914,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 614855,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4646,9 +4646,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 504921,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 614861,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4660,8 +4660,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 504944,
+      "tid": 22764,
+      "ts": 614881,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4672,9 +4672,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 504972,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 614901,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4686,9 +4686,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 504990,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 614907,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4700,9 +4700,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 505007,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 614921,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4714,9 +4714,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 505013,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 614927,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4728,8 +4728,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 505037,
+      "tid": 22764,
+      "ts": 614949,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -4740,9 +4740,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 505081,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 614964,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4754,9 +4754,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 505088,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 614970,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4768,9 +4768,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 505105,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 614984,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4782,9 +4782,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 505122,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 614990,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4796,8 +4796,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 505150,
+      "tid": 22764,
+      "ts": 615011,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -4808,9 +4808,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 505169,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 615025,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4822,9 +4822,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 505176,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 615031,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4836,9 +4836,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 505193,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 615057,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4850,9 +4850,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 505199,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 615062,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4864,8 +4864,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 505223,
+      "tid": 22764,
+      "ts": 615084,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -4876,9 +4876,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 505240,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 615100,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4890,9 +4890,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 505246,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 615116,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4904,9 +4904,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 505263,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 615131,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4918,9 +4918,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 505270,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 615136,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4932,8 +4932,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 505293,
+      "tid": 22764,
+      "ts": 615157,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -4944,9 +4944,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 505311,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 615172,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4958,9 +4958,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 505318,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 615178,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4972,9 +4972,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 505335,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 615193,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4986,9 +4986,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 505341,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 615198,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5000,8 +5000,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 505365,
+      "tid": 22764,
+      "ts": 615219,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -5012,9 +5012,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 505381,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 615233,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5026,9 +5026,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 505389,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 615239,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5040,9 +5040,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 505406,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 615253,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5054,9 +5054,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 505413,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 615259,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5068,9 +5068,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 505430,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 615273,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5082,9 +5082,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 505436,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 615278,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5096,8 +5096,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 505459,
+      "tid": 22764,
+      "ts": 615299,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -5108,8 +5108,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 505476,
+      "tid": 22764,
+      "ts": 615330,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -5120,8 +5120,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 505494,
+      "tid": 22764,
+      "ts": 615347,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -5132,8 +5132,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 505510,
+      "tid": 22764,
+      "ts": 615374,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -5144,8 +5144,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 505528,
+      "tid": 22764,
+      "ts": 615401,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -5156,8 +5156,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 505555,
+      "tid": 22764,
+      "ts": 615428,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -5168,8 +5168,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 505572,
+      "tid": 22764,
+      "ts": 615443,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -5180,8 +5180,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 505588,
+      "tid": 22764,
+      "ts": 615459,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -5192,8 +5192,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 505605,
+      "tid": 22764,
+      "ts": 615475,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -5204,8 +5204,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 505633,
+      "tid": 22764,
+      "ts": 615502,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -5216,8 +5216,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 505660,
+      "tid": 22764,
+      "ts": 615528,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -5228,8 +5228,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 505677,
+      "tid": 22764,
+      "ts": 615544,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -5240,18 +5240,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 505683,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 615550,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 505705,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 615569,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5263,18 +5263,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 505708,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 615571,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 505712,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 615586,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5286,9 +5286,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 505730,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 615601,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5300,9 +5300,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 505736,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 615606,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5314,8 +5314,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 505759,
+      "tid": 22764,
+      "ts": 615627,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5326,9 +5326,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 505772,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 615638,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5340,9 +5340,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 505779,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 615643,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5354,9 +5354,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 505795,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 615657,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5368,9 +5368,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 505801,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 615662,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5382,8 +5382,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 505824,
+      "tid": 22764,
+      "ts": 615683,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5394,9 +5394,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 505837,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 615694,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5408,9 +5408,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 505843,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 615699,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5422,9 +5422,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 505860,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 615713,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5436,9 +5436,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 505866,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 615718,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5450,8 +5450,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 505889,
+      "tid": 22764,
+      "ts": 615739,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5462,9 +5462,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 505902,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 615750,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5476,9 +5476,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 505908,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 615755,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5490,9 +5490,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 505924,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 615770,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5504,9 +5504,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 505930,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 615775,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5518,8 +5518,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 505953,
+      "tid": 22764,
+      "ts": 615795,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5530,9 +5530,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 505966,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 615806,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5544,9 +5544,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 505972,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 615812,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5558,9 +5558,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 505988,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 615826,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5572,9 +5572,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 505994,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 615831,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5586,8 +5586,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 506017,
+      "tid": 22764,
+      "ts": 615851,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5598,9 +5598,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 506030,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 615862,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5612,9 +5612,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 506036,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 615868,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5626,9 +5626,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 506052,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 615881,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5640,9 +5640,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 506059,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 615887,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5654,8 +5654,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 506081,
+      "tid": 22764,
+      "ts": 615907,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5666,9 +5666,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 506094,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 615918,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5680,9 +5680,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 506100,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 615923,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5694,9 +5694,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 506117,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 615937,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5708,9 +5708,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 506123,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 615942,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5722,8 +5722,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 506146,
+      "tid": 22764,
+      "ts": 615962,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5734,9 +5734,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 506158,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 615973,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5748,9 +5748,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 506164,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 615979,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5762,9 +5762,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 506181,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 615993,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5776,9 +5776,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 506187,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 615998,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5790,8 +5790,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 506462,
+      "tid": 22764,
+      "ts": 616342,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5802,9 +5802,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 506475,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 616355,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5816,9 +5816,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 506482,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 616361,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5830,9 +5830,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 506499,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 616375,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5844,9 +5844,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 506505,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 616380,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5858,8 +5858,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 506527,
+      "tid": 22764,
+      "ts": 616401,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5870,9 +5870,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 506540,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 616413,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5884,9 +5884,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 506546,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 616418,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5898,9 +5898,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 506563,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 616433,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5912,9 +5912,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 506569,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 616438,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5926,8 +5926,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 506591,
+      "tid": 22764,
+      "ts": 616459,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5938,9 +5938,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 506604,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 616470,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5952,9 +5952,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 506610,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 616475,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5966,9 +5966,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 506627,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 616489,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5980,9 +5980,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 506633,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 616495,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5994,8 +5994,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 506655,
+      "tid": 22764,
+      "ts": 616515,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6006,9 +6006,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 506668,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 616527,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6020,9 +6020,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 506675,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 616532,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6034,9 +6034,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 506691,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 616546,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6048,9 +6048,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 506697,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 616552,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6062,8 +6062,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 506720,
+      "tid": 22764,
+      "ts": 616572,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6074,9 +6074,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 506732,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 616584,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6088,9 +6088,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 506739,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 616589,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6102,9 +6102,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 506755,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 616604,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6116,9 +6116,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 506761,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 616609,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6130,8 +6130,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 506784,
+      "tid": 22764,
+      "ts": 616630,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6142,9 +6142,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 506797,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 616641,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6156,9 +6156,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 506803,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 616647,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6170,9 +6170,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 506820,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 616661,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6184,9 +6184,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 506826,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 616666,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6198,8 +6198,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 506848,
+      "tid": 22764,
+      "ts": 616687,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6210,9 +6210,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 506861,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 616698,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6224,9 +6224,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 506867,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 616703,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6238,9 +6238,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 506884,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 616717,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6252,9 +6252,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 506890,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 616723,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6266,8 +6266,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 506913,
+      "tid": 22764,
+      "ts": 616743,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6278,9 +6278,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 506926,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 616754,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6292,9 +6292,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 506932,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 616760,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6306,9 +6306,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 506948,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 616774,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6320,9 +6320,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 506954,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 616780,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6334,8 +6334,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 506977,
+      "tid": 22764,
+      "ts": 616800,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6346,9 +6346,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 506990,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 616812,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6360,9 +6360,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 506996,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 616817,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6374,9 +6374,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 507013,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 616831,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6388,9 +6388,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 507019,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 616837,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6402,8 +6402,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 507041,
+      "tid": 22764,
+      "ts": 616857,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6414,9 +6414,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 507059,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 616873,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6428,9 +6428,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 507065,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 616879,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6442,9 +6442,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 507082,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 616893,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6456,9 +6456,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 507088,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 616899,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6470,8 +6470,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 507110,
+      "tid": 22764,
+      "ts": 616920,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -6482,9 +6482,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 507128,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 616936,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6496,9 +6496,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 507134,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 616942,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6510,9 +6510,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 507151,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 616957,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6524,9 +6524,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 507157,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 616962,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6538,8 +6538,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 507182,
+      "tid": 22764,
+      "ts": 616983,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -6550,9 +6550,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 507198,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 616998,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6564,9 +6564,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 507205,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 617003,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6578,9 +6578,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 507221,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 617018,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6592,9 +6592,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 507227,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 617023,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6606,8 +6606,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 507251,
+      "tid": 22764,
+      "ts": 617044,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -6618,9 +6618,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 507269,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 617058,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6632,9 +6632,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 507276,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 617064,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6646,9 +6646,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 507292,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 617078,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6660,9 +6660,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 507298,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 617084,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6674,8 +6674,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 507321,
+      "tid": 22764,
+      "ts": 617107,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -6686,9 +6686,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 507338,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 617123,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6700,9 +6700,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 507345,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 617128,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6714,9 +6714,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 507361,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 617143,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6728,9 +6728,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 507367,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 617149,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6742,8 +6742,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 507392,
+      "tid": 22764,
+      "ts": 617170,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -6754,9 +6754,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 507408,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 617186,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6768,9 +6768,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 507414,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 617191,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6782,9 +6782,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 507431,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 617206,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6796,9 +6796,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 507437,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 617211,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6810,9 +6810,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 507454,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 617226,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6824,9 +6824,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 507460,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 617231,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6838,8 +6838,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 507482,
+      "tid": 22764,
+      "ts": 617251,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -6850,8 +6850,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 507499,
+      "tid": 22764,
+      "ts": 617268,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -6862,8 +6862,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 507516,
+      "tid": 22764,
+      "ts": 617283,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -6874,8 +6874,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 507532,
+      "tid": 22764,
+      "ts": 617299,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -6886,8 +6886,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 507549,
+      "tid": 22764,
+      "ts": 617314,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -6898,8 +6898,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 507565,
+      "tid": 22764,
+      "ts": 617330,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -6910,8 +6910,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 507582,
+      "tid": 22764,
+      "ts": 617345,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -6922,8 +6922,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 507598,
+      "tid": 22764,
+      "ts": 617361,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -6934,8 +6934,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 507615,
+      "tid": 22764,
+      "ts": 617376,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -6946,8 +6946,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 507631,
+      "tid": 22764,
+      "ts": 617403,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -6958,8 +6958,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 507648,
+      "tid": 22764,
+      "ts": 617419,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -6970,8 +6970,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 507664,
+      "tid": 22764,
+      "ts": 617450,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -6982,18 +6982,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 507671,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 617457,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 507691,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 617479,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7005,18 +7005,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 507694,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 617481,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 507699,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 617486,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7028,9 +7028,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 507716,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 617502,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7042,9 +7042,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 507723,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 617508,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7056,8 +7056,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 507746,
+      "tid": 22764,
+      "ts": 617541,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7068,9 +7068,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 507759,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 617553,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7082,9 +7082,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 507765,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 617558,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7096,9 +7096,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 507782,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 617572,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7110,9 +7110,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 507788,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 617578,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7124,8 +7124,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 507811,
+      "tid": 22764,
+      "ts": 617599,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7136,9 +7136,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 507824,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 617610,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7150,9 +7150,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 507830,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 617615,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7164,9 +7164,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 507847,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 617630,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7178,9 +7178,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 507853,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 617635,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7192,8 +7192,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 507875,
+      "tid": 22764,
+      "ts": 617656,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7204,9 +7204,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 507888,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 617667,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7218,9 +7218,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 507894,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 617672,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7232,9 +7232,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 507911,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 617687,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7246,9 +7246,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 507917,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 617692,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7260,8 +7260,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 507940,
+      "tid": 22764,
+      "ts": 617713,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7272,9 +7272,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 507952,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 617724,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7286,9 +7286,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 507959,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 617730,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7300,9 +7300,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 507975,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 617744,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7314,9 +7314,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 507981,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 617749,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7328,8 +7328,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 508004,
+      "tid": 22764,
+      "ts": 617770,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7340,9 +7340,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 508017,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 617781,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7354,9 +7354,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 508023,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 617786,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7368,9 +7368,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 508040,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 617801,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7382,9 +7382,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 508046,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 617806,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7396,8 +7396,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 508068,
+      "tid": 22764,
+      "ts": 617827,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7408,9 +7408,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 508081,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 617838,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7422,9 +7422,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 508087,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 617844,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7436,9 +7436,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 508104,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 617858,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7450,9 +7450,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 508110,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 617863,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7464,8 +7464,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 508132,
+      "tid": 22764,
+      "ts": 617884,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7476,9 +7476,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 508145,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 617895,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7490,9 +7490,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 508151,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 617900,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7504,9 +7504,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 508168,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 617915,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7518,9 +7518,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 508174,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 617920,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7532,8 +7532,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 508196,
+      "tid": 22764,
+      "ts": 617941,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7544,9 +7544,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 508209,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 617952,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7558,9 +7558,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 508216,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 617957,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7572,9 +7572,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 508232,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 617972,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7586,9 +7586,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 508238,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 617977,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7600,8 +7600,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 508261,
+      "tid": 22764,
+      "ts": 617998,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7612,9 +7612,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 508274,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 618009,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7626,9 +7626,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 508280,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 618014,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7640,9 +7640,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 508296,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 618029,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7654,9 +7654,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 508302,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 618034,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7668,8 +7668,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 508325,
+      "tid": 22764,
+      "ts": 618055,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7680,9 +7680,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 508337,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 618066,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7694,9 +7694,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 508344,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 618071,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7708,9 +7708,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 508360,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 618086,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7722,9 +7722,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 508366,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 618092,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7736,8 +7736,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 508390,
+      "tid": 22764,
+      "ts": 618113,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7748,9 +7748,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 508431,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 618125,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7762,9 +7762,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 508446,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 618130,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7776,9 +7776,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 508478,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 618145,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7790,9 +7790,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 508496,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 618150,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7804,8 +7804,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 508523,
+      "tid": 22764,
+      "ts": 618171,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7816,9 +7816,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 508538,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 618182,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7830,9 +7830,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 508546,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 618187,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7844,9 +7844,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 508564,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 618213,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7858,9 +7858,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 508572,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 618218,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7872,8 +7872,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 508608,
+      "tid": 22764,
+      "ts": 618240,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7884,9 +7884,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 508622,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 618262,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7898,9 +7898,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 508630,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 618267,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7912,9 +7912,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 508648,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 618282,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7926,9 +7926,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 508655,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 618287,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7940,8 +7940,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 508680,
+      "tid": 22764,
+      "ts": 618308,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7952,9 +7952,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 508695,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 618319,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7966,9 +7966,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 508702,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 618325,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7980,9 +7980,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 508721,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 618339,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7994,9 +7994,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 508728,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 618344,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8008,8 +8008,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 508753,
+      "tid": 22764,
+      "ts": 618365,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -8020,9 +8020,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 508767,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 618376,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8034,9 +8034,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 508775,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 618382,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8048,9 +8048,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 508793,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 618396,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8062,9 +8062,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 508800,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 618402,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8076,8 +8076,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 508825,
+      "tid": 22764,
+      "ts": 618422,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -8088,9 +8088,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 508840,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 618433,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8102,9 +8102,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 508847,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 618439,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8116,9 +8116,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 508866,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 618453,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8130,9 +8130,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 508873,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 618458,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8144,8 +8144,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 508898,
+      "tid": 22764,
+      "ts": 618479,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -8156,9 +8156,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 508917,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 618494,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8170,9 +8170,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 508925,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 618499,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8184,9 +8184,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 508943,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 618514,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8198,9 +8198,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 508951,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 618519,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8212,8 +8212,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 508976,
+      "tid": 22764,
+      "ts": 618540,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -8224,9 +8224,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 508995,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 618556,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8238,9 +8238,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 509003,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 618561,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8252,9 +8252,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 509021,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 618576,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8266,9 +8266,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 509028,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 618581,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8280,8 +8280,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 509053,
+      "tid": 22764,
+      "ts": 618620,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -8292,9 +8292,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 509073,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 618636,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8306,9 +8306,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 509081,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 618642,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8320,9 +8320,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 509099,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 618657,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8334,9 +8334,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 509106,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 618663,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8348,8 +8348,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 509132,
+      "tid": 22764,
+      "ts": 618685,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -8360,9 +8360,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 509150,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 618712,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8374,9 +8374,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 509158,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 618717,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8388,9 +8388,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 509176,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 618732,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8402,9 +8402,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 509184,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 618738,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8416,8 +8416,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 509209,
+      "tid": 22764,
+      "ts": 618759,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -8428,9 +8428,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 509228,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 618774,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8442,9 +8442,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 509235,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 618780,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8456,9 +8456,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 509254,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 618794,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8470,9 +8470,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 509261,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 618800,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8484,8 +8484,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 509286,
+      "tid": 22764,
+      "ts": 618821,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -8496,9 +8496,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 509304,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 618847,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8510,9 +8510,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 509311,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 618853,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8524,9 +8524,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 509330,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 618868,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8538,9 +8538,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 509337,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 618874,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8552,9 +8552,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 509356,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 618899,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8566,9 +8566,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 509363,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 618904,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8580,8 +8580,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 509389,
+      "tid": 22764,
+      "ts": 618925,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -8592,8 +8592,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 509405,
+      "tid": 22764,
+      "ts": 618941,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -8604,8 +8604,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 509424,
+      "tid": 22764,
+      "ts": 618968,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -8616,8 +8616,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 509440,
+      "tid": 22764,
+      "ts": 618985,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -8628,8 +8628,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 509457,
+      "tid": 22764,
+      "ts": 619001,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -8640,8 +8640,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 509473,
+      "tid": 22764,
+      "ts": 619028,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -8652,8 +8652,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 509489,
+      "tid": 22764,
+      "ts": 619044,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -8664,8 +8664,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 509506,
+      "tid": 22764,
+      "ts": 619064,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -8676,8 +8676,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 509522,
+      "tid": 22764,
+      "ts": 619080,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -8688,8 +8688,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 509539,
+      "tid": 22764,
+      "ts": 619097,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -8700,8 +8700,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 509555,
+      "tid": 22764,
+      "ts": 619113,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -8712,8 +8712,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 509572,
+      "tid": 22764,
+      "ts": 619128,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -8724,18 +8724,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 509578,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 619139,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 509600,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 619169,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8747,18 +8747,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 509602,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 619172,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 509607,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 619176,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8770,9 +8770,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 509624,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 619192,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8784,9 +8784,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 509631,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 619197,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8798,8 +8798,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 509656,
+      "tid": 22764,
+      "ts": 619220,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -8810,9 +8810,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 509669,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 619231,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8824,9 +8824,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 509675,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 619237,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8838,9 +8838,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 509692,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 619262,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8852,9 +8852,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 509698,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 619268,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8866,8 +8866,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 509721,
+      "tid": 22764,
+      "ts": 619305,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -8878,9 +8878,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 509734,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 619316,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8892,9 +8892,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 509740,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 619322,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8906,9 +8906,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 509757,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 619337,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8920,9 +8920,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 509763,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 619342,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8934,8 +8934,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 509786,
+      "tid": 22764,
+      "ts": 619363,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -8946,9 +8946,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 509799,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 619375,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8960,9 +8960,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 509806,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 619380,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8974,9 +8974,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 509822,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 619406,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8988,9 +8988,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 509828,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 619412,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9002,8 +9002,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 509851,
+      "tid": 22764,
+      "ts": 619432,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -9014,9 +9014,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 509864,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 619444,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9028,9 +9028,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 509870,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 619449,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9042,9 +9042,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 509887,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 619464,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9056,9 +9056,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 509893,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 619469,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9070,8 +9070,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 509916,
+      "tid": 22764,
+      "ts": 619490,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -9082,9 +9082,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 509929,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 619501,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9096,9 +9096,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 509935,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 619507,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9110,9 +9110,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 509952,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 619521,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9124,9 +9124,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 509958,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 619527,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9138,8 +9138,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 509981,
+      "tid": 22764,
+      "ts": 619559,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -9150,9 +9150,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 509994,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 619581,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9164,9 +9164,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 510000,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 619588,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9178,9 +9178,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 510016,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 619618,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9192,9 +9192,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 510022,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 619623,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9206,8 +9206,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 510045,
+      "tid": 22764,
+      "ts": 619644,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -9218,9 +9218,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 510058,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 619655,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9232,9 +9232,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 510064,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 619660,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9246,9 +9246,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 510081,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 619675,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9260,9 +9260,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 510087,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 619686,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9274,8 +9274,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 510110,
+      "tid": 22764,
+      "ts": 619707,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -9286,9 +9286,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 510123,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 619718,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9300,9 +9300,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 510130,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 619723,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9314,9 +9314,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 510146,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 619737,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9328,9 +9328,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 510152,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 619742,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9342,8 +9342,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 510175,
+      "tid": 22764,
+      "ts": 619762,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -9354,9 +9354,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 510188,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 619773,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9368,9 +9368,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 510195,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 619779,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9382,9 +9382,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 510211,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 619793,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9396,9 +9396,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 510217,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 619798,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9410,8 +9410,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 510241,
+      "tid": 22764,
+      "ts": 619818,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -9422,9 +9422,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 510253,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 619829,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9436,9 +9436,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 510260,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 619834,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9450,9 +9450,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 510276,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 619848,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9464,9 +9464,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 510282,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 619853,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9478,8 +9478,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 510306,
+      "tid": 22764,
+      "ts": 619873,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -9490,9 +9490,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 510319,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 619884,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9504,9 +9504,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 510325,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 619890,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9518,9 +9518,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 510341,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 619903,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9532,9 +9532,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 510347,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 619909,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9546,8 +9546,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 510371,
+      "tid": 22764,
+      "ts": 619940,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -9558,9 +9558,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 510385,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 619951,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9572,9 +9572,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 510391,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 619957,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9586,9 +9586,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 510408,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 619971,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9600,9 +9600,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 510414,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 619976,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9614,8 +9614,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 510437,
+      "tid": 22764,
+      "ts": 620009,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -9626,9 +9626,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 510450,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 620031,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9640,9 +9640,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 510456,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 620037,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9654,9 +9654,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 510473,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 620051,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9668,9 +9668,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 510479,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 620056,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9682,8 +9682,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 510502,
+      "tid": 22764,
+      "ts": 620077,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -9694,9 +9694,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 510516,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 620088,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9708,9 +9708,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 510522,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 620105,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9722,9 +9722,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 510538,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 620121,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9736,9 +9736,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 510544,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 620127,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9750,8 +9750,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 510568,
+      "tid": 22764,
+      "ts": 620148,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -9762,9 +9762,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 510581,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 620160,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9776,9 +9776,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 510587,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 620166,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9790,9 +9790,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 510604,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 620191,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9804,9 +9804,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 510610,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 620196,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9818,8 +9818,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 510633,
+      "tid": 22764,
+      "ts": 620217,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -9830,9 +9830,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 510647,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 620240,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9844,9 +9844,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 510653,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 620245,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9858,9 +9858,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 510669,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 620260,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9872,9 +9872,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 510675,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 620265,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9886,8 +9886,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 510699,
+      "tid": 22764,
+      "ts": 620297,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -9898,9 +9898,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 510717,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 620312,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9912,9 +9912,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 510723,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 620317,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9926,9 +9926,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 510740,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 620332,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9940,9 +9940,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 510746,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 620337,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9954,8 +9954,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 510769,
+      "tid": 22764,
+      "ts": 620358,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -9966,9 +9966,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 510786,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 620380,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9980,9 +9980,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 510792,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 620397,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9994,9 +9994,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 510809,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 620412,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10008,9 +10008,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 510815,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 620417,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10022,8 +10022,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 510838,
+      "tid": 22764,
+      "ts": 620449,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -10034,9 +10034,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 510854,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 620475,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10048,9 +10048,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 510860,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 620491,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10062,9 +10062,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 510877,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 620521,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10076,9 +10076,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 510883,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 620526,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10090,8 +10090,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 510906,
+      "tid": 22764,
+      "ts": 620576,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -10102,9 +10102,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 510922,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 620589,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10116,9 +10116,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 510929,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 620595,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10130,9 +10130,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 510945,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 620609,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10144,9 +10144,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 510951,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 620614,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10158,8 +10158,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 510974,
+      "tid": 22764,
+      "ts": 620635,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -10170,9 +10170,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 510991,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 620649,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10184,9 +10184,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 510997,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 620655,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10198,9 +10198,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 511014,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 620669,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10212,9 +10212,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 511020,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 620674,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10226,8 +10226,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 511043,
+      "tid": 22764,
+      "ts": 620695,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -10238,9 +10238,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 511059,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 620708,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10252,9 +10252,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 511065,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 620713,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10266,9 +10266,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 511082,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 620727,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10280,9 +10280,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 511088,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 620732,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10294,9 +10294,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 511104,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 620746,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10308,9 +10308,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 511110,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 620751,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10322,8 +10322,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 511132,
+      "tid": 22764,
+      "ts": 620771,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -10334,8 +10334,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 511149,
+      "tid": 22764,
+      "ts": 620787,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -10346,8 +10346,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 511165,
+      "tid": 22764,
+      "ts": 620802,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -10358,8 +10358,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 511182,
+      "tid": 22764,
+      "ts": 620817,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -10370,8 +10370,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 511198,
+      "tid": 22764,
+      "ts": 620832,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -10382,8 +10382,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 511214,
+      "tid": 22764,
+      "ts": 620848,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -10394,8 +10394,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 511231,
+      "tid": 22764,
+      "ts": 620863,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -10406,8 +10406,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 511247,
+      "tid": 22764,
+      "ts": 620878,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -10418,8 +10418,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 511263,
+      "tid": 22764,
+      "ts": 620893,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -10430,8 +10430,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 511280,
+      "tid": 22764,
+      "ts": 620908,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -10442,8 +10442,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 511296,
+      "tid": 22764,
+      "ts": 620923,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -10454,8 +10454,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 511312,
+      "tid": 22764,
+      "ts": 620938,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -10466,18 +10466,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 511319,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 620943,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 511342,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 620961,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10489,18 +10489,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 511344,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 620963,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 511349,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 620967,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10512,9 +10512,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 511367,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 620982,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10526,9 +10526,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 511373,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 620987,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10540,8 +10540,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 511397,
+      "tid": 22764,
+      "ts": 621008,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -10552,9 +10552,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 511410,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 621019,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10566,9 +10566,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 511417,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 621024,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10580,9 +10580,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 511433,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 621038,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10594,9 +10594,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 511439,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 621043,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10608,8 +10608,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 511462,
+      "tid": 22764,
+      "ts": 621063,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -10620,9 +10620,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 511475,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 621074,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10634,9 +10634,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 511481,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 621079,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10648,9 +10648,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 511498,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 621105,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10662,9 +10662,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 511504,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 621111,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10676,8 +10676,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 511526,
+      "tid": 22764,
+      "ts": 621143,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -10688,9 +10688,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 511539,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 621154,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10702,9 +10702,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 511545,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 621159,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10716,9 +10716,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 511562,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 621173,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10730,9 +10730,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 511568,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 621178,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10744,8 +10744,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 511590,
+      "tid": 22764,
+      "ts": 621198,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -10756,9 +10756,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 511603,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 621209,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10770,9 +10770,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 511609,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 621214,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10784,9 +10784,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 511626,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 621228,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10798,9 +10798,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 511632,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 621233,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10812,8 +10812,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 511655,
+      "tid": 22764,
+      "ts": 621254,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -10824,9 +10824,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 511667,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 621265,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10838,9 +10838,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 511674,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 621270,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10852,9 +10852,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 511690,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 621284,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10866,9 +10866,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 511696,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 621289,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10880,8 +10880,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 511719,
+      "tid": 22764,
+      "ts": 621309,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -10892,9 +10892,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 511732,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 621321,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10906,9 +10906,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 511738,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 621326,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10920,9 +10920,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 511754,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 621340,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10934,9 +10934,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 511761,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 621345,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10948,8 +10948,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 511783,
+      "tid": 22764,
+      "ts": 621365,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -10960,9 +10960,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 511796,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 621376,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10974,9 +10974,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 511802,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 621381,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10988,9 +10988,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 511819,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 621395,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11002,9 +11002,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 511825,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 621400,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11016,8 +11016,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 511847,
+      "tid": 22764,
+      "ts": 621420,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -11028,9 +11028,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 511860,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 621431,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11042,9 +11042,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 511866,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 621437,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11056,9 +11056,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 511883,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 621450,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11070,9 +11070,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 511889,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 621456,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11084,8 +11084,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 511911,
+      "tid": 22764,
+      "ts": 621476,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -11096,9 +11096,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 511924,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 621487,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11110,9 +11110,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 511930,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 621492,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11124,9 +11124,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 511947,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 621506,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11138,9 +11138,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 511953,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 621511,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11152,8 +11152,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 511975,
+      "tid": 22764,
+      "ts": 621531,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -11164,9 +11164,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 511988,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 621542,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11178,9 +11178,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 511994,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 621548,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11192,9 +11192,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 512011,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 621562,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11206,9 +11206,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 512017,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 621567,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11220,8 +11220,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 512040,
+      "tid": 22764,
+      "ts": 621587,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -11232,9 +11232,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 512052,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 621598,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11246,9 +11246,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 512059,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 621603,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11260,9 +11260,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 512075,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 621617,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11274,9 +11274,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 512081,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 621622,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11288,8 +11288,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 512103,
+      "tid": 22764,
+      "ts": 621642,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -11300,9 +11300,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 512116,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 621653,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11314,9 +11314,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 512122,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 621659,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11328,9 +11328,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 512139,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 621673,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11342,9 +11342,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 512145,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 621678,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11356,8 +11356,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 512168,
+      "tid": 22764,
+      "ts": 621698,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -11368,9 +11368,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 512180,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 621709,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11382,9 +11382,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 512186,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 621714,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11396,9 +11396,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 512203,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 621728,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11410,9 +11410,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 512209,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 621733,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11424,8 +11424,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 512232,
+      "tid": 22764,
+      "ts": 621753,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -11436,9 +11436,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 512244,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 621764,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11450,9 +11450,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 512251,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 621770,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11464,9 +11464,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 512267,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 621783,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11478,9 +11478,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 512273,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 621788,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11492,8 +11492,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 512296,
+      "tid": 22764,
+      "ts": 621809,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -11504,9 +11504,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 512309,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 621820,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11518,9 +11518,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 512315,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 621825,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11532,9 +11532,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 512818,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 622355,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11546,9 +11546,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 512825,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 622361,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11560,8 +11560,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 512849,
+      "tid": 22764,
+      "ts": 622383,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -11572,9 +11572,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 512862,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 622394,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11586,9 +11586,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 512868,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 622399,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11600,9 +11600,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 512885,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 622413,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11614,9 +11614,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 512891,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 622419,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11628,8 +11628,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 512914,
+      "tid": 22764,
+      "ts": 622439,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -11640,9 +11640,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 512930,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 622454,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11654,9 +11654,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 512937,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 622459,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11668,9 +11668,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 512954,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 622473,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11682,9 +11682,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 512960,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 622479,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11696,8 +11696,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 512982,
+      "tid": 22764,
+      "ts": 622500,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -11708,9 +11708,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 513000,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 622515,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11722,9 +11722,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 513006,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 622520,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11736,9 +11736,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 513023,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 622534,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11750,9 +11750,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 513029,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 622540,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11764,8 +11764,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 513051,
+      "tid": 22764,
+      "ts": 622565,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -11776,9 +11776,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 513068,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 622580,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11790,9 +11790,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 513074,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 622586,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11804,9 +11804,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 513091,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 622600,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11818,9 +11818,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 513097,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 622605,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11832,8 +11832,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 513120,
+      "tid": 22764,
+      "ts": 622625,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -11844,9 +11844,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 513136,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 622646,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11858,9 +11858,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 513142,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 622651,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11872,9 +11872,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 513159,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 622665,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11886,9 +11886,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 513165,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 622671,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11900,8 +11900,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 513187,
+      "tid": 22764,
+      "ts": 622691,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -11912,9 +11912,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 513204,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 622706,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11926,9 +11926,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 513211,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 622712,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11940,9 +11940,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 513227,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 622726,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11954,9 +11954,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 513233,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 622731,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11968,8 +11968,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 513256,
+      "tid": 22764,
+      "ts": 622752,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -11980,9 +11980,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 513272,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 622766,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11994,9 +11994,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 513278,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 622771,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12008,9 +12008,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 513295,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 622785,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12022,9 +12022,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 513301,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 622790,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12036,9 +12036,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 513317,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 622804,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12050,9 +12050,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 513323,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 622809,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12064,8 +12064,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 513345,
+      "tid": 22764,
+      "ts": 622829,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -12076,8 +12076,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 513362,
+      "tid": 22764,
+      "ts": 622844,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -12088,8 +12088,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 513378,
+      "tid": 22764,
+      "ts": 622860,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -12100,8 +12100,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 513396,
+      "tid": 22764,
+      "ts": 622875,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -12112,8 +12112,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 513413,
+      "tid": 22764,
+      "ts": 622890,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -12124,8 +12124,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 513430,
+      "tid": 22764,
+      "ts": 622905,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -12136,8 +12136,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 513447,
+      "tid": 22764,
+      "ts": 622920,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -12148,8 +12148,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 513463,
+      "tid": 22764,
+      "ts": 622935,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -12160,8 +12160,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 513485,
+      "tid": 22764,
+      "ts": 622950,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -12172,8 +12172,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 513501,
+      "tid": 22764,
+      "ts": 622965,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -12184,8 +12184,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 513517,
+      "tid": 22764,
+      "ts": 622981,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -12196,8 +12196,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 513534,
+      "tid": 22764,
+      "ts": 622996,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -12208,18 +12208,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 513540,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623003,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 513562,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623022,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12231,18 +12231,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 513564,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623024,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 513569,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623028,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12254,9 +12254,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 513586,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623043,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12268,9 +12268,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 513593,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623048,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12282,8 +12282,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 513616,
+      "tid": 22764,
+      "ts": 623069,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -12294,9 +12294,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 513629,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623080,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12308,9 +12308,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 513635,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623086,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12322,9 +12322,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 513652,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623113,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12336,9 +12336,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 513658,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623129,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12350,8 +12350,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 513681,
+      "tid": 22764,
+      "ts": 623150,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -12362,9 +12362,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 513693,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623161,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12376,9 +12376,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 513700,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623166,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12390,9 +12390,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 513716,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623180,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12404,9 +12404,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 513722,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623185,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12418,8 +12418,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 513745,
+      "tid": 22764,
+      "ts": 623206,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -12430,9 +12430,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 513758,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623217,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12444,9 +12444,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 513764,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623222,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12458,9 +12458,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 513780,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623236,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12472,9 +12472,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 513787,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623241,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12486,8 +12486,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 513809,
+      "tid": 22764,
+      "ts": 623262,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -12498,9 +12498,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 513822,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623272,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12512,9 +12512,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 513828,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623278,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12526,9 +12526,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 513845,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623292,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12540,9 +12540,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 513851,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623297,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12554,8 +12554,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 513873,
+      "tid": 22764,
+      "ts": 623317,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -12566,9 +12566,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 513886,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623328,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12580,9 +12580,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 513892,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623333,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12594,9 +12594,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 513909,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623347,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12608,9 +12608,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 513915,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623352,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12622,8 +12622,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 513937,
+      "tid": 22764,
+      "ts": 623372,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -12634,9 +12634,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 513950,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623383,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12648,9 +12648,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 513956,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623389,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12662,9 +12662,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 513972,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623403,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12676,9 +12676,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 513979,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623408,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12690,8 +12690,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 514001,
+      "tid": 22764,
+      "ts": 623428,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -12702,9 +12702,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 514014,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623439,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12716,9 +12716,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 514020,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623444,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12730,9 +12730,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 514037,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623459,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12744,9 +12744,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 514043,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623464,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12758,8 +12758,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 514066,
+      "tid": 22764,
+      "ts": 623484,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -12770,9 +12770,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 514079,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623495,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12784,9 +12784,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 514085,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623500,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12798,9 +12798,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 514102,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623514,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12812,9 +12812,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 514108,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623519,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12826,8 +12826,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 514142,
+      "tid": 22764,
+      "ts": 623539,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -12838,9 +12838,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 514155,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623550,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12852,9 +12852,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 514162,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623555,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12866,9 +12866,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 514179,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623569,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12880,9 +12880,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 514185,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623574,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12894,8 +12894,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 514208,
+      "tid": 22764,
+      "ts": 623595,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -12906,9 +12906,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 514221,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623606,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12920,9 +12920,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 514228,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623611,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12934,9 +12934,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 514245,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623625,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12948,9 +12948,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 514251,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623630,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12962,8 +12962,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 514275,
+      "tid": 22764,
+      "ts": 623651,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -12974,9 +12974,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 514288,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623662,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12988,9 +12988,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 514295,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623667,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13002,9 +13002,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 514311,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623681,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13016,9 +13016,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 514318,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623686,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13030,8 +13030,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 514341,
+      "tid": 22764,
+      "ts": 623706,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -13042,9 +13042,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 514362,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623718,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13056,9 +13056,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 514368,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623723,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13070,9 +13070,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 514386,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623737,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13084,9 +13084,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 514392,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623743,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13098,8 +13098,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 514416,
+      "tid": 22764,
+      "ts": 623763,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -13110,9 +13110,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 514429,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623774,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13124,9 +13124,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 514435,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623779,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13138,9 +13138,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 514453,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623793,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13152,9 +13152,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 514459,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623798,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13166,8 +13166,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 514482,
+      "tid": 22764,
+      "ts": 623819,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -13178,9 +13178,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 514495,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623832,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13192,9 +13192,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 514502,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623837,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13206,9 +13206,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 514518,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623851,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13220,9 +13220,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 514525,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623856,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13234,8 +13234,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 514548,
+      "tid": 22764,
+      "ts": 623877,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -13246,9 +13246,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 514561,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623888,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13260,9 +13260,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 514567,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623893,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13274,9 +13274,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 514584,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623907,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13288,9 +13288,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 514590,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623912,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13302,8 +13302,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 514614,
+      "tid": 22764,
+      "ts": 623932,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -13314,9 +13314,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 514627,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623943,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13328,9 +13328,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 514633,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623948,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13342,9 +13342,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 514651,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 623962,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13356,9 +13356,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 514657,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 623968,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13370,8 +13370,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 514681,
+      "tid": 22764,
+      "ts": 623988,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -13382,9 +13382,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 514698,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 624002,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13396,9 +13396,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 514704,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 624007,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13410,9 +13410,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 514722,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 624021,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13424,9 +13424,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 514728,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 624027,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13438,8 +13438,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 514751,
+      "tid": 22764,
+      "ts": 624047,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -13450,9 +13450,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 514769,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 624062,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13464,9 +13464,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 514776,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 624067,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13478,9 +13478,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 514793,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 624081,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13492,9 +13492,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 514799,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 624087,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13506,8 +13506,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 514823,
+      "tid": 22764,
+      "ts": 624142,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -13518,9 +13518,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 514839,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 624157,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13532,9 +13532,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 514845,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 624163,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13546,9 +13546,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 514862,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 624177,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13560,9 +13560,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 514869,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 624182,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13574,8 +13574,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 514892,
+      "tid": 22764,
+      "ts": 624203,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -13586,9 +13586,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 514908,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 624216,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13600,9 +13600,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 514915,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 624222,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13614,9 +13614,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 514942,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 624236,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13628,9 +13628,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 514949,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 624241,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13642,8 +13642,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 514971,
+      "tid": 22764,
+      "ts": 624262,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -13654,9 +13654,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 514988,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 624277,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13668,9 +13668,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 514995,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 624282,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13682,9 +13682,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 515011,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 624296,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13696,9 +13696,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 515017,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 624302,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13710,8 +13710,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 515040,
+      "tid": 22764,
+      "ts": 624322,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -13722,9 +13722,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 515056,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 624336,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13736,9 +13736,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 515062,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 624341,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13750,9 +13750,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 515079,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 624355,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13764,9 +13764,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 515085,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 624360,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13778,9 +13778,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 515101,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 624374,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13792,9 +13792,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 515107,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 624379,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13806,8 +13806,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 515129,
+      "tid": 22764,
+      "ts": 624399,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -13818,8 +13818,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 515146,
+      "tid": 22764,
+      "ts": 624414,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -13830,8 +13830,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 515163,
+      "tid": 22764,
+      "ts": 624430,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -13842,8 +13842,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 515179,
+      "tid": 22764,
+      "ts": 624445,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -13854,8 +13854,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 515195,
+      "tid": 22764,
+      "ts": 624460,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -13866,8 +13866,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 515212,
+      "tid": 22764,
+      "ts": 624475,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -13878,8 +13878,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 515228,
+      "tid": 22764,
+      "ts": 624490,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -13890,8 +13890,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 515244,
+      "tid": 22764,
+      "ts": 624505,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -13902,8 +13902,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 515261,
+      "tid": 22764,
+      "ts": 624520,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -13914,8 +13914,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 515277,
+      "tid": 22764,
+      "ts": 624536,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -13926,8 +13926,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 515293,
+      "tid": 22764,
+      "ts": 624551,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -13938,8 +13938,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 515310,
+      "tid": 22764,
+      "ts": 624566,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -13950,13 +13950,13 @@
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 515337,
+      "tid": 22764,
+      "ts": 624592,
       "pid": "GPGMM",
       "args": {
         "Flags": 0,
         "RecordOptions": {
-          "Flags": 6
+          "Flags": 3
         },
         "IsUMA": 1,
         "ResourceHeapTier": 2,
@@ -13971,8 +13971,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 515412,
+      "tid": 22764,
+      "ts": 624650,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -14002,8 +14002,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 515430,
+      "tid": 22764,
+      "ts": 624667,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -14014,8 +14014,8 @@
       "name": "ResourceAllocator.TryAllocateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 515445,
+      "tid": 22764,
+      "ts": 624681,
       "pid": "GPGMM",
       "args": {
         "Description": "Resource memory could not be allocated.",
@@ -14026,18 +14026,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababc2290",
-      "tid": 16484,
-      "ts": 515448,
+      "id": "0x15aff6cab20",
+      "tid": 22764,
+      "ts": 624683,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc2290",
-      "tid": 16484,
-      "ts": 515453,
+      "id": "0x15aff6cab20",
+      "tid": 22764,
+      "ts": 624688,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14049,18 +14049,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababc2320",
-      "tid": 16484,
-      "ts": 519404,
+      "id": "0x15aff6cb300",
+      "tid": 22764,
+      "ts": 628730,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc2320",
-      "tid": 16484,
-      "ts": 519446,
+      "id": "0x15aff6cb300",
+      "tid": 22764,
+      "ts": 628763,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14075,9 +14075,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc2320",
-      "tid": 16484,
-      "ts": 519467,
+      "id": "0x15aff6cb300",
+      "tid": 22764,
+      "ts": 628781,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14092,9 +14092,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc2320",
-      "tid": 16484,
-      "ts": 519487,
+      "id": "0x15aff6cb300",
+      "tid": 22764,
+      "ts": 628799,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14103,7 +14103,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x22ababc2290"
+            "id_ref": "0x15aff6cab20"
           }
         }
       }
@@ -14112,9 +14112,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc2320",
-      "tid": 16484,
-      "ts": 519574,
+      "id": "0x15aff6cb300",
+      "tid": 22764,
+      "ts": 628881,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14123,7 +14123,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x22ababc2290"
+            "id_ref": "0x15aff6cab20"
           }
         }
       }
@@ -14132,18 +14132,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abad78da0",
-      "tid": 16484,
-      "ts": 519576,
+      "id": "0x15aff89d7a0",
+      "tid": 22764,
+      "ts": 628884,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abad78da0",
-      "tid": 16484,
-      "ts": 519591,
+      "id": "0x15aff89d7a0",
+      "tid": 22764,
+      "ts": 628897,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14152,7 +14152,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x22ababc2320"
+            "id_ref": "0x15aff6cb300"
           }
         }
       }
@@ -14161,8 +14161,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 519713,
+      "tid": 22764,
+      "ts": 628991,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -14192,8 +14192,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 519733,
+      "tid": 22764,
+      "ts": 629009,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -14204,8 +14204,8 @@
       "name": "ResourceAllocator.TryAllocateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 519747,
+      "tid": 22764,
+      "ts": 629022,
       "pid": "GPGMM",
       "args": {
         "Description": "Resource memory could not be allocated.",
@@ -14216,18 +14216,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababc3640",
-      "tid": 16484,
-      "ts": 519750,
+      "id": "0x15aff6cb030",
+      "tid": 22764,
+      "ts": 629025,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3640",
-      "tid": 16484,
-      "ts": 519756,
+      "id": "0x15aff6cb030",
+      "tid": 22764,
+      "ts": 629030,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14239,18 +14239,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababc2950",
-      "tid": 16484,
-      "ts": 520664,
+      "id": "0x15aff6cb390",
+      "tid": 22764,
+      "ts": 629966,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc2950",
-      "tid": 16484,
-      "ts": 520696,
+      "id": "0x15aff6cb390",
+      "tid": 22764,
+      "ts": 629996,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14265,9 +14265,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc2950",
-      "tid": 16484,
-      "ts": 520713,
+      "id": "0x15aff6cb390",
+      "tid": 22764,
+      "ts": 630012,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14282,9 +14282,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc2950",
-      "tid": 16484,
-      "ts": 520732,
+      "id": "0x15aff6cb390",
+      "tid": 22764,
+      "ts": 630029,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14293,7 +14293,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x22ababc3640"
+            "id_ref": "0x15aff6cb030"
           }
         }
       }
@@ -14302,9 +14302,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc2950",
-      "tid": 16484,
-      "ts": 520806,
+      "id": "0x15aff6cb390",
+      "tid": 22764,
+      "ts": 630126,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14313,7 +14313,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x22ababc3640"
+            "id_ref": "0x15aff6cb030"
           }
         }
       }
@@ -14322,18 +14322,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abad78fb0",
-      "tid": 16484,
-      "ts": 520808,
+      "id": "0x15aff89e090",
+      "tid": 22764,
+      "ts": 630129,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abad78fb0",
-      "tid": 16484,
-      "ts": 520823,
+      "id": "0x15aff89e090",
+      "tid": 22764,
+      "ts": 630158,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14342,7 +14342,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x22ababc2950"
+            "id_ref": "0x15aff6cb390"
           }
         }
       }
@@ -14351,8 +14351,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 520937,
+      "tid": 22764,
+      "ts": 630256,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -14382,9 +14382,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 520954,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 630270,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14396,9 +14396,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 520960,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 630276,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14410,18 +14410,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababc2a70",
-      "tid": 16484,
-      "ts": 521291,
+      "id": "0x15aff6cae80",
+      "tid": 22764,
+      "ts": 630605,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc2a70",
-      "tid": 16484,
-      "ts": 521321,
+      "id": "0x15aff6cae80",
+      "tid": 22764,
+      "ts": 630635,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14436,9 +14436,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc2a70",
-      "tid": 16484,
-      "ts": 521338,
+      "id": "0x15aff6cae80",
+      "tid": 22764,
+      "ts": 630650,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14453,9 +14453,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 521348,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 630659,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14467,9 +14467,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc2a70",
-      "tid": 16484,
-      "ts": 521368,
+      "id": "0x15aff6cae80",
+      "tid": 22764,
+      "ts": 630678,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14478,7 +14478,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x22abacb5820"
+            "id_ref": "0x15aff3115c0"
           }
         }
       }
@@ -14487,9 +14487,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc2a70",
-      "tid": 16484,
-      "ts": 521460,
+      "id": "0x15aff6cae80",
+      "tid": 22764,
+      "ts": 630752,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14498,7 +14498,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x22abacb5820"
+            "id_ref": "0x15aff3115c0"
           }
         }
       }
@@ -14507,18 +14507,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abad79ed0",
-      "tid": 16484,
-      "ts": 521463,
+      "id": "0x15aff89e350",
+      "tid": 22764,
+      "ts": 630755,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abad79ed0",
-      "tid": 16484,
-      "ts": 521477,
+      "id": "0x15aff89e350",
+      "tid": 22764,
+      "ts": 630768,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14527,7 +14527,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22ababc2a70"
+            "id_ref": "0x15aff6cae80"
           }
         }
       }
@@ -14536,8 +14536,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 521603,
+      "tid": 22764,
+      "ts": 630856,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -14567,8 +14567,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 521622,
+      "tid": 22764,
+      "ts": 630875,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -14579,8 +14579,8 @@
       "name": "ResourceAllocator.TryAllocateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 521635,
+      "tid": 22764,
+      "ts": 630890,
       "pid": "GPGMM",
       "args": {
         "Description": "Resource memory could not be allocated.",
@@ -14591,9 +14591,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3640",
-      "tid": 16484,
-      "ts": 521642,
+      "id": "0x15aff6cb030",
+      "tid": 22764,
+      "ts": 630896,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14605,18 +14605,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababc3be0",
-      "tid": 16484,
-      "ts": 522535,
+      "id": "0x15aff6cb780",
+      "tid": 22764,
+      "ts": 631922,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3be0",
-      "tid": 16484,
-      "ts": 522566,
+      "id": "0x15aff6cb780",
+      "tid": 22764,
+      "ts": 631942,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14631,9 +14631,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3be0",
-      "tid": 16484,
-      "ts": 522583,
+      "id": "0x15aff6cb780",
+      "tid": 22764,
+      "ts": 631958,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14648,9 +14648,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3be0",
-      "tid": 16484,
-      "ts": 522601,
+      "id": "0x15aff6cb780",
+      "tid": 22764,
+      "ts": 631977,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14659,7 +14659,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x22ababc3640"
+            "id_ref": "0x15aff6cb030"
           }
         }
       }
@@ -14668,9 +14668,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3be0",
-      "tid": 16484,
-      "ts": 522672,
+      "id": "0x15aff6cb780",
+      "tid": 22764,
+      "ts": 632051,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14679,7 +14679,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x22ababc3640"
+            "id_ref": "0x15aff6cb030"
           }
         }
       }
@@ -14688,18 +14688,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abad795e0",
-      "tid": 16484,
-      "ts": 522674,
+      "id": "0x15aff89e6c0",
+      "tid": 22764,
+      "ts": 632054,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abad795e0",
-      "tid": 16484,
-      "ts": 522689,
+      "id": "0x15aff89e6c0",
+      "tid": 22764,
+      "ts": 632068,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14708,7 +14708,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x22ababc3be0"
+            "id_ref": "0x15aff6cb780"
           }
         }
       }
@@ -14717,9 +14717,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc2290",
-      "tid": 16484,
-      "ts": 522792,
+      "id": "0x15aff6cab20",
+      "tid": 22764,
+      "ts": 632141,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14731,17 +14731,17 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abad78da0",
-      "tid": 16484,
-      "ts": 522850,
+      "id": "0x15aff89d7a0",
+      "tid": 22764,
+      "ts": 632201,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 522903,
+      "tid": 22764,
+      "ts": 632252,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -14771,9 +14771,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 522920,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 632268,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14785,9 +14785,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 522927,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 632274,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14799,18 +14799,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababc2e60",
-      "tid": 16484,
-      "ts": 523255,
+      "id": "0x15aff6cb930",
+      "tid": 22764,
+      "ts": 632629,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc2e60",
-      "tid": 16484,
-      "ts": 523286,
+      "id": "0x15aff6cb930",
+      "tid": 22764,
+      "ts": 632648,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14825,9 +14825,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc2e60",
-      "tid": 16484,
-      "ts": 523302,
+      "id": "0x15aff6cb930",
+      "tid": 22764,
+      "ts": 632665,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14842,9 +14842,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 523312,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 632675,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14856,9 +14856,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc2e60",
-      "tid": 16484,
-      "ts": 523333,
+      "id": "0x15aff6cb930",
+      "tid": 22764,
+      "ts": 632695,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14867,7 +14867,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x22abacb4bc0"
+            "id_ref": "0x15aff311ec0"
           }
         }
       }
@@ -14876,9 +14876,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc2e60",
-      "tid": 16484,
-      "ts": 523412,
+      "id": "0x15aff6cb930",
+      "tid": 22764,
+      "ts": 632780,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14887,7 +14887,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x22abacb4bc0"
+            "id_ref": "0x15aff311ec0"
           }
         }
       }
@@ -14896,18 +14896,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abad79ab0",
-      "tid": 16484,
-      "ts": 523414,
+      "id": "0x15aff89e980",
+      "tid": 22764,
+      "ts": 632783,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abad79ab0",
-      "tid": 16484,
-      "ts": 523429,
+      "id": "0x15aff89e980",
+      "tid": 22764,
+      "ts": 632797,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14916,7 +14916,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22ababc2e60"
+            "id_ref": "0x15aff6cb930"
           }
         }
       }
@@ -14925,9 +14925,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3640",
-      "tid": 16484,
-      "ts": 523539,
+      "id": "0x15aff6cb030",
+      "tid": 22764,
+      "ts": 632860,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14939,17 +14939,17 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abad78fb0",
-      "tid": 16484,
-      "ts": 523587,
+      "id": "0x15aff89e090",
+      "tid": 22764,
+      "ts": 632921,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 523638,
+      "tid": 22764,
+      "ts": 633011,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -14979,9 +14979,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 523653,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 633025,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14993,9 +14993,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 523660,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 633032,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15007,18 +15007,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababc2560",
-      "tid": 16484,
-      "ts": 523986,
+      "id": "0x15aff6cba50",
+      "tid": 22764,
+      "ts": 633389,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc2560",
-      "tid": 16484,
-      "ts": 524016,
+      "id": "0x15aff6cba50",
+      "tid": 22764,
+      "ts": 633419,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15033,9 +15033,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc2560",
-      "tid": 16484,
-      "ts": 524033,
+      "id": "0x15aff6cba50",
+      "tid": 22764,
+      "ts": 633436,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15050,9 +15050,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 524043,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 633445,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15064,9 +15064,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc2560",
-      "tid": 16484,
-      "ts": 524062,
+      "id": "0x15aff6cba50",
+      "tid": 22764,
+      "ts": 633464,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15075,7 +15075,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x22abacb5820"
+            "id_ref": "0x15aff3115c0"
           }
         }
       }
@@ -15084,9 +15084,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc2560",
-      "tid": 16484,
-      "ts": 524140,
+      "id": "0x15aff6cba50",
+      "tid": 22764,
+      "ts": 633536,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15095,7 +15095,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x22abacb5820"
+            "id_ref": "0x15aff3115c0"
           }
         }
       }
@@ -15104,18 +15104,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abad7a450",
-      "tid": 16484,
-      "ts": 524142,
+      "id": "0x15aff89dd20",
+      "tid": 22764,
+      "ts": 633539,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abad7a450",
-      "tid": 16484,
-      "ts": 524157,
+      "id": "0x15aff89dd20",
+      "tid": 22764,
+      "ts": 633553,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15124,7 +15124,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22ababc2560"
+            "id_ref": "0x15aff6cba50"
           }
         }
       }
@@ -15133,8 +15133,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 524277,
+      "tid": 22764,
+      "ts": 633638,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -15164,9 +15164,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 524299,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 633657,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15178,9 +15178,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 524306,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 633663,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15192,18 +15192,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abad87220",
-      "tid": 16484,
-      "ts": 524753,
+      "id": "0x15aff6cc230",
+      "tid": 22764,
+      "ts": 634028,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abad87220",
-      "tid": 16484,
-      "ts": 524784,
+      "id": "0x15aff6cc230",
+      "tid": 22764,
+      "ts": 634058,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15218,9 +15218,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abad87220",
-      "tid": 16484,
-      "ts": 524813,
+      "id": "0x15aff6cc230",
+      "tid": 22764,
+      "ts": 634074,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15235,9 +15235,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 524824,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 634095,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15249,9 +15249,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abad87220",
-      "tid": 16484,
-      "ts": 524856,
+      "id": "0x15aff6cc230",
+      "tid": 22764,
+      "ts": 634126,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15260,7 +15260,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x22abacb4080"
+            "id_ref": "0x15aff3122b0"
           }
         }
       }
@@ -15269,9 +15269,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abad87220",
-      "tid": 16484,
-      "ts": 524974,
+      "id": "0x15aff6cc230",
+      "tid": 22764,
+      "ts": 634198,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15280,7 +15280,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x22abacb4080"
+            "id_ref": "0x15aff3122b0"
           }
         }
       }
@@ -15289,18 +15289,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abad78820",
-      "tid": 16484,
-      "ts": 524977,
+      "id": "0x15aff89d9b0",
+      "tid": 22764,
+      "ts": 634201,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abad78820",
-      "tid": 16484,
-      "ts": 524991,
+      "id": "0x15aff89d9b0",
+      "tid": 22764,
+      "ts": 634215,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15309,7 +15309,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abad87220"
+            "id_ref": "0x15aff6cc230"
           }
         }
       }
@@ -15318,8 +15318,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 525112,
+      "tid": 22764,
+      "ts": 634297,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -15349,9 +15349,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc2a70",
-      "tid": 16484,
-      "ts": 525133,
+      "id": "0x15aff6cae80",
+      "tid": 22764,
+      "ts": 634319,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15360,7 +15360,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 3,
           "MemoryPool": {
-            "id_ref": "0x22abacb5820"
+            "id_ref": "0x15aff3115c0"
           }
         }
       }
@@ -15369,9 +15369,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc2a70",
-      "tid": 16484,
-      "ts": 525215,
+      "id": "0x15aff6cae80",
+      "tid": 22764,
+      "ts": 634404,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15380,7 +15380,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 3,
           "MemoryPool": {
-            "id_ref": "0x22abacb5820"
+            "id_ref": "0x15aff3115c0"
           }
         }
       }
@@ -15389,18 +15389,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababbf5d0",
-      "tid": 16484,
-      "ts": 525219,
+      "id": "0x15aff89dbc0",
+      "tid": 22764,
+      "ts": 634407,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababbf5d0",
-      "tid": 16484,
-      "ts": 525233,
+      "id": "0x15aff89dbc0",
+      "tid": 22764,
+      "ts": 634421,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15409,7 +15409,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22ababc2a70"
+            "id_ref": "0x15aff6cae80"
           }
         }
       }
@@ -15418,17 +15418,17 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abad79ed0",
-      "tid": 16484,
-      "ts": 525343,
+      "id": "0x15aff89e350",
+      "tid": 22764,
+      "ts": 634507,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 525397,
+      "tid": 22764,
+      "ts": 634565,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -15458,8 +15458,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 525416,
+      "tid": 22764,
+      "ts": 634586,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -15470,8 +15470,8 @@
       "name": "ResourceAllocator.TryAllocateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 525436,
+      "tid": 22764,
+      "ts": 634600,
       "pid": "GPGMM",
       "args": {
         "Description": "Resource memory could not be allocated.",
@@ -15482,9 +15482,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3640",
-      "tid": 16484,
-      "ts": 525444,
+      "id": "0x15aff6cb030",
+      "tid": 22764,
+      "ts": 634608,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15496,9 +15496,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc2950",
-      "tid": 16484,
-      "ts": 525461,
+      "id": "0x15aff6cb390",
+      "tid": 22764,
+      "ts": 634635,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15507,7 +15507,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x22ababc3640"
+            "id_ref": "0x15aff6cb030"
           }
         }
       }
@@ -15516,9 +15516,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc2950",
-      "tid": 16484,
-      "ts": 525531,
+      "id": "0x15aff6cb390",
+      "tid": 22764,
+      "ts": 634718,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15527,7 +15527,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x22ababc3640"
+            "id_ref": "0x15aff6cb030"
           }
         }
       }
@@ -15536,18 +15536,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abad93820",
-      "tid": 16484,
-      "ts": 525534,
+      "id": "0x15aff7cf450",
+      "tid": 22764,
+      "ts": 634721,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abad93820",
-      "tid": 16484,
-      "ts": 525548,
+      "id": "0x15aff7cf450",
+      "tid": 22764,
+      "ts": 634735,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15556,7 +15556,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x22ababc2950"
+            "id_ref": "0x15aff6cb390"
           }
         }
       }
@@ -15565,9 +15565,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3640",
-      "tid": 16484,
-      "ts": 525623,
+      "id": "0x15aff6cb030",
+      "tid": 22764,
+      "ts": 634783,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15579,18 +15579,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abad795e0",
-      "tid": 16484,
-      "ts": 525670,
+      "id": "0x15aff89e6c0",
+      "tid": 22764,
+      "ts": 634832,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababc3640",
-      "tid": 16484,
-      "ts": 525704,
+      "id": "0x15aff6cb030",
+      "tid": 22764,
+      "ts": 634854,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15602,18 +15602,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abad93820",
-      "tid": 16484,
-      "ts": 525748,
+      "id": "0x15aff7cf450",
+      "tid": 22764,
+      "ts": 634900,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 525805,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 634937,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15625,9 +15625,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 525820,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 634952,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15639,18 +15639,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababbf5d0",
-      "tid": 16484,
-      "ts": 525867,
+      "id": "0x15aff89dbc0",
+      "tid": 22764,
+      "ts": 635002,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 525927,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 635033,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15662,9 +15662,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 525935,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 635041,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15676,18 +15676,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abad7a450",
-      "tid": 16484,
-      "ts": 525985,
+      "id": "0x15aff89dd20",
+      "tid": 22764,
+      "ts": 635122,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 526044,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 635153,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15699,9 +15699,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 526058,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 635163,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15713,18 +15713,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abad78820",
-      "tid": 16484,
-      "ts": 526104,
+      "id": "0x15aff89d9b0",
+      "tid": 22764,
+      "ts": 635210,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 526163,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 635250,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15736,9 +15736,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 526177,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 635271,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15750,243 +15750,243 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abad79ab0",
-      "tid": 16484,
-      "ts": 526224,
+      "id": "0x15aff89e980",
+      "tid": 22764,
+      "ts": 635327,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadf1280",
-      "tid": 16484,
-      "ts": 526236,
+      "id": "0x15afcc5bd90",
+      "tid": 22764,
+      "ts": 635336,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadfc568",
-      "tid": 16484,
-      "ts": 526250,
+      "id": "0x15afcc5cf78",
+      "tid": 22764,
+      "ts": 635350,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abad87220",
-      "tid": 16484,
-      "ts": 526252,
+      "id": "0x15aff6cc230",
+      "tid": 22764,
+      "ts": 635353,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacb4080",
-      "tid": 16484,
-      "ts": 526401,
+      "id": "0x15aff3122b0",
+      "tid": 22764,
+      "ts": 635499,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadfd568",
-      "tid": 16484,
-      "ts": 526424,
+      "id": "0x15afcc5dd78",
+      "tid": 22764,
+      "ts": 635521,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababc2e60",
-      "tid": 16484,
-      "ts": 526426,
+      "id": "0x15aff6cb930",
+      "tid": 22764,
+      "ts": 635523,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacb4bc0",
-      "tid": 16484,
-      "ts": 526561,
+      "id": "0x15aff311ec0",
+      "tid": 22764,
+      "ts": 635658,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadfbf68",
-      "tid": 16484,
-      "ts": 526582,
+      "id": "0x15afcc5e478",
+      "tid": 22764,
+      "ts": 635678,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababc2560",
-      "tid": 16484,
-      "ts": 526584,
+      "id": "0x15aff6cba50",
+      "tid": 22764,
+      "ts": 635680,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababc2a70",
-      "tid": 16484,
-      "ts": 526716,
+      "id": "0x15aff6cae80",
+      "tid": 22764,
+      "ts": 635813,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacb5820",
-      "tid": 16484,
-      "ts": 526850,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 635949,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadfc468",
-      "tid": 16484,
-      "ts": 526870,
+      "id": "0x15afcc5d478",
+      "tid": 22764,
+      "ts": 635986,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacb5280",
-      "tid": 16484,
-      "ts": 526872,
+      "id": "0x15aff311770",
+      "tid": 22764,
+      "ts": 635987,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadfcb68",
-      "tid": 16484,
-      "ts": 526889,
+      "id": "0x15afcc5d778",
+      "tid": 22764,
+      "ts": 636017,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacb5700",
-      "tid": 16484,
-      "ts": 526890,
+      "id": "0x15aff311c80",
+      "tid": 22764,
+      "ts": 636018,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadfca68",
-      "tid": 16484,
-      "ts": 526907,
+      "id": "0x15afcc5dc78",
+      "tid": 22764,
+      "ts": 636047,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abacb5c10",
-      "tid": 16484,
-      "ts": 526908,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 636049,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadfd868",
-      "tid": 16484,
-      "ts": 526924,
+      "id": "0x15afcc5ce78",
+      "tid": 22764,
+      "ts": 636066,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababc3b50",
-      "tid": 16484,
-      "ts": 526925,
+      "id": "0x15aff312220",
+      "tid": 22764,
+      "ts": 636067,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadfd768",
-      "tid": 16484,
-      "ts": 526940,
+      "id": "0x15afcc5d178",
+      "tid": 22764,
+      "ts": 636096,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababc40f0",
-      "tid": 16484,
-      "ts": 526941,
+      "id": "0x15aff6cbed0",
+      "tid": 22764,
+      "ts": 636097,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababc2320",
-      "tid": 16484,
-      "ts": 526955,
+      "id": "0x15aff6cb300",
+      "tid": 22764,
+      "ts": 636126,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababc2290",
-      "tid": 16484,
-      "ts": 527088,
+      "id": "0x15aff6cab20",
+      "tid": 22764,
+      "ts": 636277,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababc2950",
-      "tid": 16484,
-      "ts": 527091,
+      "id": "0x15aff6cb390",
+      "tid": 22764,
+      "ts": 636280,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababc3be0",
-      "tid": 16484,
-      "ts": 527222,
+      "id": "0x15aff6cb780",
+      "tid": 22764,
+      "ts": 636412,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababc3640",
-      "tid": 16484,
-      "ts": 527358,
+      "id": "0x15aff6cb030",
+      "tid": 22764,
+      "ts": 636548,
       "pid": "GPGMM"
     }
   ]

--- a/src/tests/capture_replay_tests/traces/webnn_resnet50v2_nchw.json
+++ b/src/tests/capture_replay_tests/traces/webnn_resnet50v2_nchw.json
@@ -5,27 +5,27 @@
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadf0600",
-      "tid": 16484,
-      "ts": 667048,
+      "id": "0x15afcc5c290",
+      "tid": 22764,
+      "ts": 817722,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 667060,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 817737,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 667123,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 817797,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -37,18 +37,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 667127,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 817801,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 667133,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 817806,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -60,9 +60,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 667166,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 817826,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -74,9 +74,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 667189,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 817834,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -88,8 +88,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 667217,
+      "tid": 22764,
+      "ts": 817861,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -100,9 +100,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 667231,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 817873,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -114,9 +114,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 667243,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 817886,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -128,9 +128,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 667260,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 817901,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -142,9 +142,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 667266,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 817906,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -156,8 +156,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 667290,
+      "tid": 22764,
+      "ts": 817928,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -168,9 +168,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 667328,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 817939,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -182,9 +182,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 667341,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 817945,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -196,9 +196,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 667399,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 817968,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -210,9 +210,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 667408,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 817974,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -224,8 +224,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 667445,
+      "tid": 22764,
+      "ts": 818009,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -236,9 +236,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 667474,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 818021,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -250,9 +250,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 667496,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 818037,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -264,9 +264,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 667528,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 818051,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -278,9 +278,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 667534,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 818057,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -292,8 +292,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 667579,
+      "tid": 22764,
+      "ts": 818078,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -304,9 +304,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 667592,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 818089,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -318,9 +318,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 667610,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 818095,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -332,9 +332,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 667627,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 818109,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -346,9 +346,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 667644,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 818115,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -360,8 +360,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 667667,
+      "tid": 22764,
+      "ts": 818136,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -372,9 +372,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 667703,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 818168,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -386,9 +386,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 667710,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 818174,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -400,9 +400,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 667726,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 818200,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -414,9 +414,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 667744,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 818206,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -428,8 +428,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 667778,
+      "tid": 22764,
+      "ts": 818228,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -440,9 +440,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 667807,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 818240,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -454,9 +454,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 667829,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 818246,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -468,9 +468,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 667845,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 818260,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -482,9 +482,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 667851,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 818266,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -496,8 +496,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 667874,
+      "tid": 22764,
+      "ts": 818287,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -508,9 +508,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 667887,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 818303,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -522,9 +522,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 667893,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 818308,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -536,9 +536,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 667910,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 818323,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -550,9 +550,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 667916,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 818329,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -564,8 +564,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 667938,
+      "tid": 22764,
+      "ts": 818351,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -576,9 +576,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 667951,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 818362,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -590,9 +590,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 667958,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 818368,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -604,9 +604,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 667974,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 818383,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -618,9 +618,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 667980,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 818388,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -632,8 +632,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 668003,
+      "tid": 22764,
+      "ts": 818410,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -644,9 +644,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 668016,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 818421,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -658,9 +658,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 668022,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 818427,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -672,9 +672,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 668039,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 818442,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -686,9 +686,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 668045,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 818447,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -700,8 +700,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 668067,
+      "tid": 22764,
+      "ts": 818469,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -712,9 +712,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 668080,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 818480,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -726,9 +726,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 668105,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 818519,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -740,9 +740,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 668122,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 818535,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -754,9 +754,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 668128,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 818540,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -768,8 +768,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 668151,
+      "tid": 22764,
+      "ts": 818573,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -780,9 +780,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 668164,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 818584,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -794,9 +794,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 668170,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 818590,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -808,9 +808,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 668187,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 818604,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -822,9 +822,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 668193,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 818610,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -836,8 +836,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 668215,
+      "tid": 22764,
+      "ts": 818631,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -848,9 +848,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 668228,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 818642,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -862,9 +862,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 668234,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 818648,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -876,9 +876,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 668251,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 818662,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -890,9 +890,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 668257,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 818667,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -904,8 +904,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 668280,
+      "tid": 22764,
+      "ts": 818688,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -916,9 +916,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 668294,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 818699,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -930,9 +930,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 668300,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 818705,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -944,9 +944,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 668317,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 818730,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -958,9 +958,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 668323,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 818736,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -972,8 +972,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 668345,
+      "tid": 22764,
+      "ts": 818757,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -984,9 +984,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 668359,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 818769,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -998,9 +998,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 668365,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 818774,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1012,9 +1012,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 668381,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 818789,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1026,9 +1026,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 668387,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 818795,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1040,8 +1040,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 668410,
+      "tid": 22764,
+      "ts": 818816,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1052,9 +1052,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 668423,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 818828,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1066,9 +1066,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 668429,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 818833,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1080,9 +1080,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 668446,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 818848,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1094,9 +1094,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 668452,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 818854,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1108,8 +1108,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 668475,
+      "tid": 22764,
+      "ts": 818886,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1120,9 +1120,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 668488,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 818897,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1134,9 +1134,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 668494,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 818903,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1148,9 +1148,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 668511,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 818917,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1162,9 +1162,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 668517,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 818933,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1176,8 +1176,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 668540,
+      "tid": 22764,
+      "ts": 818955,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1188,9 +1188,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 668557,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 818971,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1202,9 +1202,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 668563,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 818978,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1216,9 +1216,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 668580,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 818996,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1230,9 +1230,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 668586,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 819002,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1244,8 +1244,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 668609,
+      "tid": 22764,
+      "ts": 819035,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -1256,9 +1256,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 668627,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 819052,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1270,9 +1270,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 668633,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 819057,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1284,9 +1284,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 668650,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 819072,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1298,9 +1298,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 668656,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 819077,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1312,8 +1312,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 668679,
+      "tid": 22764,
+      "ts": 819098,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -1324,9 +1324,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 668695,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 819113,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1338,9 +1338,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 668701,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 819118,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1352,9 +1352,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 668718,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 819133,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1366,9 +1366,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 668724,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 819149,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1380,8 +1380,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 668747,
+      "tid": 22764,
+      "ts": 819170,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -1392,9 +1392,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 668763,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 819184,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1406,9 +1406,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 668769,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 819189,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1420,9 +1420,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 668854,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 819272,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1434,9 +1434,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 668861,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 819277,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1448,8 +1448,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 668884,
+      "tid": 22764,
+      "ts": 819298,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -1460,9 +1460,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 668902,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 819314,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1474,9 +1474,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 668908,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 819320,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1488,9 +1488,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 668925,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 819334,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1502,9 +1502,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 668931,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 819339,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1516,8 +1516,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 668954,
+      "tid": 22764,
+      "ts": 819359,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -1528,9 +1528,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 668970,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 819373,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1542,9 +1542,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 668976,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 819378,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1556,9 +1556,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 668993,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 819392,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1570,9 +1570,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 668999,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 819398,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1584,9 +1584,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 669015,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 819412,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1598,9 +1598,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 669022,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 819417,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1612,8 +1612,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 669044,
+      "tid": 22764,
+      "ts": 819437,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -1624,8 +1624,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 669061,
+      "tid": 22764,
+      "ts": 819453,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -1636,8 +1636,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 669078,
+      "tid": 22764,
+      "ts": 819469,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -1648,8 +1648,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 669094,
+      "tid": 22764,
+      "ts": 819484,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -1660,8 +1660,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 669111,
+      "tid": 22764,
+      "ts": 819499,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -1672,8 +1672,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 669127,
+      "tid": 22764,
+      "ts": 819514,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -1684,8 +1684,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 669144,
+      "tid": 22764,
+      "ts": 819529,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -1696,8 +1696,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 669160,
+      "tid": 22764,
+      "ts": 819544,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -1708,8 +1708,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 669176,
+      "tid": 22764,
+      "ts": 819559,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -1720,8 +1720,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 669193,
+      "tid": 22764,
+      "ts": 819574,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -1732,8 +1732,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 669209,
+      "tid": 22764,
+      "ts": 819590,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -1744,8 +1744,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 669226,
+      "tid": 22764,
+      "ts": 819605,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -1756,18 +1756,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 669232,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 819612,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 669253,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 819631,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1779,18 +1779,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 669256,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 819633,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 669261,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 819637,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1802,9 +1802,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 669278,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 819653,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1816,9 +1816,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 669284,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 819658,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1830,8 +1830,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 669309,
+      "tid": 22764,
+      "ts": 819679,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1842,9 +1842,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 669322,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 819690,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1856,9 +1856,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 669328,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 819696,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1870,9 +1870,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 669345,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 819710,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1884,9 +1884,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 669351,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 819715,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1898,8 +1898,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 669374,
+      "tid": 22764,
+      "ts": 819735,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1910,9 +1910,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 669387,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 819746,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1924,9 +1924,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 669393,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 819752,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1938,9 +1938,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 669410,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 819766,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1952,9 +1952,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 669416,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 819771,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1966,8 +1966,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 669439,
+      "tid": 22764,
+      "ts": 819791,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -1978,9 +1978,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 669452,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 819802,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1992,9 +1992,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 669458,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 819808,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2006,9 +2006,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 669475,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 819822,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2020,9 +2020,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 669481,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 819827,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2034,8 +2034,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 669503,
+      "tid": 22764,
+      "ts": 819847,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2046,9 +2046,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 669517,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 819858,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2060,9 +2060,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 669523,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 819864,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2074,9 +2074,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 669539,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 819878,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2088,9 +2088,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 669545,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 819883,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2102,8 +2102,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 669568,
+      "tid": 22764,
+      "ts": 819903,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2114,9 +2114,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 669581,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 819914,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2128,9 +2128,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 669587,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 819919,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2142,9 +2142,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 669604,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 819933,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2156,9 +2156,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 669621,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 819939,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2170,8 +2170,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 669655,
+      "tid": 22764,
+      "ts": 819959,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2182,9 +2182,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 669668,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 819970,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2196,9 +2196,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 669674,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 819975,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2210,9 +2210,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 669691,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 820002,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2224,9 +2224,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 669697,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 820018,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2238,8 +2238,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 669720,
+      "tid": 22764,
+      "ts": 820039,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2250,9 +2250,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 669732,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 820050,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2264,9 +2264,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 669739,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 820055,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2278,9 +2278,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 669755,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 820069,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2292,9 +2292,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 669761,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 820074,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2306,8 +2306,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 669784,
+      "tid": 22764,
+      "ts": 820094,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2318,9 +2318,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 669797,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 820105,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2332,9 +2332,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 669803,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 820111,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2346,9 +2346,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 669820,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 820125,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2360,9 +2360,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 669826,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 820130,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2374,8 +2374,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 669849,
+      "tid": 22764,
+      "ts": 820150,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2386,9 +2386,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 669862,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 820161,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2400,9 +2400,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 669868,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 820167,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2414,9 +2414,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 669885,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 820181,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2428,9 +2428,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 669890,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 820186,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2442,8 +2442,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 669913,
+      "tid": 22764,
+      "ts": 820206,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2454,9 +2454,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 669926,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 820217,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2468,9 +2468,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 669932,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 820222,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2482,9 +2482,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 669949,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 820236,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2496,9 +2496,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 669955,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 820242,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2510,8 +2510,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 669977,
+      "tid": 22764,
+      "ts": 820262,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2522,9 +2522,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 669990,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 820273,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2536,9 +2536,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 669996,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 820278,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2550,9 +2550,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 670013,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 820292,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2564,9 +2564,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 670019,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 820297,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2578,8 +2578,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 670042,
+      "tid": 22764,
+      "ts": 820318,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2590,9 +2590,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 670054,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 820329,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2604,9 +2604,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 670061,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 820334,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2618,9 +2618,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 670077,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 820348,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2632,9 +2632,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 670083,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 820353,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2646,8 +2646,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 670106,
+      "tid": 22764,
+      "ts": 820373,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2658,9 +2658,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 670119,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 820384,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2672,9 +2672,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 670125,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 820390,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2686,9 +2686,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 670141,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 820404,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2700,9 +2700,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 670147,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 820409,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2714,8 +2714,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 670170,
+      "tid": 22764,
+      "ts": 820429,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2726,9 +2726,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 670183,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 820440,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2740,9 +2740,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 670189,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 820446,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2754,9 +2754,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 670205,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 820460,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2768,9 +2768,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 670211,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 820465,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2782,8 +2782,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 670234,
+      "tid": 22764,
+      "ts": 820485,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2794,9 +2794,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 670247,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 820496,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2808,9 +2808,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 670253,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 820502,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2822,9 +2822,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 670270,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 820516,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2836,9 +2836,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 670276,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 820521,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2850,8 +2850,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 670299,
+      "tid": 22764,
+      "ts": 820541,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2862,9 +2862,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 670312,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 820552,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2876,9 +2876,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 670455,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 820683,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2890,9 +2890,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 670473,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 820698,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2904,9 +2904,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 670479,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 820704,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2918,8 +2918,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 670502,
+      "tid": 22764,
+      "ts": 820725,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -2930,9 +2930,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 670519,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 820739,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2944,9 +2944,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 670526,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 820745,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2958,9 +2958,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 670543,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 820759,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2972,9 +2972,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 670549,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 820765,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2986,8 +2986,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 670572,
+      "tid": 22764,
+      "ts": 820785,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -2998,9 +2998,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 670589,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 820800,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3012,9 +3012,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 670596,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 820806,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3026,9 +3026,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 670612,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 820820,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3040,9 +3040,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 670618,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 820825,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3054,8 +3054,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 670641,
+      "tid": 22764,
+      "ts": 820846,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -3066,9 +3066,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 670657,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 820860,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3080,9 +3080,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 670663,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 820865,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3094,9 +3094,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 670680,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 820880,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3108,9 +3108,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 670686,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 820885,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3122,8 +3122,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 670709,
+      "tid": 22764,
+      "ts": 820905,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -3134,9 +3134,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 670725,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 820919,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3148,9 +3148,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 670731,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 820924,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3162,9 +3162,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 670748,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 820938,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3176,9 +3176,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 670754,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 820944,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3190,8 +3190,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 670777,
+      "tid": 22764,
+      "ts": 820964,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -3202,9 +3202,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 670794,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 820990,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3216,9 +3216,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 670800,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 820997,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3230,9 +3230,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 670817,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 821022,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3244,9 +3244,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 670823,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 821027,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3258,8 +3258,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 670846,
+      "tid": 22764,
+      "ts": 821048,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -3270,9 +3270,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 670862,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 821062,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3284,9 +3284,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 670868,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 821067,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3298,9 +3298,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 670885,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 821081,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3312,9 +3312,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 670891,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 821087,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3326,9 +3326,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 670907,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 821101,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3340,9 +3340,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 670913,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 821106,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3354,8 +3354,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 670935,
+      "tid": 22764,
+      "ts": 821126,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -3366,8 +3366,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 670952,
+      "tid": 22764,
+      "ts": 821142,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -3378,8 +3378,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 670969,
+      "tid": 22764,
+      "ts": 821157,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -3390,8 +3390,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 670985,
+      "tid": 22764,
+      "ts": 821173,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -3402,8 +3402,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 671002,
+      "tid": 22764,
+      "ts": 821188,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -3414,8 +3414,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 671018,
+      "tid": 22764,
+      "ts": 821203,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -3426,8 +3426,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 671035,
+      "tid": 22764,
+      "ts": 821218,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -3438,8 +3438,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 671051,
+      "tid": 22764,
+      "ts": 821233,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -3450,8 +3450,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 671067,
+      "tid": 22764,
+      "ts": 821248,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -3462,8 +3462,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 671084,
+      "tid": 22764,
+      "ts": 821263,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -3474,8 +3474,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 671100,
+      "tid": 22764,
+      "ts": 821278,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -3486,8 +3486,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 671117,
+      "tid": 22764,
+      "ts": 821293,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -3498,18 +3498,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 671123,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 821299,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 671145,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 821316,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3521,18 +3521,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 671148,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 821319,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 671153,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 821323,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3544,9 +3544,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 671170,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 821337,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3558,9 +3558,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 671176,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 821342,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3572,8 +3572,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 671200,
+      "tid": 22764,
+      "ts": 821363,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3584,9 +3584,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 671214,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 821374,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3598,9 +3598,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 671221,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 821380,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3612,9 +3612,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 671237,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 821394,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3626,9 +3626,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 671243,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 821399,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3640,8 +3640,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 671266,
+      "tid": 22764,
+      "ts": 821420,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3652,9 +3652,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 671279,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 821431,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3666,9 +3666,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 671285,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 821437,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3680,9 +3680,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 671303,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 821451,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3694,9 +3694,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 671309,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 821456,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3708,8 +3708,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 671332,
+      "tid": 22764,
+      "ts": 821476,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3720,9 +3720,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 671345,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 821489,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3734,9 +3734,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 671351,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 821495,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3748,9 +3748,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 671368,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 821509,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3762,9 +3762,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 671374,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 821514,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3776,8 +3776,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 671396,
+      "tid": 22764,
+      "ts": 821534,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3788,9 +3788,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 671409,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 821545,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3802,9 +3802,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 671415,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 821551,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3816,9 +3816,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 671432,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 821565,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3830,9 +3830,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 671438,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 821570,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3844,8 +3844,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 671460,
+      "tid": 22764,
+      "ts": 821590,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3856,9 +3856,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 671474,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 821602,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3870,9 +3870,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 671480,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 821607,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3884,9 +3884,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 671496,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 821621,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3898,9 +3898,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 671502,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 821626,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3912,8 +3912,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 671525,
+      "tid": 22764,
+      "ts": 821646,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3924,9 +3924,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 671538,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 821657,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3938,9 +3938,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 671544,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 821663,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3952,9 +3952,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 671561,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 821677,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3966,9 +3966,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 671567,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 821682,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3980,8 +3980,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 671590,
+      "tid": 22764,
+      "ts": 821702,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -3992,9 +3992,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 671602,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 821713,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4006,9 +4006,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 671609,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 821718,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4020,9 +4020,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 671625,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 821732,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4034,9 +4034,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 671631,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 821738,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4048,8 +4048,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 671654,
+      "tid": 22764,
+      "ts": 821758,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4060,9 +4060,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 671667,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 821769,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4074,9 +4074,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 671673,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 821775,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4088,9 +4088,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 671689,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 821788,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4102,9 +4102,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 671695,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 821794,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4116,8 +4116,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 671718,
+      "tid": 22764,
+      "ts": 821814,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4128,9 +4128,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 671731,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 821825,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4142,9 +4142,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 671737,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 821830,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4156,9 +4156,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 671753,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 821844,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4170,9 +4170,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 671759,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 821850,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4184,8 +4184,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 671782,
+      "tid": 22764,
+      "ts": 821870,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4196,9 +4196,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 671795,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 821881,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4210,9 +4210,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 671801,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 821886,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4224,9 +4224,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 671817,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 821900,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4238,9 +4238,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 671823,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 821905,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4252,8 +4252,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 671846,
+      "tid": 22764,
+      "ts": 821926,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4264,9 +4264,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 671859,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 821937,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4278,9 +4278,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 671865,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 821942,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4292,9 +4292,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 671882,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 821956,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4306,9 +4306,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 671888,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 821962,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4320,8 +4320,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 671910,
+      "tid": 22764,
+      "ts": 821994,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4332,9 +4332,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 671923,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 822016,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4346,9 +4346,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 671929,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 822022,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4360,9 +4360,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 671946,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 822036,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4374,9 +4374,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 671952,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 822041,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4388,8 +4388,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 671974,
+      "tid": 22764,
+      "ts": 822061,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4400,9 +4400,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 671987,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 822072,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4414,9 +4414,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 671993,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 822078,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4428,9 +4428,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 672010,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 822092,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4442,9 +4442,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 672016,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 822097,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4456,8 +4456,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 672039,
+      "tid": 22764,
+      "ts": 822117,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4468,9 +4468,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 672052,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 822128,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4482,9 +4482,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 672058,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 822133,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4496,9 +4496,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 672074,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 822147,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4510,9 +4510,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 672080,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 822153,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4524,8 +4524,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 672103,
+      "tid": 22764,
+      "ts": 822173,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4536,9 +4536,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 672116,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 822184,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4550,9 +4550,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 672122,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 822189,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4564,9 +4564,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 672139,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 822203,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4578,9 +4578,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 672145,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 822209,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4592,8 +4592,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 672167,
+      "tid": 22764,
+      "ts": 822229,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4604,9 +4604,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 672181,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 822240,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4618,9 +4618,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 672187,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 822245,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4632,9 +4632,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 672203,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 822259,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4646,9 +4646,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 672209,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 822264,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4660,8 +4660,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 672232,
+      "tid": 22764,
+      "ts": 822284,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -4672,9 +4672,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 672250,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 822299,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4686,9 +4686,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 672256,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 822305,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4700,9 +4700,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 672273,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 822319,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4714,9 +4714,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 672279,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 822324,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4728,8 +4728,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 672304,
+      "tid": 22764,
+      "ts": 822345,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -4740,9 +4740,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 672321,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 822360,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4754,9 +4754,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 672328,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 822365,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4768,9 +4768,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 672344,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 822379,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4782,9 +4782,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 672350,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 822384,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4796,8 +4796,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 672373,
+      "tid": 22764,
+      "ts": 822405,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -4808,9 +4808,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 672389,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 822419,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4822,9 +4822,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 672396,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 822424,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4836,9 +4836,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 672413,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 822438,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4850,9 +4850,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 672419,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 822444,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4864,8 +4864,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 672442,
+      "tid": 22764,
+      "ts": 822464,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -4876,9 +4876,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 672457,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 822478,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4890,9 +4890,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 672464,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 822483,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4904,9 +4904,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 672480,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 822497,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4918,9 +4918,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 672486,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 822503,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4932,8 +4932,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 672509,
+      "tid": 22764,
+      "ts": 822523,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -4944,9 +4944,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 672526,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 822538,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4958,9 +4958,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 672533,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 822543,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4972,9 +4972,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 672549,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 822557,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4986,9 +4986,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 672555,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 822563,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5000,8 +5000,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 672578,
+      "tid": 22764,
+      "ts": 822583,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -5012,9 +5012,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 672594,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 822597,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5026,9 +5026,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 672600,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 822602,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5040,9 +5040,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 672617,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 822616,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5054,9 +5054,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 672623,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 822622,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5068,9 +5068,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 672639,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 822636,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5082,9 +5082,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 672645,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 822641,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5096,8 +5096,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 672667,
+      "tid": 22764,
+      "ts": 822661,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -5108,8 +5108,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 672684,
+      "tid": 22764,
+      "ts": 822683,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -5120,8 +5120,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 672700,
+      "tid": 22764,
+      "ts": 822698,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -5132,8 +5132,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 672717,
+      "tid": 22764,
+      "ts": 822713,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -5144,8 +5144,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 672733,
+      "tid": 22764,
+      "ts": 822728,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -5156,8 +5156,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 672749,
+      "tid": 22764,
+      "ts": 822743,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -5168,8 +5168,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 672766,
+      "tid": 22764,
+      "ts": 822758,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -5180,8 +5180,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 672782,
+      "tid": 22764,
+      "ts": 822773,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -5192,8 +5192,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 672798,
+      "tid": 22764,
+      "ts": 822789,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -5204,8 +5204,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 672815,
+      "tid": 22764,
+      "ts": 822804,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -5216,8 +5216,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 672831,
+      "tid": 22764,
+      "ts": 822819,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -5228,8 +5228,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 672848,
+      "tid": 22764,
+      "ts": 822834,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -5240,18 +5240,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 672854,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 822840,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 672874,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 822858,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5263,18 +5263,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 672877,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 822860,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 672882,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 822864,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5286,9 +5286,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 672899,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 822879,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5300,9 +5300,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 672905,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 822884,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5314,8 +5314,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 672928,
+      "tid": 22764,
+      "ts": 822905,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5326,9 +5326,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 672942,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 822916,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5340,9 +5340,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 672948,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 822921,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5354,9 +5354,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 672964,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 822935,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5368,9 +5368,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 672970,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 822941,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5382,8 +5382,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 672993,
+      "tid": 22764,
+      "ts": 822961,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5394,9 +5394,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 673006,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 822972,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5408,9 +5408,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 673012,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 822988,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5422,9 +5422,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 673029,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 823015,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5436,9 +5436,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 673035,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 823021,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5450,8 +5450,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 673057,
+      "tid": 22764,
+      "ts": 823041,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5462,9 +5462,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 673070,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 823052,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5476,9 +5476,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 673076,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 823057,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5490,9 +5490,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 673093,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 823071,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5504,9 +5504,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 673099,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 823077,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5518,8 +5518,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 673122,
+      "tid": 22764,
+      "ts": 823097,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5530,9 +5530,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 673135,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 823108,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5544,9 +5544,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 673141,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 823113,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5558,9 +5558,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 673158,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 823127,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5572,9 +5572,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 673164,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 823132,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5586,8 +5586,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 673187,
+      "tid": 22764,
+      "ts": 823153,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5598,9 +5598,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 673200,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 823163,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5612,9 +5612,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 673206,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 823169,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5626,9 +5626,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 673223,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 823183,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5640,9 +5640,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 673229,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 823188,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5654,8 +5654,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 673251,
+      "tid": 22764,
+      "ts": 823208,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5666,9 +5666,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 673264,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 823219,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5680,9 +5680,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 673270,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 823224,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5694,9 +5694,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 673287,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 823238,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5708,9 +5708,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 673306,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 823243,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5722,8 +5722,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 673329,
+      "tid": 22764,
+      "ts": 823263,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5734,9 +5734,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 673343,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 823274,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5748,9 +5748,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 673349,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 823280,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5762,9 +5762,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 673366,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 823294,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5776,9 +5776,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 673372,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 823299,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5790,8 +5790,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 673660,
+      "tid": 22764,
+      "ts": 823457,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5802,9 +5802,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 673673,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 823468,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5816,9 +5816,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 673680,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 823474,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5830,9 +5830,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 673696,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 823488,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5844,9 +5844,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 673703,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 823493,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5858,8 +5858,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 673725,
+      "tid": 22764,
+      "ts": 823513,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5870,9 +5870,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 673738,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 823524,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5884,9 +5884,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 673744,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 823529,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5898,9 +5898,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 673761,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 823544,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5912,9 +5912,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 673767,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 823549,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5926,8 +5926,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 673789,
+      "tid": 22764,
+      "ts": 823569,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -5938,9 +5938,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 673802,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 823580,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5952,9 +5952,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 673808,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 823586,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5966,9 +5966,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 673825,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 823600,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5980,9 +5980,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 673831,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 823605,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5994,8 +5994,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 673854,
+      "tid": 22764,
+      "ts": 823625,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6006,9 +6006,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 673867,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 823636,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6020,9 +6020,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 673873,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 823642,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6034,9 +6034,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 673889,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 823656,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6048,9 +6048,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 673895,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 823661,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6062,8 +6062,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 673918,
+      "tid": 22764,
+      "ts": 823681,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6074,9 +6074,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 673931,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 823692,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6088,9 +6088,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 673937,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 823698,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6102,9 +6102,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 673953,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 823711,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6116,9 +6116,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 673959,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 823717,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6130,8 +6130,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 673982,
+      "tid": 22764,
+      "ts": 823737,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6142,9 +6142,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 673995,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 823748,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6156,9 +6156,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 674001,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 823753,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6170,9 +6170,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 674017,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 823767,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6184,9 +6184,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 674024,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 823772,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6198,8 +6198,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 674046,
+      "tid": 22764,
+      "ts": 823792,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6210,9 +6210,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 674059,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 823803,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6224,9 +6224,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 674065,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 823808,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6238,9 +6238,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 674082,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 823822,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6252,9 +6252,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 674088,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 823828,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6266,8 +6266,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 674111,
+      "tid": 22764,
+      "ts": 823848,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6278,9 +6278,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 674123,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 823858,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6292,9 +6292,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 674129,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 823864,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6306,9 +6306,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 674146,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 823878,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6320,9 +6320,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 674152,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 823883,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6334,8 +6334,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 674174,
+      "tid": 22764,
+      "ts": 823903,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6346,9 +6346,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 674188,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 823914,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6360,9 +6360,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 674194,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 823919,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6374,9 +6374,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 674210,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 823934,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6388,9 +6388,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 674216,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 823939,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6402,8 +6402,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 674239,
+      "tid": 22764,
+      "ts": 823959,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -6414,9 +6414,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 674257,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 823973,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6428,9 +6428,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 674263,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 823990,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6442,9 +6442,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 674280,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 824017,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6456,9 +6456,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 674286,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 824022,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6470,8 +6470,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 674310,
+      "tid": 22764,
+      "ts": 824043,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -6482,9 +6482,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 674328,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 824058,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6496,9 +6496,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 674334,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 824064,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6510,9 +6510,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 674351,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 824078,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6524,9 +6524,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 674357,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 824084,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6538,8 +6538,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 674380,
+      "tid": 22764,
+      "ts": 824104,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -6550,9 +6550,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 674396,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 824118,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6564,9 +6564,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 674403,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 824123,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6578,9 +6578,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 674419,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 824137,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6592,9 +6592,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 674425,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 824143,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6606,8 +6606,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 674448,
+      "tid": 22764,
+      "ts": 824163,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -6618,9 +6618,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 674468,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 824177,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6632,9 +6632,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 674475,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 824183,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6646,9 +6646,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 674491,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 824197,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6660,9 +6660,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 674498,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 824202,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6674,8 +6674,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 674520,
+      "tid": 22764,
+      "ts": 824223,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -6686,9 +6686,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 674537,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 824238,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6700,9 +6700,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 674544,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 824243,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6714,9 +6714,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 674560,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 824258,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6728,9 +6728,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 674567,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 824263,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6742,8 +6742,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 674589,
+      "tid": 22764,
+      "ts": 824284,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -6754,9 +6754,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 674605,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 824305,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6768,9 +6768,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 674612,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 824310,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6782,9 +6782,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 674628,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 824325,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6796,9 +6796,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 674635,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 824330,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6810,9 +6810,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 674651,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 824344,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6824,9 +6824,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 674657,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 824350,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6838,8 +6838,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 674679,
+      "tid": 22764,
+      "ts": 824370,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -6850,8 +6850,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 674696,
+      "tid": 22764,
+      "ts": 824386,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -6862,8 +6862,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 674713,
+      "tid": 22764,
+      "ts": 824401,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -6874,8 +6874,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 674729,
+      "tid": 22764,
+      "ts": 824416,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -6886,8 +6886,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 674746,
+      "tid": 22764,
+      "ts": 824431,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -6898,8 +6898,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 674762,
+      "tid": 22764,
+      "ts": 824446,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -6910,8 +6910,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 674778,
+      "tid": 22764,
+      "ts": 824461,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -6922,8 +6922,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 674795,
+      "tid": 22764,
+      "ts": 824477,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -6934,8 +6934,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 674811,
+      "tid": 22764,
+      "ts": 824492,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -6946,8 +6946,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 674827,
+      "tid": 22764,
+      "ts": 824507,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -6958,8 +6958,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 674844,
+      "tid": 22764,
+      "ts": 824522,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -6970,8 +6970,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 674860,
+      "tid": 22764,
+      "ts": 824537,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -6982,18 +6982,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 674866,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 824542,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 674887,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 824560,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7005,18 +7005,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 674890,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 824562,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 674895,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 824566,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7028,9 +7028,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 674912,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 824581,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7042,9 +7042,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 674919,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 824586,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7056,8 +7056,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 674942,
+      "tid": 22764,
+      "ts": 824607,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7068,9 +7068,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 674955,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 824618,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7082,9 +7082,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 674961,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 824623,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7096,9 +7096,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 674978,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 824637,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7110,9 +7110,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 674984,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 824642,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7124,8 +7124,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 675007,
+      "tid": 22764,
+      "ts": 824662,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7136,9 +7136,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 675020,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 824673,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7150,9 +7150,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 675026,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 824679,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7164,9 +7164,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 675043,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 824693,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7178,9 +7178,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 675049,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 824698,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7192,8 +7192,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 675072,
+      "tid": 22764,
+      "ts": 824718,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7204,9 +7204,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 675084,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 824729,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7218,9 +7218,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 675091,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 824734,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7232,9 +7232,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 675107,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 824748,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7246,9 +7246,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 675113,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 824754,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7260,8 +7260,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 675136,
+      "tid": 22764,
+      "ts": 824774,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7272,9 +7272,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 675149,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 824785,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7286,9 +7286,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 675155,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 824790,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7300,9 +7300,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 675171,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 824804,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7314,9 +7314,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 675177,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 824809,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7328,8 +7328,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 675200,
+      "tid": 22764,
+      "ts": 824829,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7340,9 +7340,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 675213,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 824840,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7354,9 +7354,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 675219,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 824846,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7368,9 +7368,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 675236,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 824859,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7382,9 +7382,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 675242,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 824865,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7396,8 +7396,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 675264,
+      "tid": 22764,
+      "ts": 824885,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7408,9 +7408,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 675277,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 824896,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7422,9 +7422,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 675284,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 824901,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7436,9 +7436,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 675302,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 824915,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7450,9 +7450,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 675309,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 824921,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7464,8 +7464,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 675331,
+      "tid": 22764,
+      "ts": 824941,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7476,9 +7476,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 675344,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 824952,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7490,9 +7490,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 675350,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 824957,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7504,9 +7504,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 675367,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 824971,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7518,9 +7518,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 675373,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 824988,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7532,8 +7532,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 675396,
+      "tid": 22764,
+      "ts": 825038,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7544,9 +7544,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 675408,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 825050,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7558,9 +7558,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 675415,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 825055,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7572,9 +7572,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 675431,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 825070,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7586,9 +7586,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 675438,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 825075,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7600,8 +7600,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 675460,
+      "tid": 22764,
+      "ts": 825096,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7612,9 +7612,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 675473,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 825118,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7626,9 +7626,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 675479,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 825123,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7640,9 +7640,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 675496,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 825137,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7654,9 +7654,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 675502,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 825143,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7668,8 +7668,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 675524,
+      "tid": 22764,
+      "ts": 825163,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7680,9 +7680,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 675537,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 825174,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7694,9 +7694,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 675544,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 825179,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7708,9 +7708,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 675560,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 825193,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7722,9 +7722,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 675566,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 825199,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7736,8 +7736,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 675589,
+      "tid": 22764,
+      "ts": 825219,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7748,9 +7748,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 675602,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 825230,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7762,9 +7762,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 675608,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 825235,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7776,9 +7776,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 675624,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 825249,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7790,9 +7790,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 675631,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 825254,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7804,8 +7804,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 675653,
+      "tid": 22764,
+      "ts": 825275,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7816,9 +7816,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 675666,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 825286,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7830,9 +7830,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 675672,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 825291,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7844,9 +7844,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 675689,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 825305,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7858,9 +7858,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 675695,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 825310,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7872,8 +7872,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 675717,
+      "tid": 22764,
+      "ts": 825331,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7884,9 +7884,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 675730,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 825342,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7898,9 +7898,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 675737,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 825347,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7912,9 +7912,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 675753,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 825361,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7926,9 +7926,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 675759,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 825366,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7940,8 +7940,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 675782,
+      "tid": 22764,
+      "ts": 825387,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -7952,9 +7952,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 675795,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 825398,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7966,9 +7966,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 675801,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 825403,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7980,9 +7980,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 675818,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 825417,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7994,9 +7994,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 675824,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 825423,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8008,8 +8008,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 675846,
+      "tid": 22764,
+      "ts": 825443,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -8020,9 +8020,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 675859,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 825454,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8034,9 +8034,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 675865,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 825459,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8048,9 +8048,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 675882,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 825473,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8062,9 +8062,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 675888,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 825479,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8076,8 +8076,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 675910,
+      "tid": 22764,
+      "ts": 825499,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -8088,9 +8088,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 675923,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 825510,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8102,9 +8102,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 675930,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 825515,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8116,9 +8116,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 675946,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 825529,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8130,9 +8130,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 675953,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 825535,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8144,8 +8144,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 675975,
+      "tid": 22764,
+      "ts": 825555,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -8156,9 +8156,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 675992,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 825569,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8170,9 +8170,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 675998,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 825575,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8184,9 +8184,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 676015,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 825589,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8198,9 +8198,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 676021,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 825594,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8212,8 +8212,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 676043,
+      "tid": 22764,
+      "ts": 825614,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -8224,9 +8224,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 676061,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 825629,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8238,9 +8238,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 676067,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 825635,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8252,9 +8252,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 676083,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 825649,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8266,9 +8266,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 676089,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 825654,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8280,8 +8280,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 676112,
+      "tid": 22764,
+      "ts": 825676,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -8292,9 +8292,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 676128,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 825691,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8306,9 +8306,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 676135,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 825696,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8320,9 +8320,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 676152,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 825710,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8334,9 +8334,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 676158,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 825716,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8348,8 +8348,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 676180,
+      "tid": 22764,
+      "ts": 825737,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -8360,9 +8360,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 676196,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 825752,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8374,9 +8374,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 676203,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 825758,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8388,9 +8388,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 676219,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 825772,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8402,9 +8402,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 676226,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 825777,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8416,8 +8416,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 676253,
+      "tid": 22764,
+      "ts": 825798,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -8428,9 +8428,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 676272,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 825813,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8442,9 +8442,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 676278,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 825818,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8456,9 +8456,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 676296,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 825833,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8470,9 +8470,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 676302,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 825838,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8484,8 +8484,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 676326,
+      "tid": 22764,
+      "ts": 825858,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -8496,9 +8496,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 676343,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 825872,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8510,9 +8510,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 676349,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 825877,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8524,9 +8524,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 676366,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 825891,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8538,9 +8538,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 676372,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 825897,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8552,9 +8552,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 676389,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 825911,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8566,9 +8566,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 676395,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 825916,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8580,8 +8580,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 676417,
+      "tid": 22764,
+      "ts": 825936,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -8592,8 +8592,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 676433,
+      "tid": 22764,
+      "ts": 825951,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -8604,8 +8604,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 676451,
+      "tid": 22764,
+      "ts": 825966,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -8616,8 +8616,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 676468,
+      "tid": 22764,
+      "ts": 825994,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -8628,8 +8628,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 676484,
+      "tid": 22764,
+      "ts": 826021,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -8640,8 +8640,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 676501,
+      "tid": 22764,
+      "ts": 826036,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -8652,8 +8652,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 676517,
+      "tid": 22764,
+      "ts": 826052,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -8664,8 +8664,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 676533,
+      "tid": 22764,
+      "ts": 826068,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -8676,8 +8676,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 676550,
+      "tid": 22764,
+      "ts": 826084,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -8688,8 +8688,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 676566,
+      "tid": 22764,
+      "ts": 826099,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -8700,8 +8700,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 676583,
+      "tid": 22764,
+      "ts": 826114,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -8712,8 +8712,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 676599,
+      "tid": 22764,
+      "ts": 826129,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -8724,18 +8724,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 676605,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 826135,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 676626,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 826153,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8747,18 +8747,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 676628,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 826155,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 676633,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 826159,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8770,9 +8770,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 676650,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 826174,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8784,9 +8784,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 676657,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 826179,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8798,8 +8798,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 676682,
+      "tid": 22764,
+      "ts": 826200,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -8810,9 +8810,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 676695,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 826211,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8824,9 +8824,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 676701,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 826216,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8838,9 +8838,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 676718,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 826230,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8852,9 +8852,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 676724,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 826236,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8866,8 +8866,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 676748,
+      "tid": 22764,
+      "ts": 826256,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -8878,9 +8878,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 676761,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 826267,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8892,9 +8892,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 676767,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 826272,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8906,9 +8906,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 676784,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 826286,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8920,9 +8920,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 676790,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 826291,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8934,8 +8934,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 676813,
+      "tid": 22764,
+      "ts": 826312,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -8946,9 +8946,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 676826,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 826323,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8960,9 +8960,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 676832,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 826328,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8974,9 +8974,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 676849,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 826342,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8988,9 +8988,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 676855,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 826348,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9002,8 +9002,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 676878,
+      "tid": 22764,
+      "ts": 826368,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -9014,9 +9014,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 676891,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 826379,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9028,9 +9028,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 676897,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 826385,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9042,9 +9042,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 676914,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 826399,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9056,9 +9056,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 676920,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 826404,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9070,8 +9070,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 676943,
+      "tid": 22764,
+      "ts": 826424,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -9082,9 +9082,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 676956,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 826435,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9096,9 +9096,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 676962,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 826440,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9110,9 +9110,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 676979,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 826454,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9124,9 +9124,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 676985,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 826460,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9138,8 +9138,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 677008,
+      "tid": 22764,
+      "ts": 826480,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -9150,9 +9150,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 677021,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 826491,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9164,9 +9164,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 677027,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 826496,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9178,9 +9178,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 677044,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 826511,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9192,9 +9192,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 677050,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 826516,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9206,8 +9206,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 677074,
+      "tid": 22764,
+      "ts": 826536,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -9218,9 +9218,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 677087,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 826547,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9232,9 +9232,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 677093,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 826552,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9246,9 +9246,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 677110,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 826566,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9260,9 +9260,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 677116,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 826571,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9274,8 +9274,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 677139,
+      "tid": 22764,
+      "ts": 826591,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -9286,9 +9286,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 677152,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 826602,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9300,9 +9300,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 677158,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 826608,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9314,9 +9314,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 677175,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 826622,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9328,9 +9328,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 677181,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 826627,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9342,8 +9342,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 677204,
+      "tid": 22764,
+      "ts": 826647,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -9354,9 +9354,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 677217,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 826658,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9368,9 +9368,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 677224,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 826663,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9382,9 +9382,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 677240,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 826677,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9396,9 +9396,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 677246,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 826683,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9410,8 +9410,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 677269,
+      "tid": 22764,
+      "ts": 826702,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -9422,9 +9422,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 677282,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 826713,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9436,9 +9436,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 677290,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 826719,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9450,9 +9450,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 677307,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 826733,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9464,9 +9464,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 677313,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 826738,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9478,8 +9478,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 677336,
+      "tid": 22764,
+      "ts": 826758,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -9490,9 +9490,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 677349,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 826769,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9504,9 +9504,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 677356,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 826774,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9518,9 +9518,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 677372,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 826788,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9532,9 +9532,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 677378,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 826793,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9546,8 +9546,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 677401,
+      "tid": 22764,
+      "ts": 826814,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -9558,9 +9558,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 677415,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 826824,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9572,9 +9572,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 677421,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 826830,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9586,9 +9586,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 677437,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 826843,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9600,9 +9600,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 677444,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 826849,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9614,8 +9614,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 677467,
+      "tid": 22764,
+      "ts": 826869,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -9626,9 +9626,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 677480,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 826880,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9640,9 +9640,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 677486,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 826885,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9654,9 +9654,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 677503,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 826899,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9668,9 +9668,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 677509,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 826904,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9682,8 +9682,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 677532,
+      "tid": 22764,
+      "ts": 826924,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -9694,9 +9694,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 677545,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 826935,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9708,9 +9708,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 677551,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 826941,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9722,9 +9722,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 677568,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 826955,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9736,9 +9736,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 677574,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 826960,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9750,8 +9750,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 677598,
+      "tid": 22764,
+      "ts": 826992,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -9762,9 +9762,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 677611,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 827015,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9776,9 +9776,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 677617,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 827020,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9790,9 +9790,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 677633,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 827034,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9804,9 +9804,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 677640,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 827040,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9818,8 +9818,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 677663,
+      "tid": 22764,
+      "ts": 827060,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -9830,9 +9830,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 677677,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 827071,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9844,9 +9844,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 677683,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 827076,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9858,9 +9858,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 677699,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 827090,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9872,9 +9872,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 677705,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 827095,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9886,8 +9886,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 677729,
+      "tid": 22764,
+      "ts": 827116,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -9898,9 +9898,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 677747,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 827130,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9912,9 +9912,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 677753,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 827135,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9926,9 +9926,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 677770,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 827150,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9940,9 +9940,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 677775,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 827155,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9954,8 +9954,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 677798,
+      "tid": 22764,
+      "ts": 827176,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -9966,9 +9966,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 677816,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 827192,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9980,9 +9980,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 677822,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 827198,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9994,9 +9994,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 677839,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 827212,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10008,9 +10008,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 677845,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 827217,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10022,8 +10022,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 677868,
+      "tid": 22764,
+      "ts": 827237,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -10034,9 +10034,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 677884,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 827251,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10048,9 +10048,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 677891,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 827256,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10062,9 +10062,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 677907,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 827271,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10076,9 +10076,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 677913,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 827276,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10090,8 +10090,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 677936,
+      "tid": 22764,
+      "ts": 827296,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -10102,9 +10102,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 677952,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 827310,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10116,9 +10116,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 677958,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 827315,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10130,9 +10130,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 677975,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 827329,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10144,9 +10144,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 677981,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 827334,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10158,8 +10158,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 678004,
+      "tid": 22764,
+      "ts": 827355,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -10170,9 +10170,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 678021,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 827370,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10184,9 +10184,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 678027,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 827375,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10198,9 +10198,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 678044,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 827389,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10212,9 +10212,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 678050,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 827395,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10226,8 +10226,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 678073,
+      "tid": 22764,
+      "ts": 827415,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -10238,9 +10238,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 678089,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 827428,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10252,9 +10252,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 678095,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 827434,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10266,9 +10266,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 678112,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 827448,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10280,9 +10280,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 678118,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 827454,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10294,9 +10294,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 678134,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 827468,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10308,9 +10308,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 678141,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 827473,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10322,8 +10322,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 678162,
+      "tid": 22764,
+      "ts": 827493,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -10334,8 +10334,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 678179,
+      "tid": 22764,
+      "ts": 827508,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -10346,8 +10346,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 678196,
+      "tid": 22764,
+      "ts": 827523,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -10358,8 +10358,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 678213,
+      "tid": 22764,
+      "ts": 827538,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -10370,8 +10370,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 678229,
+      "tid": 22764,
+      "ts": 827554,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -10382,8 +10382,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 678245,
+      "tid": 22764,
+      "ts": 827569,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -10394,8 +10394,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 678262,
+      "tid": 22764,
+      "ts": 827584,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -10406,8 +10406,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 678278,
+      "tid": 22764,
+      "ts": 827598,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -10418,8 +10418,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 678296,
+      "tid": 22764,
+      "ts": 827613,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -10430,8 +10430,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 678312,
+      "tid": 22764,
+      "ts": 827629,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -10442,8 +10442,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 678329,
+      "tid": 22764,
+      "ts": 827644,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -10454,8 +10454,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 678345,
+      "tid": 22764,
+      "ts": 827659,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -10466,18 +10466,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 678352,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 827664,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 678374,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 827681,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10489,18 +10489,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 678376,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 827684,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 678381,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 827688,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10512,9 +10512,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 678399,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 827702,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10526,9 +10526,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 678405,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 827708,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10540,8 +10540,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 678429,
+      "tid": 22764,
+      "ts": 827729,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -10552,9 +10552,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 678442,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 827740,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10566,9 +10566,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 678448,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 827745,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10580,9 +10580,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 678465,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 827759,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10594,9 +10594,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 678471,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 827764,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10608,8 +10608,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 678494,
+      "tid": 22764,
+      "ts": 827785,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -10620,9 +10620,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 678507,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 827796,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10634,9 +10634,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 678513,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 827801,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10648,9 +10648,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 678530,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 827815,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10662,9 +10662,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 678536,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 827821,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10676,8 +10676,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 678559,
+      "tid": 22764,
+      "ts": 827841,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -10688,9 +10688,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 678572,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 827852,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10702,9 +10702,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 678578,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 827857,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10716,9 +10716,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 678595,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 827871,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10730,9 +10730,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 678601,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 827876,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10744,8 +10744,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 678623,
+      "tid": 22764,
+      "ts": 827896,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -10756,9 +10756,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 678636,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 827907,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10770,9 +10770,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 678642,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 827913,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10784,9 +10784,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 678659,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 827927,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10798,9 +10798,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 678665,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 827932,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10812,8 +10812,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 678688,
+      "tid": 22764,
+      "ts": 827952,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -10824,9 +10824,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 678701,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 827963,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10838,9 +10838,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 678707,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 827968,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10852,9 +10852,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 678724,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 827995,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10866,9 +10866,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 678730,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 828013,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10880,8 +10880,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 678752,
+      "tid": 22764,
+      "ts": 828050,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -10892,9 +10892,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 678765,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 828061,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10906,9 +10906,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 678771,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 828066,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10920,9 +10920,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 678788,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 828092,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10934,9 +10934,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 678794,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 828097,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10948,8 +10948,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 678817,
+      "tid": 22764,
+      "ts": 828117,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -10960,9 +10960,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 678830,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 828128,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10974,9 +10974,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 678836,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 828133,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10988,9 +10988,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 678852,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 828147,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11002,9 +11002,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 678859,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 828152,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11016,8 +11016,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 678881,
+      "tid": 22764,
+      "ts": 828173,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -11028,9 +11028,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 678894,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 828184,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11042,9 +11042,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 678900,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 828189,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11056,9 +11056,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 678917,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 828203,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11070,9 +11070,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 678923,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 828208,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11084,8 +11084,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 678945,
+      "tid": 22764,
+      "ts": 828229,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -11096,9 +11096,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 678958,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 828239,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11110,9 +11110,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 678965,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 828245,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11124,9 +11124,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 678981,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 828259,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11138,9 +11138,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 678987,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 828264,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11152,8 +11152,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 679010,
+      "tid": 22764,
+      "ts": 828284,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -11164,9 +11164,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 679023,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 828295,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11178,9 +11178,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 679029,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 828300,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11192,9 +11192,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 679046,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 828315,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11206,9 +11206,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 679052,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 828320,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11220,8 +11220,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 679075,
+      "tid": 22764,
+      "ts": 828340,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -11232,9 +11232,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 679087,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 828351,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11246,9 +11246,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 679094,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 828356,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11260,9 +11260,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 679120,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 828370,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11274,9 +11274,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 679126,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 828376,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11288,8 +11288,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 679148,
+      "tid": 22764,
+      "ts": 828396,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -11300,9 +11300,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 679160,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 828407,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11314,9 +11314,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 679166,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 828412,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11328,9 +11328,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 679183,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 828426,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11342,9 +11342,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 679188,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 828431,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11356,8 +11356,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 679210,
+      "tid": 22764,
+      "ts": 828451,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -11368,9 +11368,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 679223,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 828462,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11382,9 +11382,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 679229,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 828467,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11396,9 +11396,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 679245,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 828481,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11410,9 +11410,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 679251,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 828487,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11424,8 +11424,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 679273,
+      "tid": 22764,
+      "ts": 828507,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -11436,9 +11436,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 679287,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 828518,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11450,9 +11450,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 679293,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 828523,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11464,9 +11464,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 679309,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 828537,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11478,9 +11478,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 679315,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 828542,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11492,8 +11492,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 679337,
+      "tid": 22764,
+      "ts": 828562,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -11504,9 +11504,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 679349,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 828573,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11518,9 +11518,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 679356,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 828579,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11532,9 +11532,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 679867,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 829132,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11546,9 +11546,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 679874,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 829138,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11560,8 +11560,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 679897,
+      "tid": 22764,
+      "ts": 829159,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -11572,9 +11572,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 679910,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 829170,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11586,9 +11586,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 679916,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 829176,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11600,9 +11600,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 679932,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 829190,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11614,9 +11614,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 679938,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 829195,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11628,8 +11628,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 679960,
+      "tid": 22764,
+      "ts": 829215,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -11640,9 +11640,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 679976,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 829230,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11654,9 +11654,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 679983,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 829235,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11668,9 +11668,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 679999,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 829249,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11682,9 +11682,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 680005,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 829255,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11696,8 +11696,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 680027,
+      "tid": 22764,
+      "ts": 829275,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -11708,9 +11708,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 680044,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 829291,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11722,9 +11722,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 680051,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 829296,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11736,9 +11736,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 680067,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 829311,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11750,9 +11750,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 680073,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 829316,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11764,8 +11764,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 680095,
+      "tid": 22764,
+      "ts": 829340,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -11776,9 +11776,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 680111,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 829355,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11790,9 +11790,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 680117,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 829361,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11804,9 +11804,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 680134,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 829375,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11818,9 +11818,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 680140,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 829381,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11832,8 +11832,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 680162,
+      "tid": 22764,
+      "ts": 829401,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -11844,9 +11844,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 680179,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 829416,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11858,9 +11858,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 680186,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 829422,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11872,9 +11872,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 680202,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 829436,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11886,9 +11886,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 680208,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 829441,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11900,8 +11900,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 680230,
+      "tid": 22764,
+      "ts": 829461,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -11912,9 +11912,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 680247,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 829476,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11926,9 +11926,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 680253,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 829482,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11940,9 +11940,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 680269,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 829496,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11954,9 +11954,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 680275,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 829501,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11968,8 +11968,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 680299,
+      "tid": 22764,
+      "ts": 829522,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -11980,9 +11980,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 680314,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 829535,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -11994,9 +11994,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 680320,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 829540,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12008,9 +12008,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 680337,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 829555,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12022,9 +12022,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 680343,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 829560,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12036,9 +12036,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 680359,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 829574,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12050,9 +12050,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 680365,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 829579,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12064,8 +12064,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 680386,
+      "tid": 22764,
+      "ts": 829599,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -12076,8 +12076,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 680402,
+      "tid": 22764,
+      "ts": 829614,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -12088,8 +12088,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 680419,
+      "tid": 22764,
+      "ts": 829630,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -12100,8 +12100,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 680435,
+      "tid": 22764,
+      "ts": 829645,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -12112,8 +12112,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 680451,
+      "tid": 22764,
+      "ts": 829660,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -12124,8 +12124,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 680468,
+      "tid": 22764,
+      "ts": 829675,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -12136,8 +12136,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 680484,
+      "tid": 22764,
+      "ts": 829690,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -12148,8 +12148,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 680500,
+      "tid": 22764,
+      "ts": 829705,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -12160,8 +12160,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 680518,
+      "tid": 22764,
+      "ts": 829720,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -12172,8 +12172,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 680534,
+      "tid": 22764,
+      "ts": 829736,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -12184,8 +12184,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 680550,
+      "tid": 22764,
+      "ts": 829751,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -12196,8 +12196,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 680566,
+      "tid": 22764,
+      "ts": 829767,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -12208,18 +12208,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 680572,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 829773,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 680592,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 829795,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12231,18 +12231,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 680595,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 829798,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 680600,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 829802,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12254,9 +12254,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 680617,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 829817,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12268,9 +12268,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 680623,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 829822,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12282,8 +12282,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 680645,
+      "tid": 22764,
+      "ts": 829843,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -12294,9 +12294,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 680658,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 829854,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12308,9 +12308,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 680664,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 829860,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12322,9 +12322,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 680681,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 829874,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12336,9 +12336,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 680687,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 829879,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12350,8 +12350,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 680709,
+      "tid": 22764,
+      "ts": 829899,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -12362,9 +12362,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 680721,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 829910,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12376,9 +12376,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 680727,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 829915,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12390,9 +12390,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 680743,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 829930,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12404,9 +12404,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 680749,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 829935,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12418,8 +12418,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 680771,
+      "tid": 22764,
+      "ts": 829955,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -12430,9 +12430,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 680783,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 829966,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12444,9 +12444,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 680789,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 829982,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12458,9 +12458,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 680806,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830009,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12472,9 +12472,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 680812,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830014,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12486,8 +12486,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 680834,
+      "tid": 22764,
+      "ts": 830035,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -12498,9 +12498,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 680858,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830045,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12512,9 +12512,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 680864,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830051,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12526,9 +12526,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 680881,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830065,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12540,9 +12540,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 680887,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830070,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12554,8 +12554,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 680909,
+      "tid": 22764,
+      "ts": 830090,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -12566,9 +12566,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 680922,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830101,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12580,9 +12580,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 680929,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830106,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12594,9 +12594,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 680957,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830120,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12608,9 +12608,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 680963,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830126,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12622,8 +12622,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 680997,
+      "tid": 22764,
+      "ts": 830146,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -12634,9 +12634,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 681021,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830157,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12648,9 +12648,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 681027,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830162,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12662,9 +12662,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 681045,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830176,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12676,9 +12676,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 681062,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830182,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12690,8 +12690,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 681085,
+      "tid": 22764,
+      "ts": 830202,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -12702,9 +12702,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 681097,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830213,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12716,9 +12716,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 681104,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830218,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12730,9 +12730,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 681120,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830232,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12744,9 +12744,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 681126,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830237,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12758,8 +12758,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 681149,
+      "tid": 22764,
+      "ts": 830257,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -12770,9 +12770,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 681162,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830268,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12784,9 +12784,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 681168,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830274,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12798,9 +12798,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 681185,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830288,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12812,9 +12812,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 681191,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830293,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12826,8 +12826,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 681214,
+      "tid": 22764,
+      "ts": 830313,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -12838,9 +12838,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 681227,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830324,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12852,9 +12852,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 681233,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830329,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12866,9 +12866,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 681250,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830343,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12880,9 +12880,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 681256,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830348,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12894,8 +12894,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 681279,
+      "tid": 22764,
+      "ts": 830369,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -12906,9 +12906,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 681293,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830380,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12920,9 +12920,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 681299,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830385,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12934,9 +12934,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 681316,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830399,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12948,9 +12948,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 681322,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830404,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12962,8 +12962,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 681344,
+      "tid": 22764,
+      "ts": 830425,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -12974,9 +12974,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 681358,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830436,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -12988,9 +12988,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 681364,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830441,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13002,9 +13002,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 681380,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830456,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13016,9 +13016,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 681386,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830461,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13030,8 +13030,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 681420,
+      "tid": 22764,
+      "ts": 830481,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -13042,9 +13042,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 681435,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830492,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13056,9 +13056,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 681442,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830497,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13070,9 +13070,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 681459,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830511,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13084,9 +13084,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 681476,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830517,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13098,8 +13098,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 681515,
+      "tid": 22764,
+      "ts": 830537,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -13110,9 +13110,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 681528,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830548,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13124,9 +13124,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 681535,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830553,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13138,9 +13138,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 681563,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830567,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13152,9 +13152,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 681569,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830573,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13166,8 +13166,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 681591,
+      "tid": 22764,
+      "ts": 830593,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -13178,9 +13178,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 681604,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830605,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13192,9 +13192,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 681610,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830611,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13206,9 +13206,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 681627,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830625,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13220,9 +13220,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 681644,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830630,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13234,8 +13234,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 681668,
+      "tid": 22764,
+      "ts": 830651,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -13246,9 +13246,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 681691,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830662,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13260,9 +13260,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 681698,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830667,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13274,9 +13274,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 681725,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830681,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13288,9 +13288,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 681732,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830687,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13302,8 +13302,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 681765,
+      "tid": 22764,
+      "ts": 830707,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -13314,9 +13314,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 681790,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830718,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13328,9 +13328,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 681796,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830724,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13342,9 +13342,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 681824,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830738,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13356,9 +13356,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 681845,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830743,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13370,8 +13370,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 681868,
+      "tid": 22764,
+      "ts": 830763,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
@@ -13382,9 +13382,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 681886,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830778,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13396,9 +13396,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 681893,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830783,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13410,9 +13410,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 681944,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830797,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13424,9 +13424,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 681950,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830802,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13438,8 +13438,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 681985,
+      "tid": 22764,
+      "ts": 830823,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
@@ -13450,9 +13450,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 682016,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830838,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13464,9 +13464,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 682022,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830843,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13478,9 +13478,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 682038,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830858,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13492,9 +13492,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 682044,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830863,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13506,8 +13506,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 682066,
+      "tid": 22764,
+      "ts": 830883,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
@@ -13518,9 +13518,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 682082,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830897,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13532,9 +13532,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 682088,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830902,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13546,9 +13546,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 682104,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830916,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13560,9 +13560,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 682110,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830922,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13574,8 +13574,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 682132,
+      "tid": 22764,
+      "ts": 830942,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
@@ -13586,9 +13586,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 682147,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830956,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13600,9 +13600,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 682154,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830961,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13614,9 +13614,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 682170,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 830986,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13628,9 +13628,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 682176,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 830993,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13642,8 +13642,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 682198,
+      "tid": 22764,
+      "ts": 831043,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
@@ -13654,9 +13654,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 682214,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 831070,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13668,9 +13668,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 682220,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 831076,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13682,9 +13682,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 682237,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 831090,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13696,9 +13696,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 682243,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 831095,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13710,8 +13710,8 @@
       "name": "SlabBlockAllocator.AllocateBlock",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 682265,
+      "tid": 22764,
+      "ts": 831116,
       "pid": "GPGMM",
       "args": {
         "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
@@ -13722,9 +13722,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 682280,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 831130,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13736,9 +13736,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 682287,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 831135,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13750,9 +13750,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 682330,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 831149,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13764,9 +13764,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 682337,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 831154,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13778,9 +13778,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 682354,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 831168,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13792,9 +13792,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 682360,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 831174,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -13806,8 +13806,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 682383,
+      "tid": 22764,
+      "ts": 831193,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -13818,8 +13818,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 682400,
+      "tid": 22764,
+      "ts": 831209,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -13830,8 +13830,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 682428,
+      "tid": 22764,
+      "ts": 831224,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
@@ -13842,8 +13842,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 682456,
+      "tid": 22764,
+      "ts": 831250,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -13854,8 +13854,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 682472,
+      "tid": 22764,
+      "ts": 831266,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -13866,8 +13866,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 682500,
+      "tid": 22764,
+      "ts": 831281,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -13878,8 +13878,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 682543,
+      "tid": 22764,
+      "ts": 831308,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -13890,8 +13890,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 682560,
+      "tid": 22764,
+      "ts": 831335,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -13902,8 +13902,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 682576,
+      "tid": 22764,
+      "ts": 831351,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
@@ -13914,8 +13914,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 682593,
+      "tid": 22764,
+      "ts": 831378,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -13926,8 +13926,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 682609,
+      "tid": 22764,
+      "ts": 831394,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -13938,8 +13938,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 682625,
+      "tid": 22764,
+      "ts": 831420,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
@@ -13950,13 +13950,13 @@
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 682654,
+      "tid": 22764,
+      "ts": 831448,
       "pid": "GPGMM",
       "args": {
         "Flags": 0,
         "RecordOptions": {
-          "Flags": 6
+          "Flags": 3
         },
         "IsUMA": 1,
         "ResourceHeapTier": 2,
@@ -13971,8 +13971,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 682714,
+      "tid": 22764,
+      "ts": 831505,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -14002,8 +14002,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 682732,
+      "tid": 22764,
+      "ts": 831522,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (134217728 vs 4194304 bytes).",
@@ -14014,8 +14014,8 @@
       "name": "ResourceAllocator.TryAllocateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 682747,
+      "tid": 22764,
+      "ts": 831536,
       "pid": "GPGMM",
       "args": {
         "Description": "Resource memory could not be allocated.",
@@ -14026,18 +14026,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababb58b0",
-      "tid": 16484,
-      "ts": 682749,
+      "id": "0x15aff759ec0",
+      "tid": 22764,
+      "ts": 831538,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb58b0",
-      "tid": 16484,
-      "ts": 682754,
+      "id": "0x15aff759ec0",
+      "tid": 22764,
+      "ts": 831543,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14049,18 +14049,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababb50d0",
-      "tid": 16484,
-      "ts": 683109,
+      "id": "0x15aff759bf0",
+      "tid": 22764,
+      "ts": 831927,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb50d0",
-      "tid": 16484,
-      "ts": 683141,
+      "id": "0x15aff759bf0",
+      "tid": 22764,
+      "ts": 831959,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14075,9 +14075,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb50d0",
-      "tid": 16484,
-      "ts": 683163,
+      "id": "0x15aff759bf0",
+      "tid": 22764,
+      "ts": 831991,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14092,9 +14092,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb50d0",
-      "tid": 16484,
-      "ts": 683182,
+      "id": "0x15aff759bf0",
+      "tid": 22764,
+      "ts": 832010,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14103,7 +14103,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x22ababb58b0"
+            "id_ref": "0x15aff759ec0"
           }
         }
       }
@@ -14112,9 +14112,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb50d0",
-      "tid": 16484,
-      "ts": 683260,
+      "id": "0x15aff759bf0",
+      "tid": 22764,
+      "ts": 832131,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14123,7 +14123,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x22ababb58b0"
+            "id_ref": "0x15aff759ec0"
           }
         }
       }
@@ -14132,18 +14132,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababbe340",
-      "tid": 16484,
-      "ts": 683263,
+      "id": "0x15aff75aaa0",
+      "tid": 22764,
+      "ts": 832135,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababbe340",
-      "tid": 16484,
-      "ts": 683279,
+      "id": "0x15aff75aaa0",
+      "tid": 22764,
+      "ts": 832149,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14152,7 +14152,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x22ababb50d0"
+            "id_ref": "0x15aff759bf0"
           }
         }
       }
@@ -14161,8 +14161,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 683446,
+      "tid": 22764,
+      "ts": 832271,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -14192,8 +14192,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 683466,
+      "tid": 22764,
+      "ts": 832290,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (134217728 vs 4194304 bytes).",
@@ -14204,8 +14204,8 @@
       "name": "ResourceAllocator.TryAllocateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 683480,
+      "tid": 22764,
+      "ts": 832304,
       "pid": "GPGMM",
       "args": {
         "Description": "Resource memory could not be allocated.",
@@ -14216,18 +14216,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababb43e0",
-      "tid": 16484,
-      "ts": 683483,
+      "id": "0x15aff7592f0",
+      "tid": 22764,
+      "ts": 832307,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb43e0",
-      "tid": 16484,
-      "ts": 683488,
+      "id": "0x15aff7592f0",
+      "tid": 22764,
+      "ts": 832322,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14239,18 +14239,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababb4590",
-      "tid": 16484,
-      "ts": 683777,
+      "id": "0x15aff758d50",
+      "tid": 22764,
+      "ts": 832644,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb4590",
-      "tid": 16484,
-      "ts": 683808,
+      "id": "0x15aff758d50",
+      "tid": 22764,
+      "ts": 832674,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14265,9 +14265,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb4590",
-      "tid": 16484,
-      "ts": 683826,
+      "id": "0x15aff758d50",
+      "tid": 22764,
+      "ts": 832690,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14282,9 +14282,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb4590",
-      "tid": 16484,
-      "ts": 683844,
+      "id": "0x15aff758d50",
+      "tid": 22764,
+      "ts": 832707,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14293,7 +14293,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x22ababb43e0"
+            "id_ref": "0x15aff7592f0"
           }
         }
       }
@@ -14302,9 +14302,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb4590",
-      "tid": 16484,
-      "ts": 683920,
+      "id": "0x15aff758d50",
+      "tid": 22764,
+      "ts": 832801,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14313,7 +14313,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x22ababb43e0"
+            "id_ref": "0x15aff7592f0"
           }
         }
       }
@@ -14322,18 +14322,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababbfec0",
-      "tid": 16484,
-      "ts": 683923,
+      "id": "0x15aff75a310",
+      "tid": 22764,
+      "ts": 832815,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababbfec0",
-      "tid": 16484,
-      "ts": 683938,
+      "id": "0x15aff75a310",
+      "tid": 22764,
+      "ts": 832829,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14342,7 +14342,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x22ababb4590"
+            "id_ref": "0x15aff758d50"
           }
         }
       }
@@ -14351,8 +14351,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 684053,
+      "tid": 22764,
+      "ts": 832941,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -14382,9 +14382,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 684069,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 832955,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14396,9 +14396,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 684076,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 832961,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14410,18 +14410,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababb5550",
-      "tid": 16484,
-      "ts": 684429,
+      "id": "0x15aff758720",
+      "tid": 22764,
+      "ts": 833360,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5550",
-      "tid": 16484,
-      "ts": 684449,
+      "id": "0x15aff758720",
+      "tid": 22764,
+      "ts": 833390,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14436,9 +14436,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5550",
-      "tid": 16484,
-      "ts": 684467,
+      "id": "0x15aff758720",
+      "tid": 22764,
+      "ts": 833418,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14453,9 +14453,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 684477,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 833428,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14467,9 +14467,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5550",
-      "tid": 16484,
-      "ts": 684497,
+      "id": "0x15aff758720",
+      "tid": 22764,
+      "ts": 833447,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14478,7 +14478,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x22ab65b4c80"
+            "id_ref": "0x15aff3115c0"
           }
         }
       }
@@ -14487,9 +14487,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5550",
-      "tid": 16484,
-      "ts": 684573,
+      "id": "0x15aff758720",
+      "tid": 22764,
+      "ts": 833535,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14498,7 +14498,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x22ab65b4c80"
+            "id_ref": "0x15aff3115c0"
           }
         }
       }
@@ -14507,18 +14507,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababbf310",
-      "tid": 16484,
-      "ts": 684576,
+      "id": "0x15aff75b0d0",
+      "tid": 22764,
+      "ts": 833538,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababbf310",
-      "tid": 16484,
-      "ts": 684591,
+      "id": "0x15aff75b0d0",
+      "tid": 22764,
+      "ts": 833552,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14527,7 +14527,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22ababb5550"
+            "id_ref": "0x15aff758720"
           }
         }
       }
@@ -14536,8 +14536,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 684717,
+      "tid": 22764,
+      "ts": 833674,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -14567,8 +14567,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 684737,
+      "tid": 22764,
+      "ts": 833694,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (134217728 vs 4194304 bytes).",
@@ -14579,8 +14579,8 @@
       "name": "ResourceAllocator.TryAllocateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 684751,
+      "tid": 22764,
+      "ts": 833710,
       "pid": "GPGMM",
       "args": {
         "Description": "Resource memory could not be allocated.",
@@ -14591,9 +14591,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb43e0",
-      "tid": 16484,
-      "ts": 684758,
+      "id": "0x15aff7592f0",
+      "tid": 22764,
+      "ts": 833716,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14605,18 +14605,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababb59d0",
-      "tid": 16484,
-      "ts": 685049,
+      "id": "0x15aff7584e0",
+      "tid": 22764,
+      "ts": 834024,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb59d0",
-      "tid": 16484,
-      "ts": 685069,
+      "id": "0x15aff7584e0",
+      "tid": 22764,
+      "ts": 834049,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14631,9 +14631,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb59d0",
-      "tid": 16484,
-      "ts": 685087,
+      "id": "0x15aff7584e0",
+      "tid": 22764,
+      "ts": 834070,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14648,9 +14648,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb59d0",
-      "tid": 16484,
-      "ts": 685105,
+      "id": "0x15aff7584e0",
+      "tid": 22764,
+      "ts": 834102,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14659,7 +14659,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x22ababb43e0"
+            "id_ref": "0x15aff7592f0"
           }
         }
       }
@@ -14668,9 +14668,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb59d0",
-      "tid": 16484,
-      "ts": 685179,
+      "id": "0x15aff7584e0",
+      "tid": 22764,
+      "ts": 834189,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14679,7 +14679,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x22ababb43e0"
+            "id_ref": "0x15aff7592f0"
           }
         }
       }
@@ -14688,18 +14688,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababbf940",
-      "tid": 16484,
-      "ts": 685182,
+      "id": "0x15aff75ac00",
+      "tid": 22764,
+      "ts": 834191,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababbf940",
-      "tid": 16484,
-      "ts": 685196,
+      "id": "0x15aff75ac00",
+      "tid": 22764,
+      "ts": 834206,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14708,7 +14708,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x22ababb59d0"
+            "id_ref": "0x15aff7584e0"
           }
         }
       }
@@ -14717,9 +14717,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb58b0",
-      "tid": 16484,
-      "ts": 685300,
+      "id": "0x15aff759ec0",
+      "tid": 22764,
+      "ts": 834277,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14731,17 +14731,17 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababbe340",
-      "tid": 16484,
-      "ts": 685359,
+      "id": "0x15aff75aaa0",
+      "tid": 22764,
+      "ts": 834338,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 685414,
+      "tid": 22764,
+      "ts": 834388,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -14771,9 +14771,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 685430,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 834404,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14785,9 +14785,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 685437,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 834410,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14799,18 +14799,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababb4350",
-      "tid": 16484,
-      "ts": 685796,
+      "id": "0x15aff759c80",
+      "tid": 22764,
+      "ts": 834738,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb4350",
-      "tid": 16484,
-      "ts": 685816,
+      "id": "0x15aff759c80",
+      "tid": 22764,
+      "ts": 834758,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14825,9 +14825,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb4350",
-      "tid": 16484,
-      "ts": 685833,
+      "id": "0x15aff759c80",
+      "tid": 22764,
+      "ts": 834774,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14842,9 +14842,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 685843,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 834784,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14856,9 +14856,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb4350",
-      "tid": 16484,
-      "ts": 685865,
+      "id": "0x15aff759c80",
+      "tid": 22764,
+      "ts": 834803,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14867,7 +14867,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x22ab65b3180"
+            "id_ref": "0x15aff311ad0"
           }
         }
       }
@@ -14876,9 +14876,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb4350",
-      "tid": 16484,
-      "ts": 685940,
+      "id": "0x15aff759c80",
+      "tid": 22764,
+      "ts": 834882,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14887,7 +14887,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x22ab65b3180"
+            "id_ref": "0x15aff311ad0"
           }
         }
       }
@@ -14896,18 +14896,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababbe290",
-      "tid": 16484,
-      "ts": 685942,
+      "id": "0x15aff75a9f0",
+      "tid": 22764,
+      "ts": 834885,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababbe290",
-      "tid": 16484,
-      "ts": 685957,
+      "id": "0x15aff75a9f0",
+      "tid": 22764,
+      "ts": 834899,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14916,7 +14916,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22ababb4350"
+            "id_ref": "0x15aff759c80"
           }
         }
       }
@@ -14925,9 +14925,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb43e0",
-      "tid": 16484,
-      "ts": 686071,
+      "id": "0x15aff7592f0",
+      "tid": 22764,
+      "ts": 834961,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14939,17 +14939,17 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababbfec0",
-      "tid": 16484,
-      "ts": 686120,
+      "id": "0x15aff75a310",
+      "tid": 22764,
+      "ts": 835012,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 686174,
+      "tid": 22764,
+      "ts": 835061,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -14979,9 +14979,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 686189,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 835074,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -14993,9 +14993,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 686196,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 835080,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15007,18 +15007,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababb4d70",
-      "tid": 16484,
-      "ts": 686556,
+      "id": "0x15aff758f90",
+      "tid": 22764,
+      "ts": 835394,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb4d70",
-      "tid": 16484,
-      "ts": 686576,
+      "id": "0x15aff758f90",
+      "tid": 22764,
+      "ts": 835413,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15033,9 +15033,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb4d70",
-      "tid": 16484,
-      "ts": 686594,
+      "id": "0x15aff758f90",
+      "tid": 22764,
+      "ts": 835428,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15050,9 +15050,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 686604,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 835438,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15064,9 +15064,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb4d70",
-      "tid": 16484,
-      "ts": 686625,
+      "id": "0x15aff758f90",
+      "tid": 22764,
+      "ts": 835456,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15075,7 +15075,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x22ab65b4c80"
+            "id_ref": "0x15aff3115c0"
           }
         }
       }
@@ -15084,9 +15084,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb4d70",
-      "tid": 16484,
-      "ts": 686700,
+      "id": "0x15aff758f90",
+      "tid": 22764,
+      "ts": 835527,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15095,7 +15095,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x22ab65b4c80"
+            "id_ref": "0x15aff3115c0"
           }
         }
       }
@@ -15104,18 +15104,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababbfec0",
-      "tid": 16484,
-      "ts": 686703,
+      "id": "0x15aff75ae10",
+      "tid": 22764,
+      "ts": 835530,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababbfec0",
-      "tid": 16484,
-      "ts": 686717,
+      "id": "0x15aff75ae10",
+      "tid": 22764,
+      "ts": 835543,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15124,7 +15124,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22ababb4d70"
+            "id_ref": "0x15aff758f90"
           }
         }
       }
@@ -15133,8 +15133,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 686855,
+      "tid": 22764,
+      "ts": 835628,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -15164,9 +15164,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 686873,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 835649,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15178,9 +15178,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 686881,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 835655,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15192,18 +15192,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abaac0ce0",
-      "tid": 16484,
-      "ts": 687252,
+      "id": "0x15aff759410",
+      "tid": 22764,
+      "ts": 835970,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abaac0ce0",
-      "tid": 16484,
-      "ts": 687272,
+      "id": "0x15aff759410",
+      "tid": 22764,
+      "ts": 835988,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15218,9 +15218,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abaac0ce0",
-      "tid": 16484,
-      "ts": 687292,
+      "id": "0x15aff759410",
+      "tid": 22764,
+      "ts": 836004,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15235,9 +15235,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 687303,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 836013,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15249,9 +15249,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abaac0ce0",
-      "tid": 16484,
-      "ts": 687324,
+      "id": "0x15aff759410",
+      "tid": 22764,
+      "ts": 836032,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15260,7 +15260,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x22ab65b39f0"
+            "id_ref": "0x15aff312c40"
           }
         }
       }
@@ -15269,9 +15269,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abaac0ce0",
-      "tid": 16484,
-      "ts": 687397,
+      "id": "0x15aff759410",
+      "tid": 22764,
+      "ts": 836102,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15280,7 +15280,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x22ab65b39f0"
+            "id_ref": "0x15aff312c40"
           }
         }
       }
@@ -15289,18 +15289,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababbe600",
-      "tid": 16484,
-      "ts": 687400,
+      "id": "0x15aff75b2e0",
+      "tid": 22764,
+      "ts": 836105,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababbe600",
-      "tid": 16484,
-      "ts": 687415,
+      "id": "0x15aff75b2e0",
+      "tid": 22764,
+      "ts": 836119,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15309,7 +15309,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22abaac0ce0"
+            "id_ref": "0x15aff759410"
           }
         }
       }
@@ -15318,8 +15318,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 687536,
+      "tid": 22764,
+      "ts": 836200,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -15349,9 +15349,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5550",
-      "tid": 16484,
-      "ts": 687559,
+      "id": "0x15aff758720",
+      "tid": 22764,
+      "ts": 836222,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15360,7 +15360,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 3,
           "MemoryPool": {
-            "id_ref": "0x22ab65b4c80"
+            "id_ref": "0x15aff3115c0"
           }
         }
       }
@@ -15369,9 +15369,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb5550",
-      "tid": 16484,
-      "ts": 687633,
+      "id": "0x15aff758720",
+      "tid": 22764,
+      "ts": 836294,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15380,7 +15380,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 3,
           "MemoryPool": {
-            "id_ref": "0x22ab65b4c80"
+            "id_ref": "0x15aff3115c0"
           }
         }
       }
@@ -15389,18 +15389,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22ababb1830",
-      "tid": 16484,
-      "ts": 687636,
+      "id": "0x15aff75b390",
+      "tid": 22764,
+      "ts": 836297,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb1830",
-      "tid": 16484,
-      "ts": 687651,
+      "id": "0x15aff75b390",
+      "tid": 22764,
+      "ts": 836311,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15409,7 +15409,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x22ababb5550"
+            "id_ref": "0x15aff758720"
           }
         }
       }
@@ -15418,17 +15418,17 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababbf310",
-      "tid": 16484,
-      "ts": 687763,
+      "id": "0x15aff75b0d0",
+      "tid": 22764,
+      "ts": 836396,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 687816,
+      "tid": 22764,
+      "ts": 836441,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -15458,8 +15458,8 @@
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 687835,
+      "tid": 22764,
+      "ts": 836465,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -15470,8 +15470,8 @@
       "name": "ResourceAllocator.TryAllocateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 16484,
-      "ts": 687852,
+      "tid": 22764,
+      "ts": 836479,
       "pid": "GPGMM",
       "args": {
         "Description": "Resource memory could not be allocated.",
@@ -15482,18 +15482,18 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abaac1af0",
-      "tid": 16484,
-      "ts": 687854,
+      "id": "0x15aff39b620",
+      "tid": 22764,
+      "ts": 836482,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abaac1af0",
-      "tid": 16484,
-      "ts": 687859,
+      "id": "0x15aff39b620",
+      "tid": 22764,
+      "ts": 836487,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15505,18 +15505,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abaac0e00",
-      "tid": 16484,
-      "ts": 688854,
+      "id": "0x15aff39aae0",
+      "tid": 22764,
+      "ts": 837375,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abaac0e00",
-      "tid": 16484,
-      "ts": 688876,
+      "id": "0x15aff39aae0",
+      "tid": 22764,
+      "ts": 837394,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15531,9 +15531,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abaac0e00",
-      "tid": 16484,
-      "ts": 688896,
+      "id": "0x15aff39aae0",
+      "tid": 22764,
+      "ts": 837409,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15548,9 +15548,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abaac0e00",
-      "tid": 16484,
-      "ts": 688918,
+      "id": "0x15aff39aae0",
+      "tid": 22764,
+      "ts": 837427,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15559,7 +15559,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x22abaac1af0"
+            "id_ref": "0x15aff39b620"
           }
         }
       }
@@ -15568,9 +15568,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abaac0e00",
-      "tid": 16484,
-      "ts": 689015,
+      "id": "0x15aff39aae0",
+      "tid": 22764,
+      "ts": 837496,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15579,7 +15579,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x22abaac1af0"
+            "id_ref": "0x15aff39b620"
           }
         }
       }
@@ -15588,18 +15588,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x22abaacde20",
-      "tid": 16484,
-      "ts": 689018,
+      "id": "0x15aff39cb20",
+      "tid": 22764,
+      "ts": 837499,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abaacde20",
-      "tid": 16484,
-      "ts": 689037,
+      "id": "0x15aff39cb20",
+      "tid": 22764,
+      "ts": 837513,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15608,7 +15608,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x22abaac0e00"
+            "id_ref": "0x15aff39aae0"
           }
         }
       }
@@ -15617,9 +15617,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ababb43e0",
-      "tid": 16484,
-      "ts": 689148,
+      "id": "0x15aff7592f0",
+      "tid": 22764,
+      "ts": 837576,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15631,18 +15631,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababbf940",
-      "tid": 16484,
-      "ts": 689201,
+      "id": "0x15aff75ac00",
+      "tid": 22764,
+      "ts": 837623,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abaac1af0",
-      "tid": 16484,
-      "ts": 689262,
+      "id": "0x15aff39b620",
+      "tid": 22764,
+      "ts": 837648,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15654,18 +15654,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abaacde20",
-      "tid": 16484,
-      "ts": 689314,
+      "id": "0x15aff39cb20",
+      "tid": 22764,
+      "ts": 837694,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 689377,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 837719,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15677,9 +15677,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 689389,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 837731,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15691,18 +15691,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababb1830",
-      "tid": 16484,
-      "ts": 689439,
+      "id": "0x15aff75b390",
+      "tid": 22764,
+      "ts": 837778,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 689503,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 837807,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15714,9 +15714,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 689512,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 837815,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15728,18 +15728,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababbfec0",
-      "tid": 16484,
-      "ts": 689576,
+      "id": "0x15aff75ae10",
+      "tid": 22764,
+      "ts": 837861,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 689660,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 837888,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15751,9 +15751,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 689672,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 837898,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15765,18 +15765,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababbe600",
-      "tid": 16484,
-      "ts": 689723,
+      "id": "0x15aff75b2e0",
+      "tid": 22764,
+      "ts": 837944,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 689788,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 837974,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15788,9 +15788,9 @@
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 689799,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 837984,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -15802,261 +15802,261 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababbe290",
-      "tid": 16484,
-      "ts": 689849,
+      "id": "0x15aff75a9f0",
+      "tid": 22764,
+      "ts": 838030,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadf0600",
-      "tid": 16484,
-      "ts": 689862,
+      "id": "0x15afcc5c290",
+      "tid": 22764,
+      "ts": 838039,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadee868",
-      "tid": 16484,
-      "ts": 689878,
+      "id": "0x15afcbd1da8",
+      "tid": 22764,
+      "ts": 838053,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abaac0ce0",
-      "tid": 16484,
-      "ts": 689881,
+      "id": "0x15aff759410",
+      "tid": 22764,
+      "ts": 838056,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ab65b39f0",
-      "tid": 16484,
-      "ts": 690077,
+      "id": "0x15aff312c40",
+      "tid": 22764,
+      "ts": 838180,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadefe68",
-      "tid": 16484,
-      "ts": 690102,
+      "id": "0x15afcbd2da8",
+      "tid": 22764,
+      "ts": 838202,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababb4350",
-      "tid": 16484,
-      "ts": 690104,
+      "id": "0x15aff759c80",
+      "tid": 22764,
+      "ts": 838203,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ab65b3180",
-      "tid": 16484,
-      "ts": 690255,
+      "id": "0x15aff311ad0",
+      "tid": 22764,
+      "ts": 838313,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadef568",
-      "tid": 16484,
-      "ts": 690276,
+      "id": "0x15afcbd32a8",
+      "tid": 22764,
+      "ts": 838332,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababb4d70",
-      "tid": 16484,
-      "ts": 690278,
+      "id": "0x15aff758f90",
+      "tid": 22764,
+      "ts": 838334,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababb5550",
-      "tid": 16484,
-      "ts": 690456,
+      "id": "0x15aff758720",
+      "tid": 22764,
+      "ts": 838442,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ab65b4c80",
-      "tid": 16484,
-      "ts": 690633,
+      "id": "0x15aff3115c0",
+      "tid": 22764,
+      "ts": 838551,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadeec68",
-      "tid": 16484,
-      "ts": 690656,
+      "id": "0x15afcbd2ba8",
+      "tid": 22764,
+      "ts": 838571,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ab65b4020",
-      "tid": 16484,
-      "ts": 690658,
+      "id": "0x15aff311890",
+      "tid": 22764,
+      "ts": 838572,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadeef68",
-      "tid": 16484,
-      "ts": 690676,
+      "id": "0x15afcbd2ea8",
+      "tid": 22764,
+      "ts": 838589,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ab65b4f50",
-      "tid": 16484,
-      "ts": 690677,
+      "id": "0x15aff311da0",
+      "tid": 22764,
+      "ts": 838591,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadeff68",
-      "tid": 16484,
-      "ts": 690695,
+      "id": "0x15afcbd35a8",
+      "tid": 22764,
+      "ts": 838608,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ab65b42f0",
-      "tid": 16484,
-      "ts": 690696,
+      "id": "0x15aff312610",
+      "tid": 22764,
+      "ts": 838609,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadef668",
-      "tid": 16484,
-      "ts": 690713,
+      "id": "0x15afcbd18a8",
+      "tid": 22764,
+      "ts": 838626,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababb5820",
-      "tid": 16484,
-      "ts": 690715,
+      "id": "0x15aff311410",
+      "tid": 22764,
+      "ts": 838627,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abadeed68",
-      "tid": 16484,
-      "ts": 690732,
+      "id": "0x15afcbd24a8",
+      "tid": 22764,
+      "ts": 838645,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababb5310",
-      "tid": 16484,
-      "ts": 690733,
+      "id": "0x15aff7594a0",
+      "tid": 22764,
+      "ts": 838646,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababb50d0",
-      "tid": 16484,
-      "ts": 690748,
+      "id": "0x15aff759bf0",
+      "tid": 22764,
+      "ts": 838660,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababb58b0",
-      "tid": 16484,
-      "ts": 690928,
+      "id": "0x15aff759ec0",
+      "tid": 22764,
+      "ts": 838772,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abaac0e00",
-      "tid": 16484,
-      "ts": 690931,
+      "id": "0x15aff39aae0",
+      "tid": 22764,
+      "ts": 838775,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22abaac1af0",
-      "tid": 16484,
-      "ts": 691105,
+      "id": "0x15aff39b620",
+      "tid": 22764,
+      "ts": 838883,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababb59d0",
-      "tid": 16484,
-      "ts": 691107,
+      "id": "0x15aff7584e0",
+      "tid": 22764,
+      "ts": 838884,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababb4590",
-      "tid": 16484,
-      "ts": 694199,
+      "id": "0x15aff758d50",
+      "tid": 22764,
+      "ts": 841608,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x22ababb43e0",
-      "tid": 16484,
-      "ts": 697696,
+      "id": "0x15aff7592f0",
+      "tid": 22764,
+      "ts": 844940,
       "pid": "GPGMM"
     }
   ]

--- a/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
+++ b/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
@@ -462,7 +462,6 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferNeverSubAllocated) {
             nullptr, &subAllocation));
         ASSERT_NE(subAllocation, nullptr);
         EXPECT_NE(subAllocation->GetResource(), nullptr);
-        EXPECT_EQ(subAllocation->GetSize(), bufferSize);
         EXPECT_NE(subAllocation->GetMethod(), gpgmm::AllocationMethod::kSubAllocated);
     }
 
@@ -497,7 +496,6 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferNeverPooled) {
                                           D3D12_RESOURCE_STATE_GENERIC_READ, nullptr, &allocation));
         ASSERT_NE(allocation, nullptr);
         EXPECT_NE(allocation->GetResource(), nullptr);
-        EXPECT_EQ(allocation->GetSize(), bufferSize * 2);
         EXPECT_EQ(allocation->GetMethod(), gpgmm::AllocationMethod::kStandalone);
     }
 
@@ -520,7 +518,6 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferNeverPooled) {
                                           D3D12_RESOURCE_STATE_GENERIC_READ, nullptr, &allocation));
         ASSERT_NE(allocation, nullptr);
         EXPECT_NE(allocation->GetResource(), nullptr);
-        EXPECT_EQ(allocation->GetSize(), bufferSize * 3);
         EXPECT_EQ(allocation->GetMethod(), gpgmm::AllocationMethod::kStandalone);
     }
 }
@@ -548,7 +545,6 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferPooled) {
             D3D12_RESOURCE_STATE_GENERIC_READ, nullptr, &allocation));
         ASSERT_NE(allocation, nullptr);
         EXPECT_NE(allocation->GetResource(), nullptr);
-        EXPECT_EQ(allocation->GetSize(), bufferSize);
         EXPECT_EQ(allocation->GetMethod(), gpgmm::AllocationMethod::kStandalone);
     }
 
@@ -560,7 +556,6 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferPooled) {
             D3D12_RESOURCE_STATE_GENERIC_READ, nullptr, &allocation));
         ASSERT_NE(allocation, nullptr);
         EXPECT_NE(allocation->GetResource(), nullptr);
-        EXPECT_EQ(allocation->GetSize(), bufferSize / 2);
         EXPECT_EQ(allocation->GetMethod(), gpgmm::AllocationMethod::kStandalone);
     }
 
@@ -575,7 +570,6 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferPooled) {
                                           D3D12_RESOURCE_STATE_GENERIC_READ, nullptr, &allocation));
         ASSERT_NE(allocation, nullptr);
         EXPECT_NE(allocation->GetResource(), nullptr);
-        EXPECT_EQ(allocation->GetSize(), bufferSize);
         EXPECT_EQ(allocation->GetMethod(), gpgmm::AllocationMethod::kStandalone);
     }
 
@@ -590,7 +584,6 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferPooled) {
                                           D3D12_RESOURCE_STATE_GENERIC_READ, nullptr, &allocation));
         ASSERT_NE(allocation, nullptr);
         EXPECT_NE(allocation->GetResource(), nullptr);
-        EXPECT_EQ(allocation->GetSize(), bufferSize / 2);
         EXPECT_EQ(allocation->GetMethod(), gpgmm::AllocationMethod::kStandalone);
     }
 
@@ -772,8 +765,6 @@ TEST_F(D3D12ResourceAllocatorTests, CreateTexturePooled) {
             D3D12_RESOURCE_STATE_GENERIC_READ, nullptr, &firstAllocation));
         ASSERT_NE(firstAllocation, nullptr);
         EXPECT_EQ(firstAllocation->GetMethod(), gpgmm::AllocationMethod::kStandalone);
-        EXPECT_EQ(firstAllocation->GetSize(),
-                  static_cast<uint32_t>(D3D12_SMALL_RESOURCE_PLACEMENT_ALIGNMENT));
     }
 
     ALLOCATION_DESC reusePoolOnlyDesc = standaloneAllocationDesc;
@@ -788,8 +779,6 @@ TEST_F(D3D12ResourceAllocatorTests, CreateTexturePooled) {
             D3D12_RESOURCE_STATE_GENERIC_READ, nullptr, &secondAllocation));
         ASSERT_NE(secondAllocation, nullptr);
         EXPECT_EQ(secondAllocation->GetMethod(), gpgmm::AllocationMethod::kStandalone);
-        EXPECT_EQ(secondAllocation->GetSize(),
-                  static_cast<uint32_t>(D3D12_SMALL_RESOURCE_PLACEMENT_ALIGNMENT));
     }
 
     // Check the first small texture of size A cannot be reused when creating a larger texture of


### PR DESCRIPTION

Since GPGPMM can reuse heaps, there is no advantage to externally fragment them with smaller, misaligned sizes.