### PR TITLE
Add recording event filters to resource allocator.

### DIFF
--- a/src/gpgmm/TraceEvent.h
+++ b/src/gpgmm/TraceEvent.h
@@ -99,7 +99,10 @@ namespace gpgmm {
     class FileEventTracer;
     class PlatformTime;
 
-    void StartupEventTracer(const std::string& traceFile);
+    void StartupEventTracer(const std::string& traceFile,
+                            bool skipDurationEvents,
+                            bool skipObjectEvents,
+                            bool skipInstantEvents);
     void ShutdownEventTracer();
 
     bool IsEventTracerEnabled();
@@ -162,7 +165,10 @@ namespace gpgmm {
 
     class FileEventTracer {
       public:
-        explicit FileEventTracer(const std::string& traceFile);
+        explicit FileEventTracer(const std::string& traceFile,
+                                 bool skipDurationEvents,
+                                 bool skipObjectEvents,
+                                 bool skipInstantEvents);
         ~FileEventTracer();
 
         void EnqueueTraceEvent(char phase,
@@ -176,6 +182,10 @@ namespace gpgmm {
         std::vector<TraceEvent> mQueue;
         std::string mTraceFile;
         std::unique_ptr<PlatformTime> mPlatformTime;
+
+        bool mSkipDurationEvents = false;
+        bool mSkipObjectEvents = false;
+        bool mSkipInstantEvents = false;
     };
 
 }  // namespace gpgmm

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -332,24 +332,29 @@ namespace gpgmm { namespace d3d12 {
             return E_INVALIDARG;
         }
 
-        bool enableEventTracer =
-            descriptor.RecordOptions.Flags & ALLOCATOR_RECORD_FLAG_TRACE_EVENTS;
+        bool enableEventTracer = (newDescriptor.RecordOptions.Flags != ALLOCATOR_RECORD_FLAG_NONE);
 #ifdef GPGMM_ALWAYS_RECORD
         enableEventTracer = true;
+        newDescriptor.RecordOptions.Flags |= ALLOCATOR_RECORD_FLAG_ALL_EVENTS;
 #endif
 
         if (enableEventTracer) {
             const std::string& traceFile = descriptor.RecordOptions.TraceFile.empty()
                                                ? std::string(kDefaultTraceFile)
                                                : descriptor.RecordOptions.TraceFile;
-            const LogSeverity& recordEventLogLevel =
-                static_cast<LogSeverity>(descriptor.RecordOptions.MinLogLevel);
 
-            StartupEventTracer(traceFile);
+            StartupEventTracer(
+                traceFile, !(newDescriptor.RecordOptions.Flags & ALLOCATOR_RECORD_FLAG_API_TIMINGS),
+                !(newDescriptor.RecordOptions.Flags & ALLOCATOR_RECORD_FLAG_LIVE_OBJECTS),
+                !(newDescriptor.RecordOptions.Flags & ALLOCATOR_RECORD_FLAG_API_CALLS));
+
+            const LogSeverity& recordEventLogLevel =
+                static_cast<LogSeverity>(newDescriptor.RecordOptions.MinLogLevel);
+
             SetRecordEventLevel(recordEventLogLevel);
         }
 
-        const LogSeverity& logLevel = static_cast<LogSeverity>(descriptor.MinLogLevel);
+        const LogSeverity& logLevel = static_cast<LogSeverity>(newDescriptor.MinLogLevel);
         SetLogMessageLevel(logLevel);
 
         ComPtr<ResidencyManager> residencyManager;

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -72,9 +72,21 @@ namespace gpgmm { namespace d3d12 {
         // Disables all recording flags. Enabled by default.
         ALLOCATOR_RECORD_FLAG_NONE = 0x0,
 
-        // Configures event-based tracing using the Trace Event API.
-        ALLOCATOR_RECORD_FLAG_TRACE_EVENTS = 0x1,
+        // Record lifetimes of GPGMM created objects.
+        ALLOCATOR_RECORD_FLAG_LIVE_OBJECTS = 0x1,
 
+        // Record API calls made to GPGMM.
+        ALLOCATOR_RECORD_FLAG_API_CALLS = 0x2,
+
+        // Record API call durations.
+        ALLOCATOR_RECORD_FLAG_API_TIMINGS = 0x4,
+
+        // Aliases that combine flags per activity.
+        ALLOCATOR_RECORD_FLAG_CAPTURE = 0x3,
+        ALLOCATOR_RECORD_FLAG_PROFILING = 0x4,
+
+        // Record all event types.
+        ALLOCATOR_RECORD_FLAG_ALL_EVENTS = 0xFF,
     };
 
     using ALLOCATOR_RECORD_FLAGS_TYPE = Flags<ALLOCATOR_RECORD_FLAGS>;

--- a/src/tests/capture_replay_tests/D3D12EventTraceReplay.cpp
+++ b/src/tests/capture_replay_tests/D3D12EventTraceReplay.cpp
@@ -307,7 +307,7 @@ class D3D12EventTraceReplay : public D3D12TestBase, public CaptureReplayTestWith
                         ASSERT_FALSE(recordOptions.empty());
 
                         if (envParams.IsRegenerate) {
-                            allocatorDesc.RecordOptions.Flags = ALLOCATOR_RECORD_FLAG_TRACE_EVENTS;
+                            allocatorDesc.RecordOptions.Flags = ALLOCATOR_RECORD_FLAG_CAPTURE;
                             allocatorDesc.RecordOptions.TraceFile = traceFile.path;
                             allocatorDesc.RecordOptions.MinLogLevel =
                                 static_cast<ALLOCATOR_MESSAGE_SEVERITY>(envParams.RecordLevel);

--- a/src/tests/capture_replay_tests/traces/dawn_end2end_queuewritebuffertests_manywritebuffer.json
+++ b/src/tests/capture_replay_tests/traces/dawn_end2end_queuewritebuffertests_manywritebuffer.json
@@ -5,94 +5,13958 @@
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "N",
-      "id": "0x2932f700150",
-      "tid": 18876,
-      "ts": 2,
+      "id": "0x22abaccf880",
+      "tid": 16484,
+      "ts": 0,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x2932f700328",
-      "tid": 18876,
-      "ts": 18,
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 12,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "N",
-      "id": "0x2932f700588",
-      "tid": 18876,
-      "ts": 33,
-      "pid": "GPGMM"
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 96,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x2932f6f2278",
-      "tid": 18876,
-      "ts": 40,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x2932f6f2598",
-      "tid": 18876,
-      "ts": 57,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x2932f7008a8",
-      "tid": 18876,
-      "ts": 64,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x2932f6f2d18",
-      "tid": 18876,
-      "ts": 88,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x2932f6f3038",
-      "tid": 18876,
-      "ts": 93,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x2933270d388",
-      "tid": 18876,
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
       "ts": 99,
       "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 105,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 126,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 135,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 163,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 176,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 186,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 203,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 209,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 232,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 251,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 257,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 283,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 289,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 312,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 324,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 330,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 347,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 353,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 375,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 388,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 394,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 410,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 416,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 438,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 474,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 480,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 497,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 503,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 525,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 538,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 544,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 560,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 566,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 588,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 601,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 607,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 636,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 642,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 676,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 688,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 694,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 711,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 716,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 739,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 751,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 758,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 773,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 780,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 802,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 814,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 858,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 875,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 881,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 904,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 916,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 922,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 939,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 945,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 967,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 979,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 985,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 1001,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 1007,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 1030,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 1042,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 1048,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 1064,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 1070,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 1092,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 1105,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 1111,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 1127,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 1133,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 1155,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 1168,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 1174,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 1190,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 1196,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 1218,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 1231,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 1237,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 1253,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 1259,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 1281,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 1298,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 1304,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 1320,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 1327,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 1349,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 1367,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 1373,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 1389,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 1395,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 1417,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 1433,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 1439,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 1455,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 1461,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 1483,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 1499,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 1505,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 1597,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 1603,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 1639,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 1668,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 1674,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 1690,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 1696,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 1719,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 1734,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 1740,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 1756,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 1762,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 1778,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 1784,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 1806,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 1823,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 1839,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 1856,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 1872,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 1888,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 1904,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 1920,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 1936,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 1952,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 1968,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 1984,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 1990,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 2011,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 2014,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 2019,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 2036,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 2042,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 2065,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 2078,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 2084,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 2100,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 2106,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 2128,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 2141,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 2147,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 2163,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 2169,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 2191,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 2203,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 2209,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 2226,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 2232,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 2253,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 2266,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 2272,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 2288,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 2294,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 2316,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 2329,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 2335,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 2351,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 2357,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 2379,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 2392,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 2398,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 2414,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 2420,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 2442,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 2455,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 2461,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 2477,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 2483,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 2505,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 2517,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 2524,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 2540,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 2546,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 2568,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 2580,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 2586,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 2603,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 2609,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 2643,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 2667,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 2673,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 2689,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 2695,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 2717,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 2730,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 2736,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 2752,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 2758,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 2780,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 2792,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 2798,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 2814,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 2820,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 2842,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 2855,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 2861,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 2877,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 2883,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 2905,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 2917,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 2923,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 2939,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 2945,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 2967,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 2980,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 2986,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 3002,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 3008,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 3030,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 3043,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 3227,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 3256,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 3262,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 3285,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 3303,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 3310,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 3326,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 3333,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 3355,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 3373,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 3380,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 3396,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 3402,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 3436,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 3452,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 3458,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 3475,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 3481,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 3503,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 3519,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 3525,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 3541,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 3548,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 3570,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 3588,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 3595,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 3611,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 3628,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 3663,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 3679,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 3685,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 3701,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 3707,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 3723,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 3729,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 3751,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 3767,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 3784,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 3800,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 3816,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 3857,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 3873,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 3889,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 3905,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 3921,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 3937,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 3953,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 3959,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 3982,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 3985,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 3989,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 4006,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 4012,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 4035,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 4048,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 4054,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 4070,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 4076,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 4109,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 4122,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 4129,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 4157,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 4163,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 4201,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 4225,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 4244,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 4272,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 4279,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 4313,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 4338,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 4345,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 4362,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 4368,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 4391,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 4404,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 4411,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 4428,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 4434,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 4468,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 4481,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 4487,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 4504,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 4510,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 4533,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 4561,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 4567,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 4599,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 4620,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 4657,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 4681,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 4687,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 4715,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 4736,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 4774,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 4787,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 4793,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 4809,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 4816,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 4849,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 4863,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 4869,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 4897,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 4919,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 4956,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 4969,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 4975,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 4991,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 4997,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 5020,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 5033,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 5039,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 5056,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 5062,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 5084,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 5097,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 5103,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 5132,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 5139,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 5162,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 5186,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 5192,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 5224,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 5230,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 5268,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 5284,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 5291,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 5319,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 5325,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 5348,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 5361,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 5368,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 5384,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 5391,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 5425,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 5443,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 5450,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 5467,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 5473,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 5497,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 5515,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 5522,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 5539,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 5546,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 5569,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 5586,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 5592,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 5609,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 5617,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 5641,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 5658,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 5664,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 5682,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 5688,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 5711,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 5729,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 5736,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 5753,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 5759,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 5783,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 5800,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 5807,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 5835,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 5841,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 5889,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 5895,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 5948,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 5966,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 5983,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 6010,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 6042,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 6059,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 6086,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 6102,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 6118,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 6133,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 6149,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 6166,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 6173,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 6194,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 6197,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 6201,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 6219,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 6224,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 6247,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 6271,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 6277,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 6294,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 6300,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 6334,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 6346,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 6352,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 6369,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 6374,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 6397,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 6409,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 6415,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 6431,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 6438,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 6460,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 6472,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 6478,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 6494,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 6500,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 6534,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 6546,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 6553,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 6569,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 6575,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 6598,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 6622,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 6630,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 6658,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 6664,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 6687,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 6699,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 6705,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 6722,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 6740,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 7132,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 7146,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 7152,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 7168,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 7174,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 7196,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 7209,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 7215,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 7231,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 7237,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 7259,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 7271,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 7277,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 7294,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 7299,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 7321,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 7334,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 7340,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 7356,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 7362,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 7384,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 7397,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 7403,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 7419,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 7425,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 7447,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 7461,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 7467,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 7483,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 7489,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 7511,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 7524,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 7530,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 7555,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 7562,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 7584,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 7597,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 7604,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 7620,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 7628,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 7651,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 7664,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 7670,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 7687,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 7693,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 7715,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 7741,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 7747,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 7764,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 7770,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 7793,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 7810,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 7817,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 7833,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 7840,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 7862,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 7879,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 7885,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 7902,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 7908,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 7931,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 7947,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 7953,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 7970,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 7976,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 7999,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 8016,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 8023,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 8039,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 8045,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 8068,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 8084,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 8090,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 8107,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 8113,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 8129,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 8135,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 8157,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 8174,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 8190,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 8207,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 8223,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 8240,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 8256,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 8272,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 8289,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 8305,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 8321,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 8338,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 8344,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 8365,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 8368,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 8373,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 8390,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 8396,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 8420,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 8433,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 8439,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 8456,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 8462,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 8485,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 8498,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 8504,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 8521,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 8527,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 8549,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 8562,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 8569,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 8585,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 8592,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 8614,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 8628,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 8634,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 8651,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 8657,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 8680,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 8693,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 8699,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 8716,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 8722,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 8744,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 8757,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 8763,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 8780,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 8786,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 8809,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 8821,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 8828,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 8844,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 8850,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 8873,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 8886,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 8892,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 8908,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 8914,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 8937,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 8950,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 8956,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 8973,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 8979,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 9001,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 9014,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 9021,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 9037,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 9043,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 9066,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 9079,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 9085,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 9101,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 9107,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 9130,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 9143,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 9149,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 9166,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 9172,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 9194,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 9207,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 9213,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 9231,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 9237,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 9260,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 9273,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 9279,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 9295,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 9302,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 9324,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 9337,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 9343,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 9360,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 9366,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 9389,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 9402,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 9408,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 9425,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 9431,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 9453,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 9470,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 9476,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 9492,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 9499,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 9521,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 9538,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 9545,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 9561,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 9567,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 9590,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 9616,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 9624,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 9641,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 9647,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 9669,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 9686,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 9692,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 9709,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 9715,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 9745,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 9764,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 9771,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 9787,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 9794,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 9817,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 9834,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 9841,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 9858,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 9864,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 9881,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 9887,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 9909,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 9925,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 9947,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 9963,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 9980,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 9996,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 10013,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 10029,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 10046,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 10062,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 10078,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 10095,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 10101,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 10122,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 10125,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 10130,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 10147,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 10154,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 10177,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 10190,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 10196,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 10213,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 10219,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 10242,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 10255,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 10261,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 10277,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 10283,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 10306,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 10319,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 10325,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 10341,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 10348,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 10370,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 10383,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 10389,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 10406,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 10412,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 10434,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 10447,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 10453,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 10470,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 10476,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 10499,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 10512,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 10519,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 10535,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 10541,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 10564,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 10577,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 10583,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 10600,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 10606,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 10629,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 10642,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 10648,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 10665,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 10671,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 10694,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 10707,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 10713,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 10730,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 10736,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 10758,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 10771,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 10777,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 10794,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 10800,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 10823,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 10836,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 10842,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 10859,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 10865,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 10887,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 10901,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 10907,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 10923,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 10929,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 10952,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 10970,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 10977,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 10993,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 10999,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 11022,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 11035,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 11041,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 11058,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 11064,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 11087,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 11100,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 11106,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 11122,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 11128,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 11151,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 11164,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 11170,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 11186,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 11192,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 11215,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 11232,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 11239,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 11255,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 11261,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 11284,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 11302,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 11308,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 11325,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 11332,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 11355,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 11371,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 11378,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 11395,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 11408,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 11432,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 11448,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 11454,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 11471,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 11477,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 11505,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 11523,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 11530,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 11546,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 11552,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 11575,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 11591,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 11598,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 11614,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 11621,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 11638,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 11644,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 11666,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 11683,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 11700,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 11716,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 11732,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 11749,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 11765,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 11781,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 11798,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 11814,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 11831,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 11847,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 11857,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 11882,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 11884,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 11889,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 11907,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 11913,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 11936,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 11949,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 11956,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 11972,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 11978,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 12001,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 12014,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 12020,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 12037,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 12043,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 12065,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 12078,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 12084,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 12101,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 12107,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 12129,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 12142,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 12149,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 12165,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 12171,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 12194,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 12207,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 12213,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 12229,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 12235,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 12258,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 12271,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 12277,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 12294,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 12300,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 12322,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 12335,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 12342,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 12358,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 12364,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 12387,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 12400,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 12406,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 12423,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 12429,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 12451,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 12464,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 12470,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 12487,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 12493,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 12515,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 12528,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 12535,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 12551,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 12557,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 12580,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 12593,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 12599,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 12615,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 12623,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 12646,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 12659,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 12665,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 12681,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 12687,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 12710,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 12723,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 12729,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 12745,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 12752,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 12774,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 12787,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 12793,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 12810,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 12816,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 12838,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 12851,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 12857,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 13439,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 13445,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 13469,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 13482,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 13488,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 13505,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 13511,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 13534,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 13551,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 13557,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 13574,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 13580,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 13603,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 13622,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 13628,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 13645,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 13651,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 13722,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 13753,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 13760,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 13778,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 13784,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 13807,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 13824,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 13830,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 13847,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 13853,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 13876,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 13894,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 13900,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 13917,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 13923,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 13946,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 13962,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 13968,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 13985,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 13991,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 14008,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 14014,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 14036,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 14053,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 14070,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 14086,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 14103,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 14120,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 14137,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 14153,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 14179,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 14195,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 14212,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 14228,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 14235,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 14258,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 14260,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 14265,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 14282,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 14289,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 14312,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 14325,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 14332,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 14348,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 14354,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 14377,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 14401,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 14407,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 14438,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 14445,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 14467,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 14480,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 14486,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 14503,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 14509,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 14532,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 14545,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 14551,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 14581,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 14588,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 14612,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 14625,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 14631,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 14648,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 14654,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 14677,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 14690,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 14696,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 14712,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 14719,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 14741,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 14754,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 14760,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 14777,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 14783,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 14806,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 14819,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 14825,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 14842,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 14847,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 14870,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 14888,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 14894,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 14911,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 14917,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 14939,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 14953,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 14959,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 14975,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 14981,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 15004,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 15017,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 15023,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 15039,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 15045,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 15068,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 15081,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 15087,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 15103,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 15110,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 15132,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 15145,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 15151,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 15168,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 15174,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 15196,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 15209,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 15215,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 15232,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 15238,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 15260,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 15273,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 15279,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 15296,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 15302,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 15324,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 15337,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 15343,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 15360,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 15366,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 15388,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 15405,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 15411,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 15428,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 15434,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 15457,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 15474,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 15480,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 15497,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 15503,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 15526,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 15542,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 15548,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 15565,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 15571,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 15594,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 15610,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 15617,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 15634,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 15640,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 15662,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 15712,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 15719,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 15735,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 15741,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 15764,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 15780,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 15787,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 15803,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 15809,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 15826,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 15832,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 15854,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 15871,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 15888,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 15905,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 15921,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 15937,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 15954,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 15970,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 15987,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 16003,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 16020,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 16036,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
     },
     {
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 186,
+      "tid": 16484,
+      "ts": 16067,
       "pid": "GPGMM",
       "args": {
         "Flags": 1,
         "RecordOptions": {
-          "Flags": 1
+          "Flags": 6
         },
         "IsUMA": 1,
         "ResourceHeapTier": 2,
@@ -107,8 +13971,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 261,
+      "tid": 16484,
+      "ts": 16129,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -135,37 +13999,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 263,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateCommittedResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 268,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x2932f6546a0",
-      "tid": 18876,
-      "ts": 2224,
+      "id": "0x22abadec020",
+      "tid": 16484,
+      "ts": 17275,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x2932f6546a0",
-      "tid": 18876,
-      "ts": 2248,
+      "id": "0x22abadec020",
+      "tid": 16484,
+      "ts": 17298,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -180,9 +14028,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x2932f6546a0",
-      "tid": 18876,
-      "ts": 2272,
+      "id": "0x22abadec020",
+      "tid": 16484,
+      "ts": 17319,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -194,29 +14042,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateCommittedResource",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 2274,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x2933270de20",
-      "tid": 18876,
-      "ts": 2280,
+      "id": "0x22ab65c9a20",
+      "tid": 16484,
+      "ts": 17321,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x2933270de20",
-      "tid": 18876,
-      "ts": 2297,
+      "id": "0x22ab65c9a20",
+      "tid": 16484,
+      "ts": 17337,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -225,7 +14065,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x2932f6546a0"
+            "id_ref": "0x22abadec020"
           }
         }
       }
@@ -233,17 +14073,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 2299,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 2386,
+      "tid": 16484,
+      "ts": 17428,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -270,37 +14102,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 2388,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateCommittedResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 2389,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332716da0",
-      "tid": 18876,
-      "ts": 3895,
+      "id": "0x22abadeb2a0",
+      "tid": 16484,
+      "ts": 18467,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332716da0",
-      "tid": 18876,
-      "ts": 3914,
+      "id": "0x22abadeb2a0",
+      "tid": 16484,
+      "ts": 18498,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -315,9 +14131,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332716da0",
-      "tid": 18876,
-      "ts": 3930,
+      "id": "0x22abadeb2a0",
+      "tid": 16484,
+      "ts": 18516,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -329,29 +14145,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateCommittedResource",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 3932,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x2933270e870",
-      "tid": 18876,
-      "ts": 3932,
+      "id": "0x22ab65cb020",
+      "tid": 16484,
+      "ts": 18518,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x2933270e870",
-      "tid": 18876,
-      "ts": 3947,
+      "id": "0x22ab65cb020",
+      "tid": 16484,
+      "ts": 18533,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -360,7 +14168,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x29332716da0"
+            "id_ref": "0x22abadeb2a0"
           }
         }
       }
@@ -368,17 +14176,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 3949,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 4018,
+      "tid": 16484,
+      "ts": 18630,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -405,37 +14205,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 4020,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateCommittedResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 4021,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x293327165c0",
-      "tid": 18876,
-      "ts": 5398,
+      "id": "0x22abadea490",
+      "tid": 16484,
+      "ts": 19674,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327165c0",
-      "tid": 18876,
-      "ts": 5416,
+      "id": "0x22abadea490",
+      "tid": 16484,
+      "ts": 19710,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -450,9 +14234,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327165c0",
-      "tid": 18876,
-      "ts": 5432,
+      "id": "0x22abadea490",
+      "tid": 16484,
+      "ts": 19727,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -464,29 +14248,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateCommittedResource",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 5433,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x2933270db60",
-      "tid": 18876,
-      "ts": 5434,
+      "id": "0x22ab65cb7b0",
+      "tid": 16484,
+      "ts": 19730,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x2933270db60",
-      "tid": 18876,
-      "ts": 5448,
+      "id": "0x22ab65cb7b0",
+      "tid": 16484,
+      "ts": 19745,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -495,7 +14271,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x293327165c0"
+            "id_ref": "0x22abadea490"
           }
         }
       }
@@ -503,17 +14279,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 5451,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 5522,
+      "tid": 16484,
+      "ts": 19831,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -540,37 +14308,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 5524,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateCommittedResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 5525,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332715f90",
-      "tid": 18876,
-      "ts": 5751,
+      "id": "0x22abadebf90",
+      "tid": 16484,
+      "ts": 20037,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332715f90",
-      "tid": 18876,
-      "ts": 5769,
+      "id": "0x22abadebf90",
+      "tid": 16484,
+      "ts": 20068,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -585,9 +14337,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332715f90",
-      "tid": 18876,
-      "ts": 5784,
+      "id": "0x22abadebf90",
+      "tid": 16484,
+      "ts": 20085,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -599,29 +14351,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateCommittedResource",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 5786,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x2933270e0e0",
-      "tid": 18876,
-      "ts": 5786,
+      "id": "0x22ab65c9fa0",
+      "tid": 16484,
+      "ts": 20088,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x2933270e0e0",
-      "tid": 18876,
-      "ts": 5801,
+      "id": "0x22ab65c9fa0",
+      "tid": 16484,
+      "ts": 20103,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -630,234 +14374,234 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x29332715f90"
+            "id_ref": "0x22abadebf90"
           }
         }
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 5803,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 5844,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x2932f6546a0",
-      "tid": 18876,
-      "ts": 5845,
+      "id": "0x22abadec020",
+      "tid": 16484,
+      "ts": 20154,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x2933270de20",
-      "tid": 18876,
-      "ts": 6033,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 6035,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 6051,
+      "id": "0x22ab65c9a20",
+      "tid": 16484,
+      "ts": 20360,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332715f90",
-      "tid": 18876,
-      "ts": 6052,
+      "id": "0x22abadebf90",
+      "tid": 16484,
+      "ts": 20397,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x2933270e0e0",
-      "tid": 18876,
-      "ts": 6234,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 6236,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 6251,
+      "id": "0x22ab65c9fa0",
+      "tid": 16484,
+      "ts": 20582,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332716da0",
-      "tid": 18876,
-      "ts": 6252,
+      "id": "0x22abadeb2a0",
+      "tid": 16484,
+      "ts": 20609,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x2933270e870",
-      "tid": 18876,
-      "ts": 6346,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 6360,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 6377,
+      "id": "0x22ab65cb020",
+      "tid": 16484,
+      "ts": 20765,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x293327165c0",
-      "tid": 18876,
-      "ts": 6377,
+      "id": "0x22abadea490",
+      "tid": 16484,
+      "ts": 20788,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x2933270db60",
-      "tid": 18876,
-      "ts": 6540,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 6547,
+      "id": "0x22ab65cb7b0",
+      "tid": 16484,
+      "ts": 20998,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "D",
-      "id": "0x2932f700150",
-      "tid": 18876,
-      "ts": 6557,
+      "id": "0x22abaccf880",
+      "tid": 16484,
+      "ts": 21023,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x2932f700328",
-      "tid": 18876,
-      "ts": 6581,
+      "id": "0x22ab6567f58",
+      "tid": 16484,
+      "ts": 21038,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x2932f700588",
-      "tid": 18876,
-      "ts": 6600,
+      "id": "0x22abab3d2d0",
+      "tid": 16484,
+      "ts": 21042,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x2932f6f2278",
-      "tid": 18876,
-      "ts": 6603,
+      "id": "0x22ab6568558",
+      "tid": 16484,
+      "ts": 21074,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x2932f6f2598",
-      "tid": 18876,
-      "ts": 6606,
+      "id": "0x22abab3d480",
+      "tid": 16484,
+      "ts": 21076,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x2932f7008a8",
-      "tid": 18876,
-      "ts": 6608,
+      "id": "0x22ab6567458",
+      "tid": 16484,
+      "ts": 21095,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x2932f6f2d18",
-      "tid": 18876,
-      "ts": 6610,
+      "id": "0x22abab3d900",
+      "tid": 16484,
+      "ts": 21096,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x2932f6f3038",
-      "tid": 18876,
-      "ts": 6612,
+      "id": "0x22ab6568658",
+      "tid": 16484,
+      "ts": 21115,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x2933270d388",
-      "tid": 18876,
-      "ts": 6614,
+      "id": "0x22abab3d990",
+      "tid": 16484,
+      "ts": 21116,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x22ab6567358",
+      "tid": 16484,
+      "ts": 21135,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x22abab3cdc0",
+      "tid": 16484,
+      "ts": 21136,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x22ab6568758",
+      "tid": 16484,
+      "ts": 21165,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x22abab3caf0",
+      "tid": 16484,
+      "ts": 21166,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x22ab6567558",
+      "tid": 16484,
+      "ts": 21184,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x22abadeb690",
+      "tid": 16484,
+      "ts": 21185,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x22ab6568b58",
+      "tid": 16484,
+      "ts": 21202,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x22abadeb180",
+      "tid": 16484,
+      "ts": 21203,
       "pid": "GPGMM"
     }
   ]

--- a/src/tests/capture_replay_tests/traces/directml_samples_directmlxsuperresolution.json
+++ b/src/tests/capture_replay_tests/traces/directml_samples_directmlxsuperresolution.json
@@ -5,94 +5,8622 @@
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "N",
-      "id": "0x2932f64b240",
-      "tid": 18876,
-      "ts": 59310,
+      "id": "0x22abacb4800",
+      "tid": 16484,
+      "ts": 174281,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332710a08",
-      "tid": 18876,
-      "ts": 59335,
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 174292,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "N",
-      "id": "0x29332710208",
-      "tid": 18876,
-      "ts": 59353,
-      "pid": "GPGMM"
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 174365,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 174417,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 174446,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 174460,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 174476,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 174503,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 174516,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 174533,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 174555,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 174567,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 174595,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 174617,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 174630,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 174646,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 174668,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 174686,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 174702,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 174724,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 174737,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 174753,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 174792,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 174805,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 174822,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 174844,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 174856,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 174872,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 174894,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 174907,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 174923,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 174945,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 174958,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 174974,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 174995,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 175008,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 175024,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 175046,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 175064,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 175083,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 175107,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 175121,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 175159,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 175184,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 175198,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 175217,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 175241,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 175255,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 175273,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 175297,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 175311,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 175329,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 175353,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 175372,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 175390,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 175414,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 175434,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 175452,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 175476,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 175494,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 175512,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 175536,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 175554,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 175572,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 175596,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 175615,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 175633,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 175657,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 175675,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 175693,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 175710,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 175734,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 175753,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 175771,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 175790,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 175808,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 175826,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 175844,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 175862,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 175880,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 175898,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 175916,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 175935,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332710c08",
-      "tid": 18876,
-      "ts": 59368,
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 175941,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "N",
-      "id": "0x29332710d08",
-      "tid": 18876,
-      "ts": 59409,
-      "pid": "GPGMM"
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 175964,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 175984,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 176009,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176023,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176042,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 176109,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176124,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176142,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 176166,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176181,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176199,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 176223,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176237,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176255,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 176279,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176294,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176312,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 176336,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176350,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176368,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 176392,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176406,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176424,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 176448,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176463,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176480,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 176504,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176519,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176537,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 176560,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176575,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176593,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 176617,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176631,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176649,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 176673,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176687,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176705,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 176729,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176743,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176761,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 176785,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176800,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176818,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 176842,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176856,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176874,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 176898,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176912,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176930,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 176954,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176972,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 176990,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 177014,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 177033,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 177054,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 177079,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 177097,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 177115,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 177139,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 177157,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 177175,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 177199,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 177218,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 177236,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 177261,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 177278,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 177296,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 177315,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 177338,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 177357,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 177375,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 177393,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 177411,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 177429,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 177447,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 177465,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 177483,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 177501,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 177519,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 177537,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332710308",
-      "tid": 18876,
-      "ts": 59420,
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 177544,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "N",
-      "id": "0x29332710e08",
-      "tid": 18876,
-      "ts": 59443,
-      "pid": "GPGMM"
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 177567,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 177587,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 177612,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 177630,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 177647,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 177669,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 177682,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 177698,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 177720,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 177733,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 177749,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 177840,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 177854,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 177870,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 177892,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 177904,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 177920,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 177942,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 177955,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 177971,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 177993,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 178006,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 178022,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 178044,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 178061,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 178080,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 178104,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 178118,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 178136,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 178160,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 178175,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 178193,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 178217,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 178231,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 178249,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 178273,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 178287,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 178305,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 178329,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 178344,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 178362,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 178386,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 178400,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 178418,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 178442,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 178457,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 178475,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 178499,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 178513,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 178531,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 178555,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 178574,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 178593,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 178617,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 178636,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 178654,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 178678,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 178696,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 178714,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 178738,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 178756,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 178774,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 178798,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 178817,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 178835,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 178859,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 178876,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 178894,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 178912,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 178935,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 178954,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 178972,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 178990,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 179008,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 179026,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 179045,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 179078,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 179095,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 179111,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 179127,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 179143,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332710508",
-      "tid": 18876,
-      "ts": 59449,
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179149,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179170,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179188,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 179210,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179223,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179239,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 179261,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179274,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179290,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 179312,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179325,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179341,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 179364,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179376,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179392,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 179414,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179427,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179443,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 179465,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179477,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179494,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 179516,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179528,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179544,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 179566,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179579,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179595,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 179616,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179629,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179645,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 179667,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179679,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179696,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 179717,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179730,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179746,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 179768,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179780,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179796,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 179818,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179830,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179846,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 179868,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179881,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179897,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 179918,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179931,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179947,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 179969,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179982,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 179998,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 180020,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 180036,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 180058,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 180083,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 180102,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 180120,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 180145,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 180163,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 180181,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 180205,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 180226,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 180242,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 180264,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 180281,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 180298,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 180320,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 180335,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 180351,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 180367,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 180388,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 180405,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 180425,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 180450,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 180475,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 180499,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 180525,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 180545,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 180561,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 180589,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 180605,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 180632,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
       "ph": "N",
-      "id": "0x29332710f08",
-      "tid": 18876,
-      "ts": 59470,
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 180639,
       "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 180661,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 180678,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 180701,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 180714,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 180730,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 180752,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 180765,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 180781,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 180803,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 180816,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 180832,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 180853,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 180866,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 180882,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 180904,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 180917,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 180933,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 180955,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 180967,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 180983,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 181005,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 181018,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 181439,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 181482,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 181496,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 181512,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 181534,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 181547,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 181563,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 181585,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 181598,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 181614,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 181636,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 181648,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 181665,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 181698,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 181711,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 181738,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 181772,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 181785,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 181813,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 181847,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 181860,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 181887,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 181909,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 181921,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 181937,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 181986,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 181999,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 182027,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 182082,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 182111,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 182127,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 182149,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 182167,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 182183,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 182205,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 182220,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 182237,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 182259,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 182286,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 182303,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 182353,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 182372,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 182417,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 182449,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 182479,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 182496,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 182526,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 182587,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 182617,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 182634,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 182650,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 182666,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 182682,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 182698,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 182714,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 182730,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 182746,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 182762,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 182778,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 182785,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 182806,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 182824,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 182847,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 182859,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 182875,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 182897,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 182910,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 182926,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 182948,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 182960,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 182976,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 182998,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183011,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183028,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 183054,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183067,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183083,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 183105,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183118,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183134,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 183156,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183168,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183185,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 183206,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183219,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183235,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 183257,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183269,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183285,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 183307,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183320,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183336,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 183358,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183370,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183386,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 183408,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183421,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183437,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 183459,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183472,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183488,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 183510,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183522,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183538,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 183560,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183573,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183589,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 183611,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183629,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183645,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 183667,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183683,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183699,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 183721,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183738,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183755,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 183776,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183792,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183809,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 183831,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183846,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183863,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 183885,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183901,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183918,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 183941,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183958,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183974,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 183990,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 184012,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 184028,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 184047,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 184066,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 184084,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 184103,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 184121,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 184139,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 184157,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 184175,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 184193,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 184211,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 184219,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 184243,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 184262,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 184287,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 184301,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 184319,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 184343,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 184357,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 184375,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 184399,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 184414,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 184432,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 184456,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 184470,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 184488,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 184512,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 184526,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 184544,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 184568,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 184582,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 184600,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 184624,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 184639,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 184657,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 184681,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 184695,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 184713,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 184737,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 184751,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 184769,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 184793,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 184807,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 184825,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 184849,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 184863,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 184881,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 184905,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 184919,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 184937,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 184961,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 184975,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 184993,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 185017,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 185032,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 185053,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 185078,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 185092,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 185110,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 185135,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 185149,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 185167,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 185191,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 185210,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 185228,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 185252,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 185270,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 185288,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 185313,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 185330,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 185349,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 185373,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 185392,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 185411,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 185435,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 185454,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 185472,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 185496,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 185513,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 185531,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 185549,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 185572,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 185591,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 185609,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 185627,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 185646,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 185665,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 185684,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 185702,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 185720,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 185738,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 185756,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 185774,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 185780,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 185802,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 185821,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 185846,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 185860,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 185878,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 185903,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 185917,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 185935,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 185959,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 185973,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 185991,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 186015,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186029,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186050,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 186075,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186089,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186107,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 186131,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186146,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186164,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 186188,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186202,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186220,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 186244,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186258,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186276,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 186301,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186315,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186333,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 186357,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186371,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186389,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 186413,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186428,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186446,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 186470,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186486,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186504,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 186528,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186542,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186561,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 186585,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186599,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186617,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 186641,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186656,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186674,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 186698,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186712,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186730,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 186754,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186772,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186790,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 186814,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186833,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186851,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 186875,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186893,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186911,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 186935,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186952,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 186970,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 186995,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 187014,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 187033,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 187060,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 187078,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 187096,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 187114,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 187138,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 187156,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 187174,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 187192,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 187211,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 187229,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 187247,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 187265,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 187283,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 187301,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 187319,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 187337,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
     },
     {
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 59535,
+      "tid": 16484,
+      "ts": 187374,
       "pid": "GPGMM",
       "args": {
         "Flags": 0,
         "RecordOptions": {
-          "Flags": 1
+          "Flags": 6
         },
         "IsUMA": 1,
         "ResourceHeapTier": 2,
@@ -107,8 +8635,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 59588,
+      "tid": 16484,
+      "ts": 187435,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -135,44 +8663,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 59590,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 59592,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 59603,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 59607,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710208",
-      "tid": 18876,
-      "ts": 59620,
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 187451,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -181,29 +8677,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 59623,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 60263,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 187861,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 60284,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 187896,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -218,9 +8706,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 60304,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 187916,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -232,20 +8720,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 60306,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710208",
-      "tid": 18876,
-      "ts": 60313,
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 187926,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -254,36 +8734,12 @@
       }
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 60315,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 60317,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 60318,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 60331,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 187945,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -298,9 +8754,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 60357,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 188029,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -315,18 +8771,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x2933274e1e0",
-      "tid": 18876,
-      "ts": 60360,
+      "id": "0x22abacd3690",
+      "tid": 16484,
+      "ts": 188032,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x2933274e1e0",
-      "tid": 18876,
-      "ts": 60374,
+      "id": "0x22abacd3690",
+      "tid": 16484,
+      "ts": 188050,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -335,7 +8791,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbdc00"
+            "id_ref": "0x22abacc9a50"
           }
         }
       }
@@ -343,17 +8799,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 60377,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 60483,
+      "tid": 16484,
+      "ts": 188170,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -380,52 +8828,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 60485,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 60486,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 60491,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 60493,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 60494,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 60507,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 188193,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -440,9 +8848,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 60529,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 188267,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -457,18 +8865,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x2933274f730",
-      "tid": 18876,
-      "ts": 60531,
+      "id": "0x22abacd3740",
+      "tid": 16484,
+      "ts": 188269,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x2933274f730",
-      "tid": 18876,
-      "ts": 60544,
+      "id": "0x22abacd3740",
+      "tid": 16484,
+      "ts": 188284,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -477,7 +8885,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbdc00"
+            "id_ref": "0x22abacc9a50"
           }
         }
       }
@@ -485,17 +8893,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 60547,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 60616,
+      "tid": 16484,
+      "ts": 188366,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -522,52 +8922,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 60619,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 60620,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 60620,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 60622,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 60623,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 60636,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 188387,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -582,9 +8942,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 60659,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 188460,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -599,18 +8959,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x2933274ed90",
-      "tid": 18876,
-      "ts": 60661,
+      "id": "0x22abacd37f0",
+      "tid": 16484,
+      "ts": 188463,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x2933274ed90",
-      "tid": 18876,
-      "ts": 60674,
+      "id": "0x22abacd37f0",
+      "tid": 16484,
+      "ts": 188477,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -619,7 +8979,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbdc00"
+            "id_ref": "0x22abacc9a50"
           }
         }
       }
@@ -627,17 +8987,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 60676,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 60765,
+      "tid": 16484,
+      "ts": 188581,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -672,47 +9024,23 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 60768,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 60782,
-      "pid": "GPGMM"
-    },
-    {
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 60804,
+      "tid": 16484,
+      "ts": 188619,
       "pid": "GPGMM",
       "args": {
-        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "Description": "Aligned allocation size exceeded the slab size (8323072 vs 4194304 bytes).",
         "ID": 0
       }
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 60805,
-      "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.TryAllocateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 60817,
+      "tid": 16484,
+      "ts": 188633,
       "pid": "GPGMM",
       "args": {
         "Description": "Resource memory could not be allocated.",
@@ -720,45 +9048,37 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "i",
-      "tid": 18876,
-      "ts": 60830,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Suballocation was attempted but failed.",
-        "ID": 1
-      }
-    },
-    {
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 60831,
-      "pid": "GPGMM"
+      "ph": "i",
+      "tid": 16484,
+      "ts": 188650,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Heap size is not a multiple of the alignment (8323072 vs 4194304 bytes).",
+        "ID": 2
+      }
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332bbdc90",
-      "tid": 18876,
-      "ts": 61740,
+      "id": "0x22abacca350",
+      "tid": 16484,
+      "ts": 189267,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc90",
-      "tid": 18876,
-      "ts": 61758,
+      "id": "0x22abacca350",
+      "tid": 16484,
+      "ts": 189286,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "Size": 8388608,
+          "Size": 8323072,
           "IsResident": 0,
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0
@@ -769,38 +9089,13 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc90",
-      "tid": 18876,
-      "ts": 61773,
+      "id": "0x22abacca350",
+      "tid": 16484,
+      "ts": 189304,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "Size": 8388608,
-          "IsResident": 1,
-          "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 0
-        }
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 61775,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x29332bbdc90",
-      "tid": 18876,
-      "ts": 61787,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 8388608,
+          "Size": 8323072,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0
@@ -811,13 +9106,30 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc90",
-      "tid": 18876,
-      "ts": 62039,
+      "id": "0x22abacca350",
+      "tid": 16484,
+      "ts": 189319,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "Size": 8388608,
+          "Size": 8323072,
+          "IsResident": 1,
+          "MemorySegmentGroup": 0,
+          "SubAllocatedRefs": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacca350",
+      "tid": 16484,
+      "ts": 189397,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 8323072,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0
@@ -828,27 +9140,27 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x2933274e810",
-      "tid": 18876,
-      "ts": 62055,
+      "id": "0x22abacd4240",
+      "tid": 16484,
+      "ts": 189400,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x2933274e810",
-      "tid": 18876,
-      "ts": 62084,
+      "id": "0x22abacd4240",
+      "tid": 16484,
+      "ts": 189415,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
-          "Size": 8388608,
+          "Size": 8323072,
           "HeapOffset": 0,
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x29332bbdc90"
+            "id_ref": "0x22abacca350"
           }
         }
       }
@@ -856,17 +9168,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 62087,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 62212,
+      "tid": 16484,
+      "ts": 189520,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -893,44 +9197,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 62215,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 62216,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 62220,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 62223,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710c08",
-      "tid": 18876,
-      "ts": 62234,
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 189538,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -939,29 +9211,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 62236,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332bbe7d0",
-      "tid": 18876,
-      "ts": 64137,
+      "id": "0x22abacca470",
+      "tid": 16484,
+      "ts": 190584,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe7d0",
-      "tid": 18876,
-      "ts": 64157,
+      "id": "0x22abacca470",
+      "tid": 16484,
+      "ts": 190603,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -976,9 +9240,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe7d0",
-      "tid": 18876,
-      "ts": 64173,
+      "id": "0x22abacca470",
+      "tid": 16484,
+      "ts": 190621,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -990,20 +9254,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 64175,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710c08",
-      "tid": 18876,
-      "ts": 64182,
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 190631,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1012,36 +9268,12 @@
       }
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 64186,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 64188,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 64189,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe7d0",
-      "tid": 18876,
-      "ts": 64201,
+      "id": "0x22abacca470",
+      "tid": 16484,
+      "ts": 190650,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1056,9 +9288,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe7d0",
-      "tid": 18876,
-      "ts": 64225,
+      "id": "0x22abacca470",
+      "tid": 16484,
+      "ts": 190720,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1073,18 +9305,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x2933274fc00",
-      "tid": 18876,
-      "ts": 64227,
+      "id": "0x22abacdc5e0",
+      "tid": 16484,
+      "ts": 190723,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x2933274fc00",
-      "tid": 18876,
-      "ts": 64241,
+      "id": "0x22abacdc5e0",
+      "tid": 16484,
+      "ts": 190738,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1093,7 +9325,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbe7d0"
+            "id_ref": "0x22abacca470"
           }
         }
       }
@@ -1101,17 +9333,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 64244,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 64349,
+      "tid": 16484,
+      "ts": 190852,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1138,52 +9362,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 64351,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 64352,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 64354,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 64356,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 64357,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe7d0",
-      "tid": 18876,
-      "ts": 64369,
+      "id": "0x22abacca470",
+      "tid": 16484,
+      "ts": 190874,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1198,9 +9382,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe7d0",
-      "tid": 18876,
-      "ts": 64391,
+      "id": "0x22abacca470",
+      "tid": 16484,
+      "ts": 190943,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1215,18 +9399,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x2933274f470",
-      "tid": 18876,
-      "ts": 64393,
+      "id": "0x22abacdbb90",
+      "tid": 16484,
+      "ts": 190946,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x2933274f470",
-      "tid": 18876,
-      "ts": 64406,
+      "id": "0x22abacdbb90",
+      "tid": 16484,
+      "ts": 190960,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1235,7 +9419,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbe7d0"
+            "id_ref": "0x22abacca470"
           }
         }
       }
@@ -1243,17 +9427,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 64409,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 64479,
+      "tid": 16484,
+      "ts": 191044,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1280,52 +9456,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 64482,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 64482,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 64483,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 64485,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 64486,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 64499,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 191065,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1340,9 +9476,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 64519,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 191134,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1357,18 +9493,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x2933274e290",
-      "tid": 18876,
-      "ts": 64521,
+      "id": "0x22abacda9b0",
+      "tid": 16484,
+      "ts": 191137,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x2933274e290",
-      "tid": 18876,
-      "ts": 64535,
+      "id": "0x22abacda9b0",
+      "tid": 16484,
+      "ts": 191151,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1377,7 +9513,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbdc00"
+            "id_ref": "0x22abacc9a50"
           }
         }
       }
@@ -1385,17 +9521,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 64537,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 64604,
+      "tid": 16484,
+      "ts": 191232,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1422,52 +9550,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 64607,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 64607,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 64608,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 64610,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 64611,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 64623,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 191253,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1482,9 +9570,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 64643,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 191321,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1499,18 +9587,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x2933274f680",
-      "tid": 18876,
-      "ts": 64646,
+      "id": "0x22abacda850",
+      "tid": 16484,
+      "ts": 191324,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x2933274f680",
-      "tid": 18876,
-      "ts": 64660,
+      "id": "0x22abacda850",
+      "tid": 16484,
+      "ts": 191339,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1519,7 +9607,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbdc00"
+            "id_ref": "0x22abacc9a50"
           }
         }
       }
@@ -1527,17 +9615,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 64662,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 64730,
+      "tid": 16484,
+      "ts": 191421,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1564,52 +9644,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 64732,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 64733,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 64734,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 64736,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 64737,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe7d0",
-      "tid": 18876,
-      "ts": 64749,
+      "id": "0x22abacca470",
+      "tid": 16484,
+      "ts": 191441,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1624,9 +9664,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe7d0",
-      "tid": 18876,
-      "ts": 64780,
+      "id": "0x22abacca470",
+      "tid": 16484,
+      "ts": 191509,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1641,18 +9681,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x2933274f940",
-      "tid": 18876,
-      "ts": 64782,
+      "id": "0x22abacdac70",
+      "tid": 16484,
+      "ts": 191512,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x2933274f940",
-      "tid": 18876,
-      "ts": 64796,
+      "id": "0x22abacdac70",
+      "tid": 16484,
+      "ts": 191526,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1661,7 +9701,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbe7d0"
+            "id_ref": "0x22abacca470"
           }
         }
       }
@@ -1669,17 +9709,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 64798,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 64865,
+      "tid": 16484,
+      "ts": 191614,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1706,52 +9738,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 64867,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 64868,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 64869,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 64871,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 64872,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe7d0",
-      "tid": 18876,
-      "ts": 64884,
+      "id": "0x22abacca470",
+      "tid": 16484,
+      "ts": 191634,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1766,9 +9758,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe7d0",
-      "tid": 18876,
-      "ts": 64905,
+      "id": "0x22abacca470",
+      "tid": 16484,
+      "ts": 191704,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1783,18 +9775,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x2933274faa0",
-      "tid": 18876,
-      "ts": 64906,
+      "id": "0x22abacdaa60",
+      "tid": 16484,
+      "ts": 191706,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x2933274faa0",
-      "tid": 18876,
-      "ts": 64920,
+      "id": "0x22abacdaa60",
+      "tid": 16484,
+      "ts": 191721,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1803,7 +9795,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbe7d0"
+            "id_ref": "0x22abacca470"
           }
         }
       }
@@ -1811,17 +9803,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 64922,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 64988,
+      "tid": 16484,
+      "ts": 191799,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1848,52 +9832,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 64990,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 64991,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 64992,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 64994,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 64994,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 65006,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 191819,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1908,9 +9852,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 65029,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 191886,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1925,18 +9869,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332767c50",
-      "tid": 18876,
-      "ts": 65031,
+      "id": "0x22abacdafe0",
+      "tid": 16484,
+      "ts": 191889,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332767c50",
-      "tid": 18876,
-      "ts": 65044,
+      "id": "0x22abacdafe0",
+      "tid": 16484,
+      "ts": 191904,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1945,7 +9889,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbdc00"
+            "id_ref": "0x22abacc9a50"
           }
         }
       }
@@ -1953,17 +9897,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 65046,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 65113,
+      "tid": 16484,
+      "ts": 191981,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1990,52 +9926,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 65116,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 65116,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 65117,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 65119,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 65120,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 65134,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 192000,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2050,9 +9946,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 65166,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 192068,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2067,18 +9963,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x293327681d0",
-      "tid": 18876,
-      "ts": 65168,
+      "id": "0x22abacdb090",
+      "tid": 16484,
+      "ts": 192071,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327681d0",
-      "tid": 18876,
-      "ts": 65181,
+      "id": "0x22abacdb090",
+      "tid": 16484,
+      "ts": 192085,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2087,7 +9983,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbdc00"
+            "id_ref": "0x22abacc9a50"
           }
         }
       }
@@ -2095,17 +9991,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 65183,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 65252,
+      "tid": 16484,
+      "ts": 192171,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -2132,44 +10020,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 65255,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 65255,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 65259,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 65262,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710c08",
-      "tid": 18876,
-      "ts": 65270,
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 192185,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2178,29 +10034,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 65272,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332bbe6b0",
-      "tid": 18876,
-      "ts": 66718,
+      "id": "0x22abacca620",
+      "tid": 16484,
+      "ts": 193200,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe6b0",
-      "tid": 18876,
-      "ts": 66736,
+      "id": "0x22abacca620",
+      "tid": 16484,
+      "ts": 193220,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2215,9 +10063,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe6b0",
-      "tid": 18876,
-      "ts": 66751,
+      "id": "0x22abacca620",
+      "tid": 16484,
+      "ts": 193238,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2229,20 +10077,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 66753,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710c08",
-      "tid": 18876,
-      "ts": 66759,
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 193248,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2251,36 +10091,12 @@
       }
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 66762,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 66763,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 66764,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe6b0",
-      "tid": 18876,
-      "ts": 66776,
+      "id": "0x22abacca620",
+      "tid": 16484,
+      "ts": 193267,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2295,9 +10111,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe6b0",
-      "tid": 18876,
-      "ts": 66798,
+      "id": "0x22abacca620",
+      "tid": 16484,
+      "ts": 193338,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2312,18 +10128,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332768120",
-      "tid": 18876,
-      "ts": 66801,
+      "id": "0x22abacdbe50",
+      "tid": 16484,
+      "ts": 193341,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332768120",
-      "tid": 18876,
-      "ts": 66814,
+      "id": "0x22abacdbe50",
+      "tid": 16484,
+      "ts": 193356,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2332,7 +10148,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbe6b0"
+            "id_ref": "0x22abacca620"
           }
         }
       }
@@ -2340,17 +10156,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 66816,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 66914,
+      "tid": 16484,
+      "ts": 193467,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -2377,52 +10185,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 66922,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 66923,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 66924,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 66927,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 66927,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe7d0",
-      "tid": 18876,
-      "ts": 66941,
+      "id": "0x22abacca470",
+      "tid": 16484,
+      "ts": 193487,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2437,9 +10205,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe7d0",
-      "tid": 18876,
-      "ts": 66963,
+      "id": "0x22abacca470",
+      "tid": 16484,
+      "ts": 193558,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2454,18 +10222,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332768750",
-      "tid": 18876,
-      "ts": 66965,
+      "id": "0x22abacdc3d0",
+      "tid": 16484,
+      "ts": 193560,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332768750",
-      "tid": 18876,
-      "ts": 66979,
+      "id": "0x22abacdc3d0",
+      "tid": 16484,
+      "ts": 193591,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2474,7 +10242,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbe7d0"
+            "id_ref": "0x22abacca470"
           }
         }
       }
@@ -2482,17 +10250,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 66981,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 67050,
+      "tid": 16484,
+      "ts": 193672,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -2519,44 +10279,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 67052,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 67053,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 67056,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 67059,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710208",
-      "tid": 18876,
-      "ts": 67067,
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 193688,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2565,29 +10293,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 67069,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332bbd5d0",
-      "tid": 18876,
-      "ts": 68599,
+      "id": "0x22abacebb00",
+      "tid": 16484,
+      "ts": 194708,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbd5d0",
-      "tid": 18876,
-      "ts": 68617,
+      "id": "0x22abacebb00",
+      "tid": 16484,
+      "ts": 194728,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2602,9 +10322,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbd5d0",
-      "tid": 18876,
-      "ts": 68632,
+      "id": "0x22abacebb00",
+      "tid": 16484,
+      "ts": 194744,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2616,20 +10336,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 68634,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710208",
-      "tid": 18876,
-      "ts": 68641,
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 194754,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2638,36 +10350,12 @@
       }
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 68643,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 68644,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 68645,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbd5d0",
-      "tid": 18876,
-      "ts": 68657,
+      "id": "0x22abacebb00",
+      "tid": 16484,
+      "ts": 194772,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2682,9 +10370,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbd5d0",
-      "tid": 18876,
-      "ts": 68678,
+      "id": "0x22abacebb00",
+      "tid": 16484,
+      "ts": 194841,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2699,18 +10387,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332767fc0",
-      "tid": 18876,
-      "ts": 68681,
+      "id": "0x22abacdb6c0",
+      "tid": 16484,
+      "ts": 194844,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332767fc0",
-      "tid": 18876,
-      "ts": 68694,
+      "id": "0x22abacdb6c0",
+      "tid": 16484,
+      "ts": 194859,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2719,7 +10407,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbd5d0"
+            "id_ref": "0x22abacebb00"
           }
         }
       }
@@ -2727,17 +10415,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 68696,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 68795,
+      "tid": 16484,
+      "ts": 194970,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -2764,52 +10444,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 68797,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 68797,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 68799,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 68801,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 68801,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 68813,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 194990,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2824,9 +10464,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 68834,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 195059,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2841,18 +10481,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332767a40",
-      "tid": 18876,
-      "ts": 68836,
+      "id": "0x22abacdab10",
+      "tid": 16484,
+      "ts": 195062,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332767a40",
-      "tid": 18876,
-      "ts": 68849,
+      "id": "0x22abacdab10",
+      "tid": 16484,
+      "ts": 195076,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2861,7 +10501,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbdc00"
+            "id_ref": "0x22abacc9a50"
           }
         }
       }
@@ -2869,17 +10509,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 68851,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 68919,
+      "tid": 16484,
+      "ts": 195156,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -2906,52 +10538,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 68920,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 68921,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 68922,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 68924,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 68925,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe6b0",
-      "tid": 18876,
-      "ts": 68937,
+      "id": "0x22abacca620",
+      "tid": 16484,
+      "ts": 195175,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2966,9 +10558,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe6b0",
-      "tid": 18876,
-      "ts": 68957,
+      "id": "0x22abacca620",
+      "tid": 16484,
+      "ts": 195244,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2983,18 +10575,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332767620",
-      "tid": 18876,
-      "ts": 68959,
+      "id": "0x22abacdb8d0",
+      "tid": 16484,
+      "ts": 195247,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332767620",
-      "tid": 18876,
-      "ts": 68972,
+      "id": "0x22abacdb8d0",
+      "tid": 16484,
+      "ts": 195262,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3003,7 +10595,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbe6b0"
+            "id_ref": "0x22abacca620"
           }
         }
       }
@@ -3011,17 +10603,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 68974,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 69041,
+      "tid": 16484,
+      "ts": 195340,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -3048,52 +10632,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 69043,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 69044,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 69045,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 69047,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 69048,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe7d0",
-      "tid": 18876,
-      "ts": 69060,
+      "id": "0x22abacca470",
+      "tid": 16484,
+      "ts": 195360,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3108,9 +10652,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe7d0",
-      "tid": 18876,
-      "ts": 69080,
+      "id": "0x22abacca470",
+      "tid": 16484,
+      "ts": 195433,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3125,18 +10669,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332768960",
-      "tid": 18876,
-      "ts": 69082,
+      "id": "0x22abacefe00",
+      "tid": 16484,
+      "ts": 195435,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332768960",
-      "tid": 18876,
-      "ts": 69095,
+      "id": "0x22abacefe00",
+      "tid": 16484,
+      "ts": 195450,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3145,7 +10689,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbe7d0"
+            "id_ref": "0x22abacca470"
           }
         }
       }
@@ -3153,17 +10697,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 69096,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 69163,
+      "tid": 16484,
+      "ts": 195528,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -3190,52 +10726,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 69165,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 69165,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 69166,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 69168,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 69169,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbd5d0",
-      "tid": 18876,
-      "ts": 69181,
+      "id": "0x22abacebb00",
+      "tid": 16484,
+      "ts": 195548,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3250,9 +10746,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbd5d0",
-      "tid": 18876,
-      "ts": 69220,
+      "id": "0x22abacebb00",
+      "tid": 16484,
+      "ts": 195622,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3267,18 +10763,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332768b70",
-      "tid": 18876,
-      "ts": 69223,
+      "id": "0x22abacee8b0",
+      "tid": 16484,
+      "ts": 195625,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332768b70",
-      "tid": 18876,
-      "ts": 69236,
+      "id": "0x22abacee8b0",
+      "tid": 16484,
+      "ts": 196139,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3287,7 +10783,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbd5d0"
+            "id_ref": "0x22abacebb00"
           }
         }
       }
@@ -3295,17 +10791,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 69238,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 69304,
+      "tid": 16484,
+      "ts": 196220,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -3332,52 +10820,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 69306,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 69306,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 69308,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 69309,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 69310,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 69322,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 196240,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3392,9 +10840,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 69342,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 196311,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3409,18 +10857,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332767ba0",
-      "tid": 18876,
-      "ts": 69344,
+      "id": "0x22abacef9e0",
+      "tid": 16484,
+      "ts": 196314,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332767ba0",
-      "tid": 18876,
-      "ts": 69357,
+      "id": "0x22abacef9e0",
+      "tid": 16484,
+      "ts": 196328,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3429,7 +10877,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbdc00"
+            "id_ref": "0x22abacc9a50"
           }
         }
       }
@@ -3437,17 +10885,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 69359,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 69427,
+      "tid": 16484,
+      "ts": 196406,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -3474,52 +10914,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 69429,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 69430,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 69431,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 69433,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 69434,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe7d0",
-      "tid": 18876,
-      "ts": 69446,
+      "id": "0x22abacca470",
+      "tid": 16484,
+      "ts": 196426,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3534,9 +10934,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe7d0",
-      "tid": 18876,
-      "ts": 69466,
+      "id": "0x22abacca470",
+      "tid": 16484,
+      "ts": 196494,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3551,18 +10951,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332766f40",
-      "tid": 18876,
-      "ts": 69468,
+      "id": "0x22abaceeac0",
+      "tid": 16484,
+      "ts": 196497,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332766f40",
-      "tid": 18876,
-      "ts": 69481,
+      "id": "0x22abaceeac0",
+      "tid": 16484,
+      "ts": 196511,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3571,7 +10971,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbe7d0"
+            "id_ref": "0x22abacca470"
           }
         }
       }
@@ -3579,17 +10979,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 69482,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 69549,
+      "tid": 16484,
+      "ts": 196592,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -3616,52 +11008,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 69551,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 69551,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 69552,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 69554,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 69555,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe7d0",
-      "tid": 18876,
-      "ts": 69567,
+      "id": "0x22abacca470",
+      "tid": 16484,
+      "ts": 196611,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3676,9 +11028,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe7d0",
-      "tid": 18876,
-      "ts": 69589,
+      "id": "0x22abacca470",
+      "tid": 16484,
+      "ts": 196679,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3693,18 +11045,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x293327672b0",
-      "tid": 18876,
-      "ts": 69591,
+      "id": "0x22abaceed80",
+      "tid": 16484,
+      "ts": 196682,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327672b0",
-      "tid": 18876,
-      "ts": 69605,
+      "id": "0x22abaceed80",
+      "tid": 16484,
+      "ts": 196697,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3713,7 +11065,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbe7d0"
+            "id_ref": "0x22abacca470"
           }
         }
       }
@@ -3721,17 +11073,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 69607,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 69675,
+      "tid": 16484,
+      "ts": 196775,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -3758,52 +11102,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 69676,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 69677,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 69678,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 69680,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 69681,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 69693,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 196794,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3818,9 +11122,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 69713,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 196863,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3835,18 +11139,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332768070",
-      "tid": 18876,
-      "ts": 69715,
+      "id": "0x22abacf02d0",
+      "tid": 16484,
+      "ts": 196865,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332768070",
-      "tid": 18876,
-      "ts": 69728,
+      "id": "0x22abacf02d0",
+      "tid": 16484,
+      "ts": 196880,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3855,7 +11159,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbdc00"
+            "id_ref": "0x22abacc9a50"
           }
         }
       }
@@ -3863,17 +11167,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 69729,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 69796,
+      "tid": 16484,
+      "ts": 196958,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -3900,52 +11196,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 69798,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 69798,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 69799,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 69801,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 69802,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 69814,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 196978,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3960,9 +11216,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 69835,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 197045,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3977,18 +11233,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x293327649a0",
-      "tid": 18876,
-      "ts": 69838,
+      "id": "0x22abacefb40",
+      "tid": 16484,
+      "ts": 197048,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327649a0",
-      "tid": 18876,
-      "ts": 69851,
+      "id": "0x22abacefb40",
+      "tid": 16484,
+      "ts": 197062,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3997,7 +11253,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbdc00"
+            "id_ref": "0x22abacc9a50"
           }
         }
       }
@@ -4005,17 +11261,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 69853,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 69923,
+      "tid": 16484,
+      "ts": 197147,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -4042,52 +11290,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 69925,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 69925,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 69926,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 69928,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 69929,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe7d0",
-      "tid": 18876,
-      "ts": 69941,
+      "id": "0x22abacca470",
+      "tid": 16484,
+      "ts": 197166,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4102,9 +11310,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe7d0",
-      "tid": 18876,
-      "ts": 69963,
+      "id": "0x22abacca470",
+      "tid": 16484,
+      "ts": 197247,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4119,18 +11327,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332764160",
-      "tid": 18876,
-      "ts": 69965,
+      "id": "0x22abacf0430",
+      "tid": 16484,
+      "ts": 197249,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332764160",
-      "tid": 18876,
-      "ts": 69978,
+      "id": "0x22abacf0430",
+      "tid": 16484,
+      "ts": 197264,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4139,7 +11347,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbe7d0"
+            "id_ref": "0x22abacca470"
           }
         }
       }
@@ -4147,17 +11355,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 69981,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 70049,
+      "tid": 16484,
+      "ts": 197345,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -4184,52 +11384,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70050,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70051,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70052,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70054,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70055,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe7d0",
-      "tid": 18876,
-      "ts": 70067,
+      "id": "0x22abacca470",
+      "tid": 16484,
+      "ts": 197365,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4244,9 +11404,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe7d0",
-      "tid": 18876,
-      "ts": 70087,
+      "id": "0x22abacca470",
+      "tid": 16484,
+      "ts": 197435,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4261,18 +11421,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332763d40",
-      "tid": 18876,
-      "ts": 70089,
+      "id": "0x22abacf0640",
+      "tid": 16484,
+      "ts": 197438,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332763d40",
-      "tid": 18876,
-      "ts": 70102,
+      "id": "0x22abacf0640",
+      "tid": 16484,
+      "ts": 197453,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4281,7 +11441,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbe7d0"
+            "id_ref": "0x22abacca470"
           }
         }
       }
@@ -4289,17 +11449,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70104,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 70170,
+      "tid": 16484,
+      "ts": 197533,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -4326,52 +11478,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70172,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70172,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70173,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70175,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70176,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 70188,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 197553,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4386,9 +11498,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 70208,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 197679,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4403,18 +11515,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332764b00",
-      "tid": 18876,
-      "ts": 70210,
+      "id": "0x22abacef250",
+      "tid": 16484,
+      "ts": 197682,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332764b00",
-      "tid": 18876,
-      "ts": 70223,
+      "id": "0x22abacef250",
+      "tid": 16484,
+      "ts": 197699,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4423,7 +11535,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbdc00"
+            "id_ref": "0x22abacc9a50"
           }
         }
       }
@@ -4431,17 +11543,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70225,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 70292,
+      "tid": 16484,
+      "ts": 197802,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -4468,52 +11572,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70293,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70294,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70295,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70297,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70298,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 70310,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 197836,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4528,9 +11592,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 70330,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 197932,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4545,18 +11609,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332764e70",
-      "tid": 18876,
-      "ts": 70332,
+      "id": "0x22abacef1a0",
+      "tid": 16484,
+      "ts": 197934,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332764e70",
-      "tid": 18876,
-      "ts": 70345,
+      "id": "0x22abacef1a0",
+      "tid": 16484,
+      "ts": 197960,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4565,7 +11629,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbdc00"
+            "id_ref": "0x22abacc9a50"
           }
         }
       }
@@ -4573,17 +11637,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70347,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 70414,
+      "tid": 16484,
+      "ts": 198052,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -4610,52 +11666,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70415,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70416,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70417,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70419,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70420,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe7d0",
-      "tid": 18876,
-      "ts": 70432,
+      "id": "0x22abacca470",
+      "tid": 16484,
+      "ts": 198072,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4670,9 +11686,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe7d0",
-      "tid": 18876,
-      "ts": 70452,
+      "id": "0x22abacca470",
+      "tid": 16484,
+      "ts": 198141,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4687,18 +11703,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x293327637c0",
-      "tid": 18876,
-      "ts": 70454,
+      "id": "0x22abacef880",
+      "tid": 16484,
+      "ts": 198144,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327637c0",
-      "tid": 18876,
-      "ts": 70467,
+      "id": "0x22abacef880",
+      "tid": 16484,
+      "ts": 198158,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4707,7 +11723,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbe7d0"
+            "id_ref": "0x22abacca470"
           }
         }
       }
@@ -4715,17 +11731,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70468,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 70535,
+      "tid": 16484,
+      "ts": 198238,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -4752,52 +11760,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70537,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70537,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70538,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70540,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70541,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 70553,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 198258,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4812,9 +11780,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 70573,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 198326,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4829,18 +11797,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332764bb0",
-      "tid": 18876,
-      "ts": 70575,
+      "id": "0x22abacef720",
+      "tid": 16484,
+      "ts": 198329,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332764bb0",
-      "tid": 18876,
-      "ts": 70588,
+      "id": "0x22abacef720",
+      "tid": 16484,
+      "ts": 198343,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -4849,400 +11817,72 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbdc00"
+            "id_ref": "0x22abacc9a50"
           }
         }
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
+      "name": "GPUMemoryAllocation",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70590,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70640,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70640,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70642,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70642,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70643,
+      "ph": "D",
+      "id": "0x22abacda9b0",
+      "tid": 16484,
+      "ts": 198462,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x2933274e290",
-      "tid": 18876,
-      "ts": 70647,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70647,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70670,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70670,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70670,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70671,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70671,
+      "id": "0x22abacda850",
+      "tid": 16484,
+      "ts": 198539,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x2933274f680",
-      "tid": 18876,
-      "ts": 70673,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70673,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70696,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70696,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70696,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70697,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70697,
+      "id": "0x22abacdafe0",
+      "tid": 16484,
+      "ts": 198615,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332767c50",
-      "tid": 18876,
-      "ts": 70698,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70698,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70720,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70720,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70721,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70721,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70722,
+      "id": "0x22abacdb090",
+      "tid": 16484,
+      "ts": 198686,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x293327681d0",
-      "tid": 18876,
-      "ts": 70722,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70723,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70744,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70745,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70745,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70746,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70746,
+      "id": "0x22abacdb6c0",
+      "tid": 16484,
+      "ts": 198757,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332767fc0",
-      "tid": 18876,
-      "ts": 70747,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70747,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70769,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70769,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70770,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70770,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70771,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x29332767a40",
-      "tid": 18876,
-      "ts": 70772,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70772,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70806,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70806,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70807,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70807,
+      "id": "0x22abacdab10",
+      "tid": 16484,
+      "ts": 198829,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710208",
-      "tid": 18876,
-      "ts": 70815,
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 198884,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5254,400 +11894,80 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332bbd5d0",
-      "tid": 18876,
-      "ts": 70818,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70819,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70819,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70823,
+      "id": "0x22abacebb00",
+      "tid": 16484,
+      "ts": 198887,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332768b70",
-      "tid": 18876,
-      "ts": 70939,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70940,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70979,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70979,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 70980,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70996,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70996,
+      "id": "0x22abacee8b0",
+      "tid": 16484,
+      "ts": 199100,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332767ba0",
-      "tid": 18876,
-      "ts": 70998,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 70998,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 71021,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 71021,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 71022,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 71022,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 71023,
+      "id": "0x22abacef9e0",
+      "tid": 16484,
+      "ts": 199180,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332768070",
-      "tid": 18876,
-      "ts": 71023,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 71024,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 71046,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 71046,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 71046,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 71047,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 71047,
+      "id": "0x22abacf02d0",
+      "tid": 16484,
+      "ts": 199253,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x293327649a0",
-      "tid": 18876,
-      "ts": 71048,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 71048,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 71070,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 71070,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 71071,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 71071,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 71072,
+      "id": "0x22abacefb40",
+      "tid": 16484,
+      "ts": 199335,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332764b00",
-      "tid": 18876,
-      "ts": 71072,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 71073,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 71095,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 71095,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 71096,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 71096,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 71097,
+      "id": "0x22abacef250",
+      "tid": 16484,
+      "ts": 199408,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332764e70",
-      "tid": 18876,
-      "ts": 71097,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 71098,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 71119,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 71120,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 71120,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 71121,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 71121,
+      "id": "0x22abacef1a0",
+      "tid": 16484,
+      "ts": 199481,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332764bb0",
-      "tid": 18876,
-      "ts": 71122,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 71122,
+      "id": "0x22abacef720",
+      "tid": 16484,
+      "ts": 199554,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 71167,
+      "tid": 16484,
+      "ts": 199633,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -5674,44 +11994,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 71169,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 71170,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 71174,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 71177,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710c08",
-      "tid": 18876,
-      "ts": 71186,
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 199667,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5720,29 +12008,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 71188,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332bbeb30",
-      "tid": 18876,
-      "ts": 71697,
+      "id": "0x22abaceae10",
+      "tid": 16484,
+      "ts": 200016,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbeb30",
-      "tid": 18876,
-      "ts": 71714,
+      "id": "0x22abaceae10",
+      "tid": 16484,
+      "ts": 200046,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5757,9 +12037,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbeb30",
-      "tid": 18876,
-      "ts": 71729,
+      "id": "0x22abaceae10",
+      "tid": 16484,
+      "ts": 200064,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5771,20 +12051,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 71730,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710c08",
-      "tid": 18876,
-      "ts": 71737,
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 200073,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5793,36 +12065,12 @@
       }
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 71739,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 71741,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 71742,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbeb30",
-      "tid": 18876,
-      "ts": 71753,
+      "id": "0x22abaceae10",
+      "tid": 16484,
+      "ts": 200092,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5837,9 +12085,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbeb30",
-      "tid": 18876,
-      "ts": 71774,
+      "id": "0x22abaceae10",
+      "tid": 16484,
+      "ts": 200184,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5854,18 +12102,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x293327654a0",
-      "tid": 18876,
-      "ts": 71777,
+      "id": "0x22abacef250",
+      "tid": 16484,
+      "ts": 200187,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327654a0",
-      "tid": 18876,
-      "ts": 71790,
+      "id": "0x22abacef250",
+      "tid": 16484,
+      "ts": 200203,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -5874,7 +12122,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbeb30"
+            "id_ref": "0x22abaceae10"
           }
         }
       }
@@ -5882,17 +12130,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 71792,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 71891,
+      "tid": 16484,
+      "ts": 200353,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -5919,27 +12159,11 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 71893,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 71893,
-      "pid": "GPGMM"
-    },
-    {
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 71910,
+      "tid": 16484,
+      "ts": 200386,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (12451840 vs 4194304 bytes).",
@@ -5947,19 +12171,11 @@
       }
     },
     {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 71912,
-      "pid": "GPGMM"
-    },
-    {
       "name": "ResourceAllocator.TryAllocateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 71923,
+      "tid": 16484,
+      "ts": 200400,
       "pid": "GPGMM",
       "args": {
         "Description": "Resource memory could not be allocated.",
@@ -5967,31 +12183,11 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "i",
-      "tid": 18876,
-      "ts": 71936,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Suballocation was attempted but failed.",
-        "ID": 1
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 71938,
-      "pid": "GPGMM"
-    },
-    {
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 71952,
+      "tid": 16484,
+      "ts": 200428,
       "pid": "GPGMM",
       "args": {
         "Description": "Heap size is not a multiple of the alignment (12451840 vs 4194304 bytes).",
@@ -6002,18 +12198,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332bbe3e0",
-      "tid": 18876,
-      "ts": 75567,
+      "id": "0x22abaceba70",
+      "tid": 16484,
+      "ts": 203411,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe3e0",
-      "tid": 18876,
-      "ts": 75585,
+      "id": "0x22abaceba70",
+      "tid": 16484,
+      "ts": 203431,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6028,34 +12224,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe3e0",
-      "tid": 18876,
-      "ts": 75600,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 12451840,
-          "IsResident": 1,
-          "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 0
-        }
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 75602,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x29332bbe3e0",
-      "tid": 18876,
-      "ts": 75614,
+      "id": "0x22abaceba70",
+      "tid": 16484,
+      "ts": 203448,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6070,9 +12241,26 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe3e0",
-      "tid": 18876,
-      "ts": 75635,
+      "id": "0x22abaceba70",
+      "tid": 16484,
+      "ts": 203464,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 12451840,
+          "IsResident": 1,
+          "MemorySegmentGroup": 0,
+          "SubAllocatedRefs": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abaceba70",
+      "tid": 16484,
+      "ts": 203534,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6087,18 +12275,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332763710",
-      "tid": 18876,
-      "ts": 75637,
+      "id": "0x22abacefb40",
+      "tid": 16484,
+      "ts": 203536,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332763710",
-      "tid": 18876,
-      "ts": 75687,
+      "id": "0x22abacefb40",
+      "tid": 16484,
+      "ts": 203551,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6107,7 +12295,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x29332bbe3e0"
+            "id_ref": "0x22abaceba70"
           }
         }
       }
@@ -6115,17 +12303,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 75689,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 75785,
+      "tid": 16484,
+      "ts": 203665,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -6152,44 +12332,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 75786,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 75787,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 75791,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 75793,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710c08",
-      "tid": 18876,
-      "ts": 75800,
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 203683,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6198,29 +12346,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 75803,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332bbdae0",
-      "tid": 18876,
-      "ts": 77417,
+      "id": "0x22abacea7e0",
+      "tid": 16484,
+      "ts": 204701,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdae0",
-      "tid": 18876,
-      "ts": 77435,
+      "id": "0x22abacea7e0",
+      "tid": 16484,
+      "ts": 204722,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6235,9 +12375,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdae0",
-      "tid": 18876,
-      "ts": 77450,
+      "id": "0x22abacea7e0",
+      "tid": 16484,
+      "ts": 204739,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6249,20 +12389,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 77451,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710c08",
-      "tid": 18876,
-      "ts": 77458,
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 204748,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6271,36 +12403,12 @@
       }
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 77460,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 77462,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 77463,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdae0",
-      "tid": 18876,
-      "ts": 77474,
+      "id": "0x22abacea7e0",
+      "tid": 16484,
+      "ts": 204767,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6315,9 +12423,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdae0",
-      "tid": 18876,
-      "ts": 77496,
+      "id": "0x22abacea7e0",
+      "tid": 16484,
+      "ts": 204839,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6332,18 +12440,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332764bb0",
-      "tid": 18876,
-      "ts": 77498,
+      "id": "0x22abacdbf00",
+      "tid": 16484,
+      "ts": 204842,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332764bb0",
-      "tid": 18876,
-      "ts": 77511,
+      "id": "0x22abacdbf00",
+      "tid": 16484,
+      "ts": 204858,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6352,7 +12460,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbdae0"
+            "id_ref": "0x22abacea7e0"
           }
         }
       }
@@ -6360,17 +12468,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 77513,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 77676,
+      "tid": 16484,
+      "ts": 204972,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -6397,27 +12497,11 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 77678,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 77678,
-      "pid": "GPGMM"
-    },
-    {
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 77710,
+      "tid": 16484,
+      "ts": 204992,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (709230592 vs 4194304 bytes).",
@@ -6425,19 +12509,11 @@
       }
     },
     {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 77712,
-      "pid": "GPGMM"
-    },
-    {
       "name": "ResourceAllocator.TryAllocateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 77739,
+      "tid": 16484,
+      "ts": 205010,
       "pid": "GPGMM",
       "args": {
         "Description": "Resource memory could not be allocated.",
@@ -6445,31 +12521,11 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "i",
-      "tid": 18876,
-      "ts": 77751,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Suballocation was attempted but failed.",
-        "ID": 1
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 77753,
-      "pid": "GPGMM"
-    },
-    {
       "name": "ResourceAllocator.CreateResourceHeap",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 77767,
+      "tid": 16484,
+      "ts": 205028,
       "pid": "GPGMM",
       "args": {
         "Description": "Heap size is not a multiple of the alignment (709230592 vs 4194304 bytes).",
@@ -6480,18 +12536,18 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332bbd8a0",
-      "tid": 18876,
-      "ts": 291590,
+      "id": "0x22abaceb7a0",
+      "tid": 16484,
+      "ts": 205817,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbd8a0",
-      "tid": 18876,
-      "ts": 291630,
+      "id": "0x22abaceb7a0",
+      "tid": 16484,
+      "ts": 205837,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6506,34 +12562,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbd8a0",
-      "tid": 18876,
-      "ts": 291650,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 709230592,
-          "IsResident": 1,
-          "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 0
-        }
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 291652,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x29332bbd8a0",
-      "tid": 18876,
-      "ts": 291667,
+      "id": "0x22abaceb7a0",
+      "tid": 16484,
+      "ts": 205855,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6548,9 +12579,26 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbd8a0",
-      "tid": 18876,
-      "ts": 291705,
+      "id": "0x22abaceb7a0",
+      "tid": 16484,
+      "ts": 205871,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 709230592,
+          "IsResident": 1,
+          "MemorySegmentGroup": 0,
+          "SubAllocatedRefs": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abaceb7a0",
+      "tid": 16484,
+      "ts": 205941,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6565,18 +12613,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332764e70",
-      "tid": 18876,
-      "ts": 291707,
+      "id": "0x22abad05d10",
+      "tid": 16484,
+      "ts": 205944,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332764e70",
-      "tid": 18876,
-      "ts": 291722,
+      "id": "0x22abad05d10",
+      "tid": 16484,
+      "ts": 205959,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6585,400 +12633,72 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x29332bbd8a0"
+            "id_ref": "0x22abaceb7a0"
           }
         }
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
+      "name": "GPUMemoryAllocation",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 291725,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 291811,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 291811,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 291813,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 291814,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 291815,
+      "ph": "D",
+      "id": "0x22abacdc5e0",
+      "tid": 16484,
+      "ts": 206103,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x2933274fc00",
-      "tid": 18876,
-      "ts": 291820,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 291821,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 291845,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 291845,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 291846,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 291846,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 291847,
+      "id": "0x22abacdbb90",
+      "tid": 16484,
+      "ts": 206180,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x2933274f470",
-      "tid": 18876,
-      "ts": 291848,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 291849,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 291872,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 291872,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 291873,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 291873,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 291874,
+      "id": "0x22abacdac70",
+      "tid": 16484,
+      "ts": 206254,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x2933274f940",
-      "tid": 18876,
-      "ts": 291875,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 291875,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 291898,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 291899,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 291899,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 291900,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 291900,
+      "id": "0x22abacdaa60",
+      "tid": 16484,
+      "ts": 206328,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x2933274faa0",
-      "tid": 18876,
-      "ts": 291901,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 291901,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 291924,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 291924,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 291925,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 291926,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 291926,
+      "id": "0x22abacdbe50",
+      "tid": 16484,
+      "ts": 206402,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332768120",
-      "tid": 18876,
-      "ts": 291927,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 291928,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 291950,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 291951,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 291951,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 291952,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 291952,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x29332768750",
-      "tid": 18876,
-      "ts": 291953,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 291954,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 291990,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 291990,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 291991,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 291992,
+      "id": "0x22abacdc3d0",
+      "tid": 16484,
+      "ts": 206475,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710c08",
-      "tid": 18876,
-      "ts": 292001,
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 206531,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -6990,376 +12710,72 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332bbe6b0",
-      "tid": 18876,
-      "ts": 292004,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 292005,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 292005,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 292011,
+      "id": "0x22abacca620",
+      "tid": 16484,
+      "ts": 206533,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332767620",
-      "tid": 18876,
-      "ts": 292155,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 292167,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 292205,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 292206,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 292206,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 292207,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 292207,
+      "id": "0x22abacdb8d0",
+      "tid": 16484,
+      "ts": 206700,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332768960",
-      "tid": 18876,
-      "ts": 292209,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 292210,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 292232,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 292233,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 292233,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 292234,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 292234,
+      "id": "0x22abacefe00",
+      "tid": 16484,
+      "ts": 206782,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332766f40",
-      "tid": 18876,
-      "ts": 292235,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 292236,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 292259,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 292259,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 292260,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 292260,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 292261,
+      "id": "0x22abaceeac0",
+      "tid": 16484,
+      "ts": 206856,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x293327672b0",
-      "tid": 18876,
-      "ts": 292262,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 292262,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 292284,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 292285,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 292285,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 292286,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 292286,
+      "id": "0x22abaceed80",
+      "tid": 16484,
+      "ts": 206929,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332764160",
-      "tid": 18876,
-      "ts": 292287,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 292287,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 292310,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 292311,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 292311,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 292312,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 292312,
+      "id": "0x22abacf0430",
+      "tid": 16484,
+      "ts": 207000,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332763d40",
-      "tid": 18876,
-      "ts": 292313,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 292313,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 292349,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 292349,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 292350,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 292351,
+      "id": "0x22abacf0640",
+      "tid": 16484,
+      "ts": 207073,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710c08",
-      "tid": 18876,
-      "ts": 292361,
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 207129,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7371,58 +12787,26 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332bbe7d0",
-      "tid": 18876,
-      "ts": 292363,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 292364,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 292364,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 292369,
+      "id": "0x22abacca470",
+      "tid": 16484,
+      "ts": 207131,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x293327637c0",
-      "tid": 18876,
-      "ts": 292519,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 292520,
+      "id": "0x22abacef880",
+      "tid": 16484,
+      "ts": 207279,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 292596,
+      "tid": 16484,
+      "ts": 207337,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -7449,44 +12833,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 292597,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 292599,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 292604,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 292608,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710c08",
-      "tid": 18876,
-      "ts": 292616,
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 207351,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7495,29 +12847,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 292618,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332bbe080",
-      "tid": 18876,
-      "ts": 293230,
+      "id": "0x22abacebcb0",
+      "tid": 16484,
+      "ts": 208433,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe080",
-      "tid": 18876,
-      "ts": 293250,
+      "id": "0x22abacebcb0",
+      "tid": 16484,
+      "ts": 208453,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7532,9 +12876,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe080",
-      "tid": 18876,
-      "ts": 293266,
+      "id": "0x22abacebcb0",
+      "tid": 16484,
+      "ts": 208470,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7546,20 +12890,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 293268,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710c08",
-      "tid": 18876,
-      "ts": 293274,
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 208480,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7568,36 +12904,12 @@
       }
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 293277,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 293279,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 293280,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe080",
-      "tid": 18876,
-      "ts": 293292,
+      "id": "0x22abacebcb0",
+      "tid": 16484,
+      "ts": 208498,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7612,9 +12924,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe080",
-      "tid": 18876,
-      "ts": 293316,
+      "id": "0x22abacebcb0",
+      "tid": 16484,
+      "ts": 208576,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7629,27 +12941,27 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332763d40",
-      "tid": 18876,
-      "ts": 293319,
+      "id": "0x22abad06fa0",
+      "tid": 16484,
+      "ts": 208579,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332763d40",
-      "tid": 18876,
-      "ts": 293344,
+      "id": "0x22abad06fa0",
+      "tid": 16484,
+      "ts": 208595,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 65536,
-          "HeapOffset": 0,
+          "HeapOffset": 655360,
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbe080"
+            "id_ref": "0x22abacebcb0"
           }
         }
       }
@@ -7657,17 +12969,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 293347,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 293479,
+      "tid": 16484,
+      "ts": 208709,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -7694,52 +12998,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 293480,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 293482,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 293483,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 293486,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 293487,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 293500,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 208732,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7754,9 +13018,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 293523,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 208804,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7771,18 +13035,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332767f10",
-      "tid": 18876,
-      "ts": 293525,
+      "id": "0x22abad06a20",
+      "tid": 16484,
+      "ts": 208806,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332767f10",
-      "tid": 18876,
-      "ts": 293540,
+      "id": "0x22abad06a20",
+      "tid": 16484,
+      "ts": 208822,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7791,7 +13055,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbdc00"
+            "id_ref": "0x22abacc9a50"
           }
         }
       }
@@ -7799,17 +13063,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 293542,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 293625,
+      "tid": 16484,
+      "ts": 208903,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -7836,52 +13092,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 293627,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 293627,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 293628,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 293630,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 293631,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 293644,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 208923,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7896,9 +13112,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 293664,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 208994,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7913,18 +13129,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332767fc0",
-      "tid": 18876,
-      "ts": 293666,
+      "id": "0x22abad075d0",
+      "tid": 16484,
+      "ts": 208996,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332767fc0",
-      "tid": 18876,
-      "ts": 293680,
+      "id": "0x22abad075d0",
+      "tid": 16484,
+      "ts": 209011,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -7933,7 +13149,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbdc00"
+            "id_ref": "0x22abacc9a50"
           }
         }
       }
@@ -7941,17 +13157,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 293682,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 293751,
+      "tid": 16484,
+      "ts": 209092,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -7978,52 +13186,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 293753,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 293754,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 293755,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 293757,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 293758,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 293770,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 209112,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8038,9 +13206,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 293790,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 209181,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8055,18 +13223,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x293327681d0",
-      "tid": 18876,
-      "ts": 293792,
+      "id": "0x22abad07730",
+      "tid": 16484,
+      "ts": 209184,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327681d0",
-      "tid": 18876,
-      "ts": 293806,
+      "id": "0x22abad07730",
+      "tid": 16484,
+      "ts": 209199,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8075,7 +13243,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbdc00"
+            "id_ref": "0x22abacc9a50"
           }
         }
       }
@@ -8083,17 +13251,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 293808,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 293877,
+      "tid": 16484,
+      "ts": 209279,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -8120,52 +13280,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 293879,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 293880,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 293880,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 293882,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 293883,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 293895,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 209299,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8180,9 +13300,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 293916,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 209369,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8197,18 +13317,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332768070",
-      "tid": 18876,
-      "ts": 293918,
+      "id": "0x22abad06340",
+      "tid": 16484,
+      "ts": 209372,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332768070",
-      "tid": 18876,
-      "ts": 293931,
+      "id": "0x22abad06340",
+      "tid": 16484,
+      "ts": 209387,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8217,7 +13337,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbdc00"
+            "id_ref": "0x22abacc9a50"
           }
         }
       }
@@ -8225,17 +13345,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 293933,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 294003,
+      "tid": 16484,
+      "ts": 209466,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -8262,52 +13374,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 294005,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 294005,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 294006,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 294008,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 294009,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 294021,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 209486,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8322,9 +13394,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 294041,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 209558,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8339,18 +13411,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x293327685f0",
-      "tid": 18876,
-      "ts": 294044,
+      "id": "0x22abad05840",
+      "tid": 16484,
+      "ts": 209561,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327685f0",
-      "tid": 18876,
-      "ts": 294057,
+      "id": "0x22abad05840",
+      "tid": 16484,
+      "ts": 209576,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8359,310 +13431,62 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbdc00"
+            "id_ref": "0x22abacc9a50"
           }
         }
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
+      "name": "GPUMemoryAllocation",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 294059,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 294108,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 294109,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 294110,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 294110,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 294111,
+      "ph": "D",
+      "id": "0x22abad06a20",
+      "tid": 16484,
+      "ts": 209687,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332767f10",
-      "tid": 18876,
-      "ts": 294113,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 294114,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 294136,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 294137,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 294137,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 294138,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 294138,
+      "id": "0x22abad075d0",
+      "tid": 16484,
+      "ts": 209761,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332767fc0",
-      "tid": 18876,
-      "ts": 294139,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 294139,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 294161,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 294162,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 294162,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 294163,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 294163,
+      "id": "0x22abad07730",
+      "tid": 16484,
+      "ts": 209834,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x293327681d0",
-      "tid": 18876,
-      "ts": 294164,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 294164,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 294187,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 294187,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 294188,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 294188,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 294188,
+      "id": "0x22abad06340",
+      "tid": 16484,
+      "ts": 209906,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332768070",
-      "tid": 18876,
-      "ts": 294189,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 294190,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 294212,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 294212,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 294213,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 294213,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 294213,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x293327685f0",
-      "tid": 18876,
-      "ts": 294214,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 294215,
+      "id": "0x22abad05840",
+      "tid": 16484,
+      "ts": 209978,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 294259,
+      "tid": 16484,
+      "ts": 210030,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -8689,44 +13513,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 294260,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 294261,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 294264,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 294268,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710208",
-      "tid": 18876,
-      "ts": 294276,
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 210042,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8735,29 +13527,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 294278,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332bbe980",
-      "tid": 18876,
-      "ts": 294820,
+      "id": "0x22abaceb560",
+      "tid": 16484,
+      "ts": 210357,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe980",
-      "tid": 18876,
-      "ts": 294839,
+      "id": "0x22abaceb560",
+      "tid": 16484,
+      "ts": 210376,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8772,9 +13556,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe980",
-      "tid": 18876,
-      "ts": 294855,
+      "id": "0x22abaceb560",
+      "tid": 16484,
+      "ts": 210393,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8786,20 +13570,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 294856,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710208",
-      "tid": 18876,
-      "ts": 294863,
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 210402,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8808,36 +13584,12 @@
       }
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 294866,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 294867,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 294868,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe980",
-      "tid": 18876,
-      "ts": 294880,
+      "id": "0x22abaceb560",
+      "tid": 16484,
+      "ts": 210421,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8852,9 +13604,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe980",
-      "tid": 18876,
-      "ts": 294903,
+      "id": "0x22abaceb560",
+      "tid": 16484,
+      "ts": 210491,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -8869,405 +13621,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x2933274f470",
-      "tid": 18876,
-      "ts": 294906,
+      "id": "0x22abad07260",
+      "tid": 16484,
+      "ts": 210493,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x2933274f470",
-      "tid": 18876,
-      "ts": 294919,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 131072,
-          "HeapOffset": 0,
-          "OffsetFromResource": 0,
-          "Method": 2,
-          "ResourceHeap": {
-            "id_ref": "0x29332bbe980"
-          }
-        }
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 294922,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "i",
-      "tid": 18876,
-      "ts": 295023,
-      "pid": "GPGMM",
-      "args": {
-        "allocationDescriptor": {
-          "Flags": 0,
-          "HeapType": 2
-        },
-        "resourceDescriptor": {
-          "Dimension": 1,
-          "Alignment": 0,
-          "Width": 524288,
-          "Height": 1,
-          "DepthOrArraySize": 1,
-          "MipLevels": 1,
-          "Format": 0,
-          "Layout": 1,
-          "SampleDesc": {
-            "Count": 1,
-            "Quality": 0
-          },
-          "Flags": 0
-        },
-        "initialResourceState": 2755,
-        "clearValue": {}
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 295027,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 295028,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 295033,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 295036,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x29332710208",
-      "tid": 18876,
-      "ts": 295046,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 8388608
-        }
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 295048,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x29332bbf160",
-      "tid": 18876,
-      "ts": 296417,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x29332bbf160",
-      "tid": 18876,
-      "ts": 296437,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 0,
-          "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 0
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x29332bbf160",
-      "tid": 18876,
-      "ts": 296452,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 0
-        }
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 296454,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x29332710208",
-      "tid": 18876,
-      "ts": 296461,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 12582912
-        }
-      }
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 296463,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 296465,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 296466,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x29332bbf160",
-      "tid": 18876,
-      "ts": 296478,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 2
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x29332bbf160",
-      "tid": 18876,
-      "ts": 296501,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 2
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x2933274f940",
-      "tid": 18876,
-      "ts": 296504,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x2933274f940",
-      "tid": 18876,
-      "ts": 296518,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 524288,
-          "HeapOffset": 0,
-          "OffsetFromResource": 0,
-          "Method": 2,
-          "ResourceHeap": {
-            "id_ref": "0x29332bbf160"
-          }
-        }
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 296520,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "i",
-      "tid": 18876,
-      "ts": 296623,
-      "pid": "GPGMM",
-      "args": {
-        "allocationDescriptor": {
-          "Flags": 0,
-          "HeapType": 2
-        },
-        "resourceDescriptor": {
-          "Dimension": 1,
-          "Alignment": 0,
-          "Width": 131072,
-          "Height": 1,
-          "DepthOrArraySize": 1,
-          "MipLevels": 1,
-          "Format": 0,
-          "Layout": 1,
-          "SampleDesc": {
-            "Count": 1,
-            "Quality": 0
-          },
-          "Flags": 0
-        },
-        "initialResourceState": 2755,
-        "clearValue": {}
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 296625,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 296626,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 296627,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 296629,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 296630,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x29332bbe980",
-      "tid": 18876,
-      "ts": 296643,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 3
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x29332bbe980",
-      "tid": 18876,
-      "ts": 296665,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 4194304,
-          "IsResident": 1,
-          "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 3
-        }
-      }
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x29332770ee0",
-      "tid": 18876,
-      "ts": 296669,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x29332770ee0",
-      "tid": 18876,
-      "ts": 296683,
+      "id": "0x22abad07260",
+      "tid": 16484,
+      "ts": 210509,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9276,7 +13641,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbe980"
+            "id_ref": "0x22abaceb560"
           }
         }
       }
@@ -9284,17 +13649,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 296685,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 296754,
+      "tid": 16484,
+      "ts": 210626,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -9321,59 +13678,42 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
+      "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 296756,
-      "pid": "GPGMM"
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 210642,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 8388608
+        }
+      }
     },
     {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
+      "name": "GPUMemoryBlock",
       "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 296757,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 296758,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 296760,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 296761,
+      "ph": "N",
+      "id": "0x22abacec6d0",
+      "tid": 16484,
+      "ts": 210957,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbf160",
-      "tid": 18876,
-      "ts": 296773,
+      "id": "0x22abacec6d0",
+      "tid": 16484,
+      "ts": 210976,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
-          "IsResident": 1,
+          "IsResident": 0,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 3
+          "SubAllocatedRefs": 0
         }
       }
     },
@@ -9381,16 +13721,64 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbf160",
-      "tid": 18876,
-      "ts": 296794,
+      "id": "0x22abacec6d0",
+      "tid": 16484,
+      "ts": 210992,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 3
+          "SubAllocatedRefs": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 211001,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 12582912
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacec6d0",
+      "tid": 16484,
+      "ts": 211020,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 0,
+          "SubAllocatedRefs": 2
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacec6d0",
+      "tid": 16484,
+      "ts": 211089,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 0,
+          "SubAllocatedRefs": 2
         }
       }
     },
@@ -9398,27 +13786,27 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332771930",
-      "tid": 18876,
-      "ts": 296796,
+      "id": "0x22abad06ad0",
+      "tid": 16484,
+      "ts": 211092,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332771930",
-      "tid": 18876,
-      "ts": 296809,
+      "id": "0x22abad06ad0",
+      "tid": 16484,
+      "ts": 211107,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 524288,
-          "HeapOffset": 524288,
+          "HeapOffset": 0,
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbf160"
+            "id_ref": "0x22abacec6d0"
           }
         }
       }
@@ -9426,17 +13814,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 296811,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 296881,
+      "tid": 16484,
+      "ts": 211220,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -9463,59 +13843,19 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 296882,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 296883,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 296884,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 296886,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 296887,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe980",
-      "tid": 18876,
-      "ts": 296899,
+      "id": "0x22abaceb560",
+      "tid": 16484,
+      "ts": 211240,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 4
+          "SubAllocatedRefs": 3
         }
       }
     },
@@ -9523,16 +13863,16 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbe980",
-      "tid": 18876,
-      "ts": 296919,
+      "id": "0x22abaceb560",
+      "tid": 16484,
+      "ts": 211310,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 4194304,
           "IsResident": 1,
           "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 4
+          "SubAllocatedRefs": 3
         }
       }
     },
@@ -9540,27 +13880,27 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332771670",
-      "tid": 18876,
-      "ts": 296922,
+      "id": "0x22abad05840",
+      "tid": 16484,
+      "ts": 211313,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332771670",
-      "tid": 18876,
-      "ts": 296935,
+      "id": "0x22abad05840",
+      "tid": 16484,
+      "ts": 211328,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "Size": 131072,
-          "HeapOffset": 262144,
+          "HeapOffset": 0,
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbe980"
+            "id_ref": "0x22abaceb560"
           }
         }
       }
@@ -9568,17 +13908,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 296937,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 297006,
+      "tid": 16484,
+      "ts": 211408,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -9605,52 +13937,106 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
+      "name": "GPUMemoryBlock",
       "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 297008,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 297008,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 297009,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 297011,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 297012,
-      "pid": "GPGMM"
+      "ph": "O",
+      "id": "0x22abacec6d0",
+      "tid": 16484,
+      "ts": 211428,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 0,
+          "SubAllocatedRefs": 3
+        }
+      }
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbf160",
-      "tid": 18876,
-      "ts": 297025,
+      "id": "0x22abacec6d0",
+      "tid": 16484,
+      "ts": 211497,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 0,
+          "SubAllocatedRefs": 3
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22abad06a20",
+      "tid": 16484,
+      "ts": 211500,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abad06a20",
+      "tid": 16484,
+      "ts": 211514,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 524288,
+          "HeapOffset": 524288,
+          "OffsetFromResource": 0,
+          "Method": 2,
+          "ResourceHeap": {
+            "id_ref": "0x22abacec6d0"
+          }
+        }
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 211597,
+      "pid": "GPGMM",
+      "args": {
+        "allocationDescriptor": {
+          "Flags": 0,
+          "HeapType": 2
+        },
+        "resourceDescriptor": {
+          "Dimension": 1,
+          "Alignment": 0,
+          "Width": 131072,
+          "Height": 1,
+          "DepthOrArraySize": 1,
+          "MipLevels": 1,
+          "Format": 0,
+          "Layout": 1,
+          "SampleDesc": {
+            "Count": 1,
+            "Quality": 0
+          },
+          "Flags": 0
+        },
+        "initialResourceState": 2755,
+        "clearValue": {}
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abaceb560",
+      "tid": 16484,
+      "ts": 211618,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9665,9 +14051,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332bbf160",
-      "tid": 18876,
-      "ts": 297045,
+      "id": "0x22abaceb560",
+      "tid": 16484,
+      "ts": 211688,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9682,18 +14068,112 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332771f60",
-      "tid": 18876,
-      "ts": 297047,
+      "id": "0x22abad066b0",
+      "tid": 16484,
+      "ts": 211690,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332771f60",
-      "tid": 18876,
-      "ts": 297061,
+      "id": "0x22abad066b0",
+      "tid": 16484,
+      "ts": 211705,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 131072,
+          "HeapOffset": 262144,
+          "OffsetFromResource": 0,
+          "Method": 2,
+          "ResourceHeap": {
+            "id_ref": "0x22abaceb560"
+          }
+        }
+      }
+    },
+    {
+      "name": "ResourceAllocator.CreateResource",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 211785,
+      "pid": "GPGMM",
+      "args": {
+        "allocationDescriptor": {
+          "Flags": 0,
+          "HeapType": 2
+        },
+        "resourceDescriptor": {
+          "Dimension": 1,
+          "Alignment": 0,
+          "Width": 524288,
+          "Height": 1,
+          "DepthOrArraySize": 1,
+          "MipLevels": 1,
+          "Format": 0,
+          "Layout": 1,
+          "SampleDesc": {
+            "Count": 1,
+            "Quality": 0
+          },
+          "Flags": 0
+        },
+        "initialResourceState": 2755,
+        "clearValue": {}
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacec6d0",
+      "tid": 16484,
+      "ts": 211805,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 0,
+          "SubAllocatedRefs": 4
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacec6d0",
+      "tid": 16484,
+      "ts": 211875,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 4194304,
+          "IsResident": 1,
+          "MemorySegmentGroup": 0,
+          "SubAllocatedRefs": 4
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22abacdc5e0",
+      "tid": 16484,
+      "ts": 211878,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryAllocation",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacdc5e0",
+      "tid": 16484,
+      "ts": 211892,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9702,92 +14182,36 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332bbf160"
+            "id_ref": "0x22abacec6d0"
           }
         }
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 297063,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 297106,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332bbd8a0",
-      "tid": 18876,
-      "ts": 297107,
+      "id": "0x22abaceb7a0",
+      "tid": 16484,
+      "ts": 211947,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332764e70",
-      "tid": 18876,
-      "ts": 351450,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 351456,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 351510,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 351510,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 351512,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 351514,
+      "id": "0x22abad05d10",
+      "tid": 16484,
+      "ts": 217414,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710c08",
-      "tid": 18876,
-      "ts": 351536,
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 217493,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9799,125 +14223,45 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332bbdae0",
-      "tid": 18876,
-      "ts": 351540,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 351541,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 351542,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 351548,
+      "id": "0x22abacea7e0",
+      "tid": 16484,
+      "ts": 217496,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332764bb0",
-      "tid": 18876,
-      "ts": 351673,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 351676,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 351713,
+      "id": "0x22abacdbf00",
+      "tid": 16484,
+      "ts": 217730,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332bbe3e0",
-      "tid": 18876,
-      "ts": 351713,
+      "id": "0x22abaceba70",
+      "tid": 16484,
+      "ts": 217759,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332763710",
-      "tid": 18876,
-      "ts": 351891,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 351893,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 351961,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 351961,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 351962,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 351963,
+      "id": "0x22abacefb40",
+      "tid": 16484,
+      "ts": 217920,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710c08",
-      "tid": 18876,
-      "ts": 351976,
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 217985,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -9929,239 +14273,63 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332bbeb30",
-      "tid": 18876,
-      "ts": 351978,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 351979,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 351979,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 351984,
+      "id": "0x22abaceae10",
+      "tid": 16484,
+      "ts": 217988,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x293327654a0",
-      "tid": 18876,
-      "ts": 352112,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 352113,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 352153,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 352153,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 352154,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 352155,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 352155,
+      "id": "0x22abacef250",
+      "tid": 16484,
+      "ts": 218144,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x2933274ed90",
-      "tid": 18876,
-      "ts": 352172,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 352174,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 352196,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 352197,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 352197,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 352198,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 352198,
+      "id": "0x22abacd37f0",
+      "tid": 16484,
+      "ts": 218230,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x2933274e1e0",
-      "tid": 18876,
-      "ts": 352199,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 352200,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 352215,
+      "id": "0x22abacd3690",
+      "tid": 16484,
+      "ts": 218307,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332bbdc90",
-      "tid": 18876,
-      "ts": 352216,
+      "id": "0x22abacca350",
+      "tid": 16484,
+      "ts": 218329,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x2933274e810",
-      "tid": 18876,
-      "ts": 352341,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 352360,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 352434,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 352434,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 352435,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 352436,
+      "id": "0x22abacd4240",
+      "tid": 16484,
+      "ts": 218473,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710c08",
-      "tid": 18876,
-      "ts": 352461,
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 218537,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10173,91 +14341,27 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332bbe080",
-      "tid": 18876,
-      "ts": 352463,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 352464,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 352464,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 352468,
+      "id": "0x22abacebcb0",
+      "tid": 16484,
+      "ts": 218540,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332763d40",
-      "tid": 18876,
-      "ts": 352589,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 352590,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 352657,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 352657,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 352658,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 352659,
+      "id": "0x22abad06fa0",
+      "tid": 16484,
+      "ts": 218689,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710208",
-      "tid": 18876,
-      "ts": 352668,
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 218750,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10269,205 +14373,45 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332bbdc00",
-      "tid": 18876,
-      "ts": 352670,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 352671,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 352671,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 352676,
+      "id": "0x22abacc9a50",
+      "tid": 16484,
+      "ts": 218752,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x2933274f730",
-      "tid": 18876,
-      "ts": 352818,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 352819,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 352858,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 352859,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 352860,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 352860,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 352876,
+      "id": "0x22abacd3740",
+      "tid": 16484,
+      "ts": 218900,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332771670",
-      "tid": 18876,
-      "ts": 352878,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 352878,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 352901,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 352901,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 352902,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 352902,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 352902,
+      "id": "0x22abad066b0",
+      "tid": 16484,
+      "ts": 218982,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332770ee0",
-      "tid": 18876,
-      "ts": 352903,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 352904,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 352939,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 352940,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 352940,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 352941,
+      "id": "0x22abad05840",
+      "tid": 16484,
+      "ts": 219056,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710208",
-      "tid": 18876,
-      "ts": 352950,
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 219113,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10479,205 +14423,45 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332bbe980",
-      "tid": 18876,
-      "ts": 352952,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 352953,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 352953,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 352957,
+      "id": "0x22abaceb560",
+      "tid": 16484,
+      "ts": 219115,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x2933274f470",
-      "tid": 18876,
-      "ts": 353098,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 353099,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 353138,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 353138,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 353139,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 353140,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 353140,
+      "id": "0x22abad07260",
+      "tid": 16484,
+      "ts": 219259,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332771f60",
-      "tid": 18876,
-      "ts": 353157,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 353157,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 353180,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 353180,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 353180,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 353181,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 353181,
+      "id": "0x22abacdc5e0",
+      "tid": 16484,
+      "ts": 219340,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332771930",
-      "tid": 18876,
-      "ts": 353182,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 353183,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 353217,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 353217,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 353218,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 353218,
+      "id": "0x22abad06a20",
+      "tid": 16484,
+      "ts": 219415,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710208",
-      "tid": 18876,
-      "ts": 353231,
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 219475,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -10689,131 +14473,99 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332bbf160",
-      "tid": 18876,
-      "ts": 353233,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 353233,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 353234,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 353237,
+      "id": "0x22abacec6d0",
+      "tid": 16484,
+      "ts": 219477,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x2933274f940",
-      "tid": 18876,
-      "ts": 353391,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 353392,
+      "id": "0x22abad06ad0",
+      "tid": 16484,
+      "ts": 219628,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "D",
-      "id": "0x2932f64b240",
-      "tid": 18876,
-      "ts": 353418,
+      "id": "0x22abacb4800",
+      "tid": 16484,
+      "ts": 219643,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332710a08",
-      "tid": 18876,
-      "ts": 353428,
+      "id": "0x22abadfba48",
+      "tid": 16484,
+      "ts": 219659,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332710208",
-      "tid": 18876,
-      "ts": 353449,
+      "id": "0x22abadfbc48",
+      "tid": 16484,
+      "ts": 219681,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332710c08",
-      "tid": 18876,
-      "ts": 353452,
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 219702,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332710d08",
-      "tid": 18876,
-      "ts": 353454,
+      "id": "0x22abadfb748",
+      "tid": 16484,
+      "ts": 219724,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332710308",
-      "tid": 18876,
-      "ts": 353457,
+      "id": "0x22abadfa748",
+      "tid": 16484,
+      "ts": 219742,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332710e08",
-      "tid": 18876,
-      "ts": 353460,
+      "id": "0x22abadfb548",
+      "tid": 16484,
+      "ts": 219760,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332710508",
-      "tid": 18876,
-      "ts": 353462,
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 219777,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332710f08",
-      "tid": 18876,
-      "ts": 353464,
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 219856,
       "pid": "GPGMM"
     }
   ]

--- a/src/tests/capture_replay_tests/traces/webnn_end2end_mobilenetv2nchwtests_nchwtest0.json
+++ b/src/tests/capture_replay_tests/traces/webnn_end2end_mobilenetv2nchwtests_nchwtest0.json
@@ -5,94 +5,8622 @@
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "N",
-      "id": "0x2932f64b8e0",
-      "tid": 18876,
-      "ts": 387364,
+      "id": "0x22abadf0600",
+      "tid": 16484,
+      "ts": 360853,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332710b08",
-      "tid": 18876,
-      "ts": 387380,
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 360866,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "N",
-      "id": "0x29332710a08",
-      "tid": 18876,
-      "ts": 387394,
-      "pid": "GPGMM"
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 360928,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 360952,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 360983,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 360997,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361014,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 361045,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361065,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361082,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 361105,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361118,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361145,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 361168,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361181,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361197,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 361220,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361233,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361250,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 361273,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361286,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361302,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 361344,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361357,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361374,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 361396,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361409,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361426,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 361449,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361461,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361483,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 361507,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361520,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361536,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 361559,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361571,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361588,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 361611,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361624,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361640,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 361662,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361676,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361728,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 361751,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361764,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361781,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 361803,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361816,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361833,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 361855,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361868,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361884,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 361907,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361924,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361941,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 361964,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361982,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 361999,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 362021,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 362038,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 362055,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 362077,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 362093,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 362110,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 362132,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 362150,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 362166,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 362189,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 362205,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 362221,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 362238,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 362260,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 362277,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 362294,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 362310,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 362327,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 362343,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 362360,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 362376,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 362392,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 362409,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 362425,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 362441,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332710708",
-      "tid": 18876,
-      "ts": 387410,
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 362448,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "N",
-      "id": "0x29332710d08",
-      "tid": 18876,
-      "ts": 387416,
-      "pid": "GPGMM"
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 362471,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 362488,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 362512,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 362525,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 362542,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 362601,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 362615,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 362632,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 362654,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 362667,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 362684,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 362706,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 362719,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 362736,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 362758,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 362771,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 362788,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 362810,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 362823,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 362840,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 362862,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 362875,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 362892,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 362914,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 362927,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 362943,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 362966,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 362979,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 362995,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 363017,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 363030,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 363047,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 363069,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 363082,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 363099,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 363121,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 363134,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 363151,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 363173,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 363186,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 363203,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 363225,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 363238,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 363254,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 363277,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 363290,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 363306,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 363328,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 363341,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 363358,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 363380,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 363398,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 363414,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 363437,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 363454,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 363472,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 363495,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 363511,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 363528,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 363550,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 363567,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 363583,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 363606,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 363625,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 363642,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 363664,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 363680,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 363697,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 363713,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 363735,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 363752,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 363769,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 363785,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 363802,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 363818,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 363834,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 363851,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 363867,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 363884,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 363900,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 364054,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332710908",
-      "tid": 18876,
-      "ts": 387425,
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 364062,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "N",
-      "id": "0x29332710208",
-      "tid": 18876,
-      "ts": 387439,
-      "pid": "GPGMM"
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 364099,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 364117,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 364142,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 364155,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 364172,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 364195,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 364208,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 364224,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 364247,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 364260,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 364277,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 364437,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 364451,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 364470,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 364533,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 364549,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 364617,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 364643,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 364667,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 364695,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 364767,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 364792,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 364810,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 364872,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 364887,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 364903,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 364926,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 364939,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 364956,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 364979,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 364992,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 365008,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 365031,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 365044,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 365060,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 365083,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 365096,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 365112,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 365135,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 365148,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 365164,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 365187,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 365200,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 365217,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 365239,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 365252,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 365268,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 365291,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 365304,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 365320,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 365343,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 365362,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 365378,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 365401,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 365419,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 365436,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 365458,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 365487,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 365504,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 365527,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 365544,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 365561,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 365584,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 365602,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 365619,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 365653,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 365669,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 365686,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 365703,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 365725,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 365742,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 365759,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 365776,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 365793,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 365809,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 365826,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 365842,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 365859,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 365875,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 365892,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 365908,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332710e08",
-      "tid": 18876,
-      "ts": 387445,
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 365915,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 365936,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 365954,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 365977,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 365991,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366007,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 366030,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366043,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366060,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 366083,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366096,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366112,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 366135,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366148,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366164,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 366187,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366200,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366216,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 366239,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366252,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366268,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 366291,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366303,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366320,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 366343,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366355,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366372,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 366394,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366407,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366424,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 366447,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366460,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366478,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 366500,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366513,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366530,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 366552,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366565,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366581,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 366604,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366617,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366634,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 366656,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366669,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366686,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 366708,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366721,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366738,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 366761,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366774,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366791,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 366813,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366832,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366849,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 366871,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366889,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366906,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 366930,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366947,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 366964,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 366987,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 367004,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 367021,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 367044,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 367061,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 367078,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 367151,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 367171,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 367199,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 367216,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 367238,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 367255,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 367272,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 367289,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 367305,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 367322,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 367338,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 367355,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 367371,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 367387,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 367404,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 367420,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
       "ph": "N",
-      "id": "0x29332710c08",
-      "tid": 18876,
-      "ts": 387450,
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 367427,
       "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 367448,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 367467,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 367490,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 367503,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 367520,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 367543,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 367556,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 367572,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 367595,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 367608,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 367624,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 367647,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 367660,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 367676,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 367699,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 367712,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 367728,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 367751,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 367764,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 367780,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 367803,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 367816,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 368091,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 368115,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 368129,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 368145,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 368168,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 368181,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 368198,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 368220,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 368233,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 368249,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 368272,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 368285,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 368301,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 368324,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 368337,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 368354,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 368376,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 368389,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 368405,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 368428,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 368441,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 368458,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 368481,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 368494,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 368511,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 368534,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 368546,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 368563,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 368585,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 368602,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 368619,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 368642,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 368659,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 368676,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 368698,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 368714,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 368731,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 368754,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 368770,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 368787,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 368809,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 368827,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 368844,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 368866,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 368882,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 368899,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 368915,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 368937,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 368954,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 368976,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 368993,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 369010,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 369026,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 369043,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 369059,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 369076,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 369092,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 369108,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 369125,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 369131,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 369153,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 369171,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 369194,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 369207,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 369224,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 369247,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 369260,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 369277,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 369299,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 369312,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 369329,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 369352,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 369364,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 369392,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 369415,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 369429,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 369446,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 369470,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 369484,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 369501,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 369524,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 369537,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 369554,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 369577,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 369601,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 369618,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 369640,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 369653,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 369670,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 369692,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 369705,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 369722,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 369745,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 369757,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 369774,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 369797,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 369810,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 369826,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 369849,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 369867,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 369884,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 369907,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 369920,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 369936,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 369959,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 369972,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 369988,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 370011,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 370024,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 370041,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 370063,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 370080,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 370097,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 370120,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 370137,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 370154,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 370177,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 370193,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 370210,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 370233,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 370249,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 370266,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 370289,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 370306,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 370322,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 370345,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 370361,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 370377,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 370394,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 370420,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 370438,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 370456,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 370474,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 370492,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 370509,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 370526,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 370543,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 370560,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 370577,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 370606,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 370624,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 370631,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 370655,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 370673,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 370698,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 370711,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 370728,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 370751,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 370765,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 370782,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 370805,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 370819,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 370836,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 370859,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 370872,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 370889,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 370912,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 370925,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 370942,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 370966,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 370979,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 370996,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 371019,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 371033,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 371049,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 371072,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 371086,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 371103,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 371126,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 371139,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 371156,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 371179,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 371192,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 371209,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 371233,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 371246,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 371263,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 371286,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 371299,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 371327,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 371365,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 371378,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 371396,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 371419,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 371432,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 371449,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 371474,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 371488,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 371505,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 371528,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 371541,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 371558,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 371581,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 371598,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 371616,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 371639,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 371667,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 371684,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 371719,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 371736,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 371753,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 371802,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 371820,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 371837,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 371860,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 371878,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 371896,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 371919,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 371936,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 371953,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 371970,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 371992,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 372009,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 372027,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 372043,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 372061,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 372078,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 372096,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 372113,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 372132,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 372149,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 372177,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 372209,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 372216,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 372239,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 372268,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 372302,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 372316,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 372332,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 372355,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 372368,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 372385,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 372407,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 372421,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 372437,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 372460,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 372474,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 372491,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 372513,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 372527,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 372544,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 372566,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 372579,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 372596,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 372618,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 372631,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 372648,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 372671,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 372684,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 372739,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 372765,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 372783,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 372800,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 372823,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 372836,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 372853,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 372875,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 372888,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 372905,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 372928,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 372941,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 372958,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 372980,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 372993,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 373010,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 373032,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 373045,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 373062,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 373085,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 373098,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 373114,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 373136,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 373149,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 373166,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 373189,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 373206,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 373223,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 373245,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 373263,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 373280,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 373303,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 373318,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 373335,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 373358,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 373374,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 373390,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 373413,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 373430,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 373447,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 373483,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 373500,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 373517,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 373534,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 373556,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 373573,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 373590,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 373607,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 373623,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 373640,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 373656,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 373673,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 373689,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 373706,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 373722,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 373738,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
     },
     {
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 387497,
+      "tid": 16484,
+      "ts": 373767,
       "pid": "GPGMM",
       "args": {
         "Flags": 0,
         "RecordOptions": {
-          "Flags": 1
+          "Flags": 6
         },
         "IsUMA": 1,
         "ResourceHeapTier": 2,
@@ -107,8 +8635,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 387570,
+      "tid": 16484,
+      "ts": 373829,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -135,27 +8663,11 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 387572,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 387574,
-      "pid": "GPGMM"
-    },
-    {
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 387593,
+      "tid": 16484,
+      "ts": 373848,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -163,19 +8675,11 @@
       }
     },
     {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 387596,
-      "pid": "GPGMM"
-    },
-    {
       "name": "ResourceAllocator.TryAllocateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 387608,
+      "tid": 16484,
+      "ts": 373862,
       "pid": "GPGMM",
       "args": {
         "Description": "Resource memory could not be allocated.",
@@ -183,41 +8687,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "i",
-      "tid": 18876,
-      "ts": 387621,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Suballocation was attempted but failed.",
-        "ID": 1
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 387626,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332716030",
-      "tid": 18876,
-      "ts": 389771,
+      "id": "0x22abadcdd00",
+      "tid": 16484,
+      "ts": 374853,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332716030",
-      "tid": 18876,
-      "ts": 389823,
+      "id": "0x22abadcdd00",
+      "tid": 16484,
+      "ts": 374876,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -232,34 +8716,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332716030",
-      "tid": 18876,
-      "ts": 389845,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 16777216,
-          "IsResident": 1,
-          "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 0
-        }
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 389847,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x29332716030",
-      "tid": 18876,
-      "ts": 389863,
+      "id": "0x22abadcdd00",
+      "tid": 16484,
+      "ts": 374897,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -274,9 +8733,26 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332716030",
-      "tid": 18876,
-      "ts": 389904,
+      "id": "0x22abadcdd00",
+      "tid": 16484,
+      "ts": 374913,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 16777216,
+          "IsResident": 1,
+          "MemorySegmentGroup": 0,
+          "SubAllocatedRefs": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadcdd00",
+      "tid": 16484,
+      "ts": 374991,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -291,18 +8767,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332744220",
-      "tid": 18876,
-      "ts": 389906,
+      "id": "0x22abadd27c0",
+      "tid": 16484,
+      "ts": 374994,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332744220",
-      "tid": 18876,
-      "ts": 389922,
+      "id": "0x22abadd27c0",
+      "tid": 16484,
+      "ts": 375010,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -311,7 +8787,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x29332716030"
+            "id_ref": "0x22abadcdd00"
           }
         }
       }
@@ -319,17 +8795,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 389924,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 390051,
+      "tid": 16484,
+      "ts": 375123,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -356,27 +8824,11 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 390053,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 390055,
-      "pid": "GPGMM"
-    },
-    {
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 390074,
+      "tid": 16484,
+      "ts": 375142,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -384,19 +8836,11 @@
       }
     },
     {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 390076,
-      "pid": "GPGMM"
-    },
-    {
       "name": "ResourceAllocator.TryAllocateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 390088,
+      "tid": 16484,
+      "ts": 375157,
       "pid": "GPGMM",
       "args": {
         "Description": "Resource memory could not be allocated.",
@@ -404,41 +8848,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "i",
-      "tid": 18876,
-      "ts": 390113,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Suballocation was attempted but failed.",
-        "ID": 1
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 390116,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332715b20",
-      "tid": 18876,
-      "ts": 392847,
+      "id": "0x22abadcd9a0",
+      "tid": 16484,
+      "ts": 376063,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332715b20",
-      "tid": 18876,
-      "ts": 392886,
+      "id": "0x22abadcd9a0",
+      "tid": 16484,
+      "ts": 376083,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -453,34 +8877,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332715b20",
-      "tid": 18876,
-      "ts": 392905,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 16777216,
-          "IsResident": 1,
-          "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 0
-        }
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 392907,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x29332715b20",
-      "tid": 18876,
-      "ts": 392922,
+      "id": "0x22abadcd9a0",
+      "tid": 16484,
+      "ts": 376101,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -495,9 +8894,26 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332715b20",
-      "tid": 18876,
-      "ts": 392955,
+      "id": "0x22abadcd9a0",
+      "tid": 16484,
+      "ts": 376117,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 16777216,
+          "IsResident": 1,
+          "MemorySegmentGroup": 0,
+          "SubAllocatedRefs": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadcd9a0",
+      "tid": 16484,
+      "ts": 376189,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -512,18 +8928,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x293327433b0",
-      "tid": 18876,
-      "ts": 392958,
+      "id": "0x22abadd2240",
+      "tid": 16484,
+      "ts": 376191,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327433b0",
-      "tid": 18876,
-      "ts": 392973,
+      "id": "0x22abadd2240",
+      "tid": 16484,
+      "ts": 376207,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -532,7 +8948,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x29332715b20"
+            "id_ref": "0x22abadcd9a0"
           }
         }
       }
@@ -540,17 +8956,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 392975,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 393084,
+      "tid": 16484,
+      "ts": 376312,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -577,44 +8985,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 393086,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 393088,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 393096,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 393101,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710708",
-      "tid": 18876,
-      "ts": 393115,
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 376327,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -623,29 +8999,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 393117,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332716150",
-      "tid": 18876,
-      "ts": 393775,
+      "id": "0x22abadcd250",
+      "tid": 16484,
+      "ts": 376645,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332716150",
-      "tid": 18876,
-      "ts": 393794,
+      "id": "0x22abadcd250",
+      "tid": 16484,
+      "ts": 376665,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -660,9 +9028,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332716150",
-      "tid": 18876,
-      "ts": 393809,
+      "id": "0x22abadcd250",
+      "tid": 16484,
+      "ts": 376682,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -674,20 +9042,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 393811,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710708",
-      "tid": 18876,
-      "ts": 393817,
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 376691,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -696,36 +9056,12 @@
       }
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 393820,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 393822,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 393822,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332716150",
-      "tid": 18876,
-      "ts": 393835,
+      "id": "0x22abadcd250",
+      "tid": 16484,
+      "ts": 376711,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -740,9 +9076,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332716150",
-      "tid": 18876,
-      "ts": 393857,
+      "id": "0x22abadcd250",
+      "tid": 16484,
+      "ts": 376784,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -757,18 +9093,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x293327430f0",
-      "tid": 18876,
-      "ts": 393860,
+      "id": "0x22abadd3000",
+      "tid": 16484,
+      "ts": 376787,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327430f0",
-      "tid": 18876,
-      "ts": 393874,
+      "id": "0x22abadd3000",
+      "tid": 16484,
+      "ts": 376802,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -777,7 +9113,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332716150"
+            "id_ref": "0x22abadcd250"
           }
         }
       }
@@ -785,17 +9121,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 393876,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 393984,
+      "tid": 16484,
+      "ts": 376917,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -822,27 +9150,11 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 393998,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 393999,
-      "pid": "GPGMM"
-    },
-    {
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 394018,
+      "tid": 16484,
+      "ts": 376936,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -850,19 +9162,11 @@
       }
     },
     {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 394020,
-      "pid": "GPGMM"
-    },
-    {
       "name": "ResourceAllocator.TryAllocateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 394032,
+      "tid": 16484,
+      "ts": 376951,
       "pid": "GPGMM",
       "args": {
         "Description": "Resource memory could not be allocated.",
@@ -870,41 +9174,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "i",
-      "tid": 18876,
-      "ts": 394045,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Suballocation was attempted but failed.",
-        "ID": 1
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 394047,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332715bb0",
-      "tid": 18876,
-      "ts": 399525,
+      "id": "0x22abadccdd0",
+      "tid": 16484,
+      "ts": 377102,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332715bb0",
-      "tid": 18876,
-      "ts": 399568,
+      "id": "0x22abadccdd0",
+      "tid": 16484,
+      "ts": 377122,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -919,34 +9203,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332715bb0",
-      "tid": 18876,
-      "ts": 399589,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 16777216,
-          "IsResident": 1,
-          "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 0
-        }
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 399590,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x29332715bb0",
-      "tid": 18876,
-      "ts": 399606,
+      "id": "0x22abadccdd0",
+      "tid": 16484,
+      "ts": 377140,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -961,9 +9220,26 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332715bb0",
-      "tid": 18876,
-      "ts": 399644,
+      "id": "0x22abadccdd0",
+      "tid": 16484,
+      "ts": 377156,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 16777216,
+          "IsResident": 1,
+          "MemorySegmentGroup": 0,
+          "SubAllocatedRefs": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadccdd0",
+      "tid": 16484,
+      "ts": 377226,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -978,18 +9254,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332744170",
-      "tid": 18876,
-      "ts": 399646,
+      "id": "0x22ababc70e0",
+      "tid": 16484,
+      "ts": 377229,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332744170",
-      "tid": 18876,
-      "ts": 399661,
+      "id": "0x22ababc70e0",
+      "tid": 16484,
+      "ts": 377245,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -998,59 +9274,35 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x29332715bb0"
+            "id_ref": "0x22abadccdd0"
           }
         }
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 399664,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 399743,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332716030",
-      "tid": 18876,
-      "ts": 399745,
+      "id": "0x22abadcdd00",
+      "tid": 16484,
+      "ts": 377320,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332744220",
-      "tid": 18876,
-      "ts": 399926,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 399927,
+      "id": "0x22abadd27c0",
+      "tid": 16484,
+      "ts": 377492,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 399983,
+      "tid": 16484,
+      "ts": 377549,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1077,44 +9329,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 399985,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 399987,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 399994,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 399999,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710a08",
-      "tid": 18876,
-      "ts": 400014,
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 377566,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1123,29 +9343,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 400017,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332715970",
-      "tid": 18876,
-      "ts": 400737,
+      "id": "0x22abadcd520",
+      "tid": 16484,
+      "ts": 377882,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332715970",
-      "tid": 18876,
-      "ts": 400756,
+      "id": "0x22abadcd520",
+      "tid": 16484,
+      "ts": 377902,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1160,9 +9372,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332715970",
-      "tid": 18876,
-      "ts": 400772,
+      "id": "0x22abadcd520",
+      "tid": 16484,
+      "ts": 377922,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1174,20 +9386,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 400774,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710a08",
-      "tid": 18876,
-      "ts": 400781,
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 377931,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1196,36 +9400,12 @@
       }
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 400784,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 400786,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 400787,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332715970",
-      "tid": 18876,
-      "ts": 400799,
+      "id": "0x22abadcd520",
+      "tid": 16484,
+      "ts": 377950,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1240,9 +9420,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332715970",
-      "tid": 18876,
-      "ts": 400824,
+      "id": "0x22abadcd520",
+      "tid": 16484,
+      "ts": 378020,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1257,18 +9437,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332744c70",
-      "tid": 18876,
-      "ts": 400826,
+      "id": "0x22ababb58f0",
+      "tid": 16484,
+      "ts": 378023,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332744c70",
-      "tid": 18876,
-      "ts": 400841,
+      "id": "0x22ababb58f0",
+      "tid": 16484,
+      "ts": 378038,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1277,59 +9457,35 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332715970"
+            "id_ref": "0x22abadcd520"
           }
         }
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 400843,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 400920,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332715b20",
-      "tid": 18876,
-      "ts": 400921,
+      "id": "0x22abadcd9a0",
+      "tid": 16484,
+      "ts": 378121,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x293327433b0",
-      "tid": 18876,
-      "ts": 401077,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 401079,
+      "id": "0x22abadd2240",
+      "tid": 16484,
+      "ts": 378266,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 401132,
+      "tid": 16484,
+      "ts": 378323,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1356,44 +9512,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 401134,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 401135,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 401139,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 401142,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710708",
-      "tid": 18876,
-      "ts": 401151,
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 378338,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1402,29 +9526,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 401154,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332716390",
-      "tid": 18876,
-      "ts": 401782,
+      "id": "0x22abadccb00",
+      "tid": 16484,
+      "ts": 378651,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332716390",
-      "tid": 18876,
-      "ts": 401801,
+      "id": "0x22abadccb00",
+      "tid": 16484,
+      "ts": 378671,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1439,9 +9555,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332716390",
-      "tid": 18876,
-      "ts": 401816,
+      "id": "0x22abadccb00",
+      "tid": 16484,
+      "ts": 378688,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1453,20 +9569,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 401818,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710708",
-      "tid": 18876,
-      "ts": 401825,
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 378697,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1475,36 +9583,12 @@
       }
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 401828,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 401829,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 401830,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332716390",
-      "tid": 18876,
-      "ts": 401843,
+      "id": "0x22abadccb00",
+      "tid": 16484,
+      "ts": 378717,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1519,9 +9603,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332716390",
-      "tid": 18876,
-      "ts": 401866,
+      "id": "0x22abadccb00",
+      "tid": 16484,
+      "ts": 378787,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1536,18 +9620,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332743bf0",
-      "tid": 18876,
-      "ts": 401869,
+      "id": "0x22ababb5210",
+      "tid": 16484,
+      "ts": 378790,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332743bf0",
-      "tid": 18876,
-      "ts": 401883,
+      "id": "0x22ababb5210",
+      "tid": 16484,
+      "ts": 378805,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1556,7 +9640,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332716390"
+            "id_ref": "0x22abadccb00"
           }
         }
       }
@@ -1564,17 +9648,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 401885,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 402005,
+      "tid": 16484,
+      "ts": 378916,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1601,44 +9677,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 402008,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 402009,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 402014,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 402019,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710b08",
-      "tid": 18876,
-      "ts": 402031,
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 378934,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1647,29 +9691,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 402033,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332714b60",
-      "tid": 18876,
-      "ts": 402659,
+      "id": "0x22abadcc200",
+      "tid": 16484,
+      "ts": 379247,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332714b60",
-      "tid": 18876,
-      "ts": 402678,
+      "id": "0x22abadcc200",
+      "tid": 16484,
+      "ts": 379266,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1684,9 +9720,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332714b60",
-      "tid": 18876,
-      "ts": 402694,
+      "id": "0x22abadcc200",
+      "tid": 16484,
+      "ts": 379283,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1698,20 +9734,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 402695,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710b08",
-      "tid": 18876,
-      "ts": 402702,
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 379292,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1720,36 +9748,12 @@
       }
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 402705,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 402706,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 402707,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332714b60",
-      "tid": 18876,
-      "ts": 402719,
+      "id": "0x22abadcc200",
+      "tid": 16484,
+      "ts": 379313,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1764,9 +9768,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332714b60",
-      "tid": 18876,
-      "ts": 402743,
+      "id": "0x22abadcc200",
+      "tid": 16484,
+      "ts": 379382,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1781,18 +9785,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332743510",
-      "tid": 18876,
-      "ts": 402745,
+      "id": "0x22ababb5420",
+      "tid": 16484,
+      "ts": 379385,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332743510",
-      "tid": 18876,
-      "ts": 402759,
+      "id": "0x22ababb5420",
+      "tid": 16484,
+      "ts": 379400,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1801,7 +9805,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332714b60"
+            "id_ref": "0x22abadcc200"
           }
         }
       }
@@ -1809,17 +9813,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 402762,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 402864,
+      "tid": 16484,
+      "ts": 379514,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1846,52 +9842,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 402866,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 402867,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 402868,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 402871,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 402872,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332716150",
-      "tid": 18876,
-      "ts": 402884,
+      "id": "0x22abadcd250",
+      "tid": 16484,
+      "ts": 379535,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1906,9 +9862,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332716150",
-      "tid": 18876,
-      "ts": 402907,
+      "id": "0x22abadcd250",
+      "tid": 16484,
+      "ts": 379606,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1923,18 +9879,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x293327495f0",
-      "tid": 18876,
-      "ts": 402916,
+      "id": "0x22ababb5580",
+      "tid": 16484,
+      "ts": 379608,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327495f0",
-      "tid": 18876,
-      "ts": 402931,
+      "id": "0x22ababb5580",
+      "tid": 16484,
+      "ts": 379623,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1943,82 +9899,26 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332716150"
+            "id_ref": "0x22abadcd250"
           }
         }
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 402933,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 402986,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 402987,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 402988,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 402988,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 402989,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x293327430f0",
-      "tid": 18876,
-      "ts": 402992,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 402993,
+      "id": "0x22abadd3000",
+      "tid": 16484,
+      "ts": 379739,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 403039,
+      "tid": 16484,
+      "ts": 379792,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -2045,27 +9945,11 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 403040,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 403041,
-      "pid": "GPGMM"
-    },
-    {
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 403059,
+      "tid": 16484,
+      "ts": 379812,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -2073,19 +9957,11 @@
       }
     },
     {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 403061,
-      "pid": "GPGMM"
-    },
-    {
       "name": "ResourceAllocator.TryAllocateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 403074,
+      "tid": 16484,
+      "ts": 379826,
       "pid": "GPGMM",
       "args": {
         "Description": "Resource memory could not be allocated.",
@@ -2093,41 +9969,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "i",
-      "tid": 18876,
-      "ts": 403087,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Suballocation was attempted but failed.",
-        "ID": 1
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 403089,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332715190",
-      "tid": 18876,
-      "ts": 405276,
+      "id": "0x22abadcd130",
+      "tid": 16484,
+      "ts": 380945,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332715190",
-      "tid": 18876,
-      "ts": 405316,
+      "id": "0x22abadcd130",
+      "tid": 16484,
+      "ts": 380967,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2142,34 +9998,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332715190",
-      "tid": 18876,
-      "ts": 405336,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "Size": 16777216,
-          "IsResident": 1,
-          "MemorySegmentGroup": 0,
-          "SubAllocatedRefs": 0
-        }
-      }
-    },
-    {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 405338,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryBlock",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x29332715190",
-      "tid": 18876,
-      "ts": 405353,
+      "id": "0x22abadcd130",
+      "tid": 16484,
+      "ts": 380985,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2184,9 +10015,26 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332715190",
-      "tid": 18876,
-      "ts": 405389,
+      "id": "0x22abadcd130",
+      "tid": 16484,
+      "ts": 381001,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "Size": 16777216,
+          "IsResident": 1,
+          "MemorySegmentGroup": 0,
+          "SubAllocatedRefs": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryBlock",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadcd130",
+      "tid": 16484,
+      "ts": 381075,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2201,18 +10049,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x2933274a3b0",
-      "tid": 18876,
-      "ts": 405392,
+      "id": "0x22ababb5fd0",
+      "tid": 16484,
+      "ts": 381078,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x2933274a3b0",
-      "tid": 18876,
-      "ts": 405406,
+      "id": "0x22ababb5fd0",
+      "tid": 16484,
+      "ts": 381094,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2221,126 +10069,54 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x29332715190"
+            "id_ref": "0x22abadcd130"
           }
         }
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 405409,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 405491,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332715bb0",
-      "tid": 18876,
-      "ts": 405492,
+      "id": "0x22abadccdd0",
+      "tid": 16484,
+      "ts": 381175,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332744170",
-      "tid": 18876,
-      "ts": 405652,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 405654,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 405673,
+      "id": "0x22ababc70e0",
+      "tid": 16484,
+      "ts": 381401,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332715190",
-      "tid": 18876,
-      "ts": 405673,
+      "id": "0x22abadcd130",
+      "tid": 16484,
+      "ts": 381427,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x2933274a3b0",
-      "tid": 18876,
-      "ts": 405803,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 405805,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 405844,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 405845,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 405847,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 405848,
+      "id": "0x22ababb5fd0",
+      "tid": 16484,
+      "ts": 381589,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710708",
-      "tid": 18876,
-      "ts": 405859,
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 381665,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2352,91 +10128,27 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332716150",
-      "tid": 18876,
-      "ts": 405862,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 405863,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 405863,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 405870,
+      "id": "0x22abadcd250",
+      "tid": 16484,
+      "ts": 381667,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x293327495f0",
-      "tid": 18876,
-      "ts": 405993,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 405994,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 406035,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 406035,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 406036,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 406037,
+      "id": "0x22ababb5580",
+      "tid": 16484,
+      "ts": 381854,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710708",
-      "tid": 18876,
-      "ts": 406051,
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 381916,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2448,91 +10160,27 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332716390",
-      "tid": 18876,
-      "ts": 406053,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 406054,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 406054,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 406059,
+      "id": "0x22abadccb00",
+      "tid": 16484,
+      "ts": 381919,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332743bf0",
-      "tid": 18876,
-      "ts": 406180,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 406181,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 406221,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 406222,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 406223,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 406224,
+      "id": "0x22ababb5210",
+      "tid": 16484,
+      "ts": 382083,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710b08",
-      "tid": 18876,
-      "ts": 406237,
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 382148,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2544,91 +10192,27 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332714b60",
-      "tid": 18876,
-      "ts": 406239,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 406240,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 406240,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 406244,
+      "id": "0x22abadcc200",
+      "tid": 16484,
+      "ts": 382150,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332743510",
-      "tid": 18876,
-      "ts": 406366,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 406368,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 406408,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 406408,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 406409,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 406410,
+      "id": "0x22ababb5420",
+      "tid": 16484,
+      "ts": 382351,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332710a08",
-      "tid": 18876,
-      "ts": 406423,
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 382413,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2640,131 +10224,99 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332715970",
-      "tid": 18876,
-      "ts": 406425,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 406426,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 406426,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 406430,
+      "id": "0x22abadcd520",
+      "tid": 16484,
+      "ts": 382416,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332744c70",
-      "tid": 18876,
-      "ts": 406560,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 406561,
+      "id": "0x22ababb58f0",
+      "tid": 16484,
+      "ts": 382586,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "D",
-      "id": "0x2932f64b8e0",
-      "tid": 18876,
-      "ts": 406574,
+      "id": "0x22abadf0600",
+      "tid": 16484,
+      "ts": 382601,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332710b08",
-      "tid": 18876,
-      "ts": 406582,
+      "id": "0x22abadfa848",
+      "tid": 16484,
+      "ts": 382617,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332710a08",
-      "tid": 18876,
-      "ts": 406587,
+      "id": "0x22abadfa348",
+      "tid": 16484,
+      "ts": 382641,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332710708",
-      "tid": 18876,
-      "ts": 406590,
+      "id": "0x22abadfa948",
+      "tid": 16484,
+      "ts": 382660,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332710d08",
-      "tid": 18876,
-      "ts": 406592,
+      "id": "0x22abadfaa48",
+      "tid": 16484,
+      "ts": 382678,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332710908",
-      "tid": 18876,
-      "ts": 406595,
+      "id": "0x22abadfb048",
+      "tid": 16484,
+      "ts": 382695,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332710208",
-      "tid": 18876,
-      "ts": 406597,
+      "id": "0x22abadfb148",
+      "tid": 16484,
+      "ts": 382713,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332710e08",
-      "tid": 18876,
-      "ts": 406600,
+      "id": "0x22abadfae48",
+      "tid": 16484,
+      "ts": 382730,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332710c08",
-      "tid": 18876,
-      "ts": 406602,
+      "id": "0x22abadfab48",
+      "tid": 16484,
+      "ts": 382747,
       "pid": "GPGMM"
     }
   ]

--- a/src/tests/capture_replay_tests/traces/webnn_mobilenetv2_nchw.json
+++ b/src/tests/capture_replay_tests/traces/webnn_mobilenetv2_nchw.json
@@ -5,94 +5,13958 @@
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "N",
-      "id": "0x2932f64b8e0",
-      "tid": 18876,
-      "ts": 433948,
+      "id": "0x22abadf1280",
+      "tid": 16484,
+      "ts": 499841,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x2932f6ef2a8",
-      "tid": 18876,
-      "ts": 433962,
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 499865,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "N",
-      "id": "0x2932f6ee6a8",
-      "tid": 18876,
-      "ts": 433971,
-      "pid": "GPGMM"
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 499913,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x2932f6eeaa8",
-      "tid": 18876,
-      "ts": 433980,
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 499917,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "N",
-      "id": "0x2932f6ef4a8",
-      "tid": 18876,
-      "ts": 433985,
-      "pid": "GPGMM"
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 499924,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 499947,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 499957,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 499987,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 500002,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 500013,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 500032,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 500039,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 500065,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 500080,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 500087,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 500112,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 500119,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 500144,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 500159,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 500166,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 500185,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 500192,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 500217,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 500232,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 500239,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 500257,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 500265,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 500289,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 500316,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 500324,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 500342,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 500350,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 500375,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 500391,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 500397,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 500414,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 500420,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 500443,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 500456,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 500463,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 500479,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 500485,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 500508,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 500521,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 500527,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 500544,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 500550,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 500572,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 500585,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 500591,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 500608,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 500614,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 500637,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 500649,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 500675,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 500692,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 500698,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 500721,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 500734,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 500740,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 500757,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 500763,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 500785,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 500798,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 500804,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 500821,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 500827,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 500850,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 500863,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 500869,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 500885,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 500891,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 500914,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 500927,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 500933,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 500949,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 500956,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 500978,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 500991,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 500997,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 501013,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 501019,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 501042,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 501055,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 501061,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 501077,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 501083,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 501106,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 501123,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 501129,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 501146,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 501152,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 501175,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 501193,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 501199,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 501216,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 501222,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 501245,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 501261,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 501267,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 501284,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 501290,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 501313,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 501329,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 501336,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 501419,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 501425,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 501449,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 501467,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 501473,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 501490,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 501496,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 501519,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 501535,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 501541,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 501557,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 501564,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 501580,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 501586,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 501609,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 501626,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 501643,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 501659,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 501676,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 501692,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 501708,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 501724,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 501741,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 501757,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 501774,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 501790,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x2932f6efca8",
-      "tid": 18876,
-      "ts": 433992,
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 501796,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "N",
-      "id": "0x2932f6efda8",
-      "tid": 18876,
-      "ts": 433998,
-      "pid": "GPGMM"
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 501818,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x2932f6ef3a8",
-      "tid": 18876,
-      "ts": 434004,
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 501820,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 501825,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 501843,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 501849,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 501873,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 501886,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 501892,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 501908,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 501915,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 501937,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 501950,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 501956,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 501973,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 501979,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 502001,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 502014,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 502020,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 502037,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 502043,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 502066,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 502078,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 502084,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 502101,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 502107,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 502130,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 502143,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 502149,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 502165,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 502172,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 502194,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 502207,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 502213,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 502229,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 502236,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 502258,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 502271,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 502277,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 502294,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 502300,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 502322,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 502335,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 502341,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 502358,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 502364,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 502387,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 502401,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 502408,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 502424,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 502430,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 502453,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 502466,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 502472,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 502488,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 502494,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 502517,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 502530,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 502536,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 502553,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 502559,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 502581,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 502594,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 502601,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 502617,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 502623,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 502646,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 502659,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 502665,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 502681,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 502687,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 502710,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 502723,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 502729,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 502746,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 502752,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 502775,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 502787,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 502793,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 502810,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 502816,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 502839,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 502851,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 502991,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 503009,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 503015,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 503038,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 503055,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 503062,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 503079,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 503085,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 503108,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 503125,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 503132,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 503148,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 503154,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 503177,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 503193,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 503200,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 503216,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 503222,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 503245,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 503262,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 503268,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 503284,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 503302,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 503325,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 503343,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 503349,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 503366,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 503373,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 503397,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 503414,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 503421,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 503438,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 503444,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 503461,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 503468,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 503491,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 503508,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 503525,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 503542,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 503559,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 503586,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 503603,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 503619,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 503636,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 503652,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 503668,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 503685,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
       "ph": "N",
-      "id": "0x2932f6ef5a8",
-      "tid": 18876,
-      "ts": 434008,
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 503691,
       "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 503714,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 503716,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 503721,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 503739,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 503745,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 503768,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 503794,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 503801,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 503818,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 503824,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 503847,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 503860,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 503867,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 503884,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 503890,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 503913,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 503926,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 503932,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 503949,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 503956,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 503979,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 503992,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 503999,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 504015,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 504022,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 504045,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 504058,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 504064,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 504081,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 504088,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 504111,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 504124,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 504130,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 504147,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 504153,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 504176,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 504190,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 504196,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 504213,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 504219,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 504242,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 504255,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 504262,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 504278,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 504285,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 504308,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 504321,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 504327,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 504344,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 504350,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 504373,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 504388,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 504394,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 504411,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 504417,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 504441,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 504454,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 504460,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 504477,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 504483,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 504507,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 504531,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 504553,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 504570,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 504576,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 504610,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 504639,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 504645,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 504662,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 504668,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 504691,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 504705,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 504711,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 504728,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 504734,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 504757,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 504779,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 504802,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 504846,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 504853,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 504878,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 504891,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 504897,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 504914,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 504921,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 504944,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 504972,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 504990,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 505007,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 505013,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 505037,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 505081,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 505088,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 505105,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 505122,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 505150,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 505169,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 505176,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 505193,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 505199,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 505223,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 505240,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 505246,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 505263,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 505270,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 505293,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 505311,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 505318,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 505335,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 505341,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 505365,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 505381,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 505389,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 505406,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 505413,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 505430,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 505436,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 505459,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 505476,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 505494,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 505510,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 505528,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 505555,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 505572,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 505588,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 505605,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 505633,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 505660,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 505677,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 505683,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 505705,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 505708,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 505712,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 505730,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 505736,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 505759,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 505772,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 505779,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 505795,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 505801,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 505824,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 505837,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 505843,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 505860,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 505866,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 505889,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 505902,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 505908,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 505924,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 505930,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 505953,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 505966,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 505972,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 505988,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 505994,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 506017,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 506030,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 506036,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 506052,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 506059,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 506081,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 506094,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 506100,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 506117,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 506123,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 506146,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 506158,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 506164,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 506181,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 506187,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 506462,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 506475,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 506482,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 506499,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 506505,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 506527,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 506540,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 506546,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 506563,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 506569,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 506591,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 506604,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 506610,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 506627,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 506633,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 506655,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 506668,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 506675,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 506691,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 506697,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 506720,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 506732,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 506739,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 506755,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 506761,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 506784,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 506797,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 506803,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 506820,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 506826,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 506848,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 506861,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 506867,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 506884,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 506890,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 506913,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 506926,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 506932,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 506948,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 506954,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 506977,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 506990,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 506996,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 507013,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 507019,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 507041,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 507059,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 507065,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 507082,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 507088,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 507110,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 507128,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 507134,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 507151,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 507157,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 507182,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 507198,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 507205,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 507221,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 507227,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 507251,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 507269,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 507276,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 507292,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 507298,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 507321,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 507338,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 507345,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 507361,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 507367,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 507392,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 507408,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 507414,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 507431,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 507437,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 507454,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 507460,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 507482,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 507499,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 507516,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 507532,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 507549,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 507565,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 507582,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 507598,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 507615,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 507631,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 507648,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 507664,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 507671,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 507691,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 507694,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 507699,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 507716,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 507723,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 507746,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 507759,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 507765,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 507782,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 507788,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 507811,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 507824,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 507830,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 507847,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 507853,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 507875,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 507888,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 507894,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 507911,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 507917,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 507940,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 507952,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 507959,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 507975,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 507981,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 508004,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 508017,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 508023,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 508040,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 508046,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 508068,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 508081,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 508087,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 508104,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 508110,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 508132,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 508145,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 508151,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 508168,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 508174,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 508196,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 508209,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 508216,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 508232,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 508238,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 508261,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 508274,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 508280,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 508296,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 508302,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 508325,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 508337,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 508344,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 508360,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 508366,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 508390,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 508431,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 508446,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 508478,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 508496,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 508523,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 508538,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 508546,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 508564,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 508572,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 508608,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 508622,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 508630,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 508648,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 508655,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 508680,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 508695,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 508702,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 508721,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 508728,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 508753,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 508767,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 508775,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 508793,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 508800,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 508825,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 508840,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 508847,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 508866,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 508873,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 508898,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 508917,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 508925,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 508943,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 508951,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 508976,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 508995,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 509003,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 509021,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 509028,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 509053,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 509073,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 509081,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 509099,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 509106,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 509132,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 509150,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 509158,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 509176,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 509184,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 509209,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 509228,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 509235,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 509254,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 509261,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 509286,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 509304,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 509311,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 509330,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 509337,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 509356,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 509363,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 509389,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 509405,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 509424,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 509440,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 509457,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 509473,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 509489,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 509506,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 509522,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 509539,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 509555,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 509572,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 509578,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 509600,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 509602,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 509607,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 509624,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 509631,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 509656,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 509669,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 509675,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 509692,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 509698,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 509721,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 509734,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 509740,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 509757,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 509763,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 509786,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 509799,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 509806,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 509822,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 509828,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 509851,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 509864,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 509870,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 509887,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 509893,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 509916,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 509929,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 509935,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 509952,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 509958,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 509981,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 509994,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 510000,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 510016,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 510022,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 510045,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 510058,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 510064,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 510081,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 510087,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 510110,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 510123,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 510130,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 510146,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 510152,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 510175,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 510188,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 510195,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 510211,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 510217,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 510241,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 510253,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 510260,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 510276,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 510282,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 510306,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 510319,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 510325,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 510341,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 510347,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 510371,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 510385,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 510391,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 510408,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 510414,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 510437,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 510450,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 510456,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 510473,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 510479,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 510502,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 510516,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 510522,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 510538,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 510544,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 510568,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 510581,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 510587,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 510604,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 510610,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 510633,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 510647,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 510653,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 510669,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 510675,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 510699,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 510717,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 510723,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 510740,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 510746,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 510769,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 510786,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 510792,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 510809,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 510815,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 510838,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 510854,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 510860,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 510877,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 510883,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 510906,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 510922,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 510929,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 510945,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 510951,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 510974,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 510991,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 510997,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 511014,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 511020,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 511043,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 511059,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 511065,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 511082,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 511088,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 511104,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 511110,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 511132,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 511149,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 511165,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 511182,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 511198,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 511214,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 511231,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 511247,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 511263,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 511280,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 511296,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 511312,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 511319,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 511342,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 511344,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 511349,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 511367,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 511373,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 511397,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 511410,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 511417,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 511433,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 511439,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 511462,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 511475,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 511481,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 511498,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 511504,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 511526,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 511539,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 511545,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 511562,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 511568,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 511590,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 511603,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 511609,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 511626,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 511632,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 511655,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 511667,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 511674,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 511690,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 511696,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 511719,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 511732,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 511738,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 511754,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 511761,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 511783,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 511796,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 511802,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 511819,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 511825,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 511847,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 511860,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 511866,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 511883,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 511889,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 511911,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 511924,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 511930,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 511947,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 511953,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 511975,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 511988,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 511994,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 512011,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 512017,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 512040,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 512052,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 512059,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 512075,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 512081,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 512103,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 512116,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 512122,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 512139,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 512145,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 512168,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 512180,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 512186,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 512203,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 512209,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 512232,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 512244,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 512251,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 512267,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 512273,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 512296,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 512309,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 512315,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 512818,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 512825,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 512849,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 512862,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 512868,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 512885,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 512891,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 512914,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 512930,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 512937,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 512954,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 512960,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 512982,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 513000,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 513006,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 513023,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 513029,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 513051,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 513068,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 513074,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 513091,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 513097,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 513120,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 513136,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 513142,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 513159,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 513165,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 513187,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 513204,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 513211,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 513227,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 513233,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 513256,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 513272,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 513278,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 513295,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 513301,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 513317,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 513323,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 513345,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 513362,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 513378,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 513396,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 513413,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 513430,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 513447,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 513463,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 513485,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 513501,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 513517,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 513534,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 513540,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 513562,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 513564,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 513569,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 513586,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 513593,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 513616,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 513629,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 513635,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 513652,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 513658,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 513681,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 513693,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 513700,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 513716,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 513722,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 513745,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 513758,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 513764,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 513780,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 513787,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 513809,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 513822,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 513828,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 513845,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 513851,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 513873,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 513886,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 513892,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 513909,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 513915,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 513937,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 513950,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 513956,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 513972,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 513979,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 514001,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 514014,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 514020,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 514037,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 514043,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 514066,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 514079,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 514085,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 514102,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 514108,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 514142,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 514155,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 514162,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 514179,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 514185,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 514208,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 514221,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 514228,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 514245,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 514251,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 514275,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 514288,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 514295,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 514311,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 514318,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 514341,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 514362,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 514368,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 514386,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 514392,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 514416,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 514429,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 514435,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 514453,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 514459,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 514482,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 514495,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 514502,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 514518,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 514525,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 514548,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 514561,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 514567,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 514584,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 514590,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 514614,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 514627,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 514633,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 514651,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 514657,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 514681,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 514698,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 514704,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 514722,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 514728,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 514751,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 514769,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 514776,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 514793,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 514799,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 514823,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 514839,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 514845,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 514862,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 514869,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 514892,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 514908,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 514915,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 514942,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 514949,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 514971,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 514988,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 514995,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 515011,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 515017,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 515040,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 515056,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 515062,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 515079,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 515085,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 515101,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 515107,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 515129,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 515146,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 515163,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 515179,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 515195,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 515212,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 515228,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 515244,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 515261,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 515277,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 515293,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 515310,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
     },
     {
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 434051,
+      "tid": 16484,
+      "ts": 515337,
       "pid": "GPGMM",
       "args": {
         "Flags": 0,
         "RecordOptions": {
-          "Flags": 1
+          "Flags": 6
         },
         "IsUMA": 1,
         "ResourceHeapTier": 2,
@@ -107,8 +13971,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 434121,
+      "tid": 16484,
+      "ts": 515412,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -135,27 +13999,11 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 434123,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 434125,
-      "pid": "GPGMM"
-    },
-    {
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 434143,
+      "tid": 16484,
+      "ts": 515430,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -163,19 +14011,11 @@
       }
     },
     {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 434145,
-      "pid": "GPGMM"
-    },
-    {
       "name": "ResourceAllocator.TryAllocateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 434158,
+      "tid": 16484,
+      "ts": 515445,
       "pid": "GPGMM",
       "args": {
         "Description": "Resource memory could not be allocated.",
@@ -183,41 +14023,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "i",
-      "tid": 18876,
-      "ts": 434171,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Suballocation was attempted but failed.",
-        "ID": 1
-      }
-    },
-    {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 434176,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x293327130f0",
-      "tid": 18876,
-      "ts": 434177,
+      "id": "0x22ababc2290",
+      "tid": 16484,
+      "ts": 515448,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327130f0",
-      "tid": 18876,
-      "ts": 434188,
+      "id": "0x22ababc2290",
+      "tid": 16484,
+      "ts": 515453,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -226,29 +14046,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 434190,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332712d00",
-      "tid": 18876,
-      "ts": 436277,
+      "id": "0x22ababc2320",
+      "tid": 16484,
+      "ts": 519404,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332712d00",
-      "tid": 18876,
-      "ts": 436319,
+      "id": "0x22ababc2320",
+      "tid": 16484,
+      "ts": 519446,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -263,9 +14075,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332712d00",
-      "tid": 18876,
-      "ts": 436340,
+      "id": "0x22ababc2320",
+      "tid": 16484,
+      "ts": 519467,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -277,28 +14089,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 436342,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 436344,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332712d00",
-      "tid": 18876,
-      "ts": 436362,
+      "id": "0x22ababc2320",
+      "tid": 16484,
+      "ts": 519487,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -307,7 +14103,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x293327130f0"
+            "id_ref": "0x22ababc2290"
           }
         }
       }
@@ -316,9 +14112,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332712d00",
-      "tid": 18876,
-      "ts": 436400,
+      "id": "0x22ababc2320",
+      "tid": 16484,
+      "ts": 519574,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -327,7 +14123,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x293327130f0"
+            "id_ref": "0x22ababc2290"
           }
         }
       }
@@ -336,18 +14132,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332723540",
-      "tid": 18876,
-      "ts": 436403,
+      "id": "0x22abad78da0",
+      "tid": 16484,
+      "ts": 519576,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332723540",
-      "tid": 18876,
-      "ts": 436417,
+      "id": "0x22abad78da0",
+      "tid": 16484,
+      "ts": 519591,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -356,7 +14152,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x29332712d00"
+            "id_ref": "0x22ababc2320"
           }
         }
       }
@@ -364,17 +14160,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 436420,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 436546,
+      "tid": 16484,
+      "ts": 519713,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -401,27 +14189,11 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 436548,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 436556,
-      "pid": "GPGMM"
-    },
-    {
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 436576,
+      "tid": 16484,
+      "ts": 519733,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -429,19 +14201,11 @@
       }
     },
     {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 436578,
-      "pid": "GPGMM"
-    },
-    {
       "name": "ResourceAllocator.TryAllocateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 436593,
+      "tid": 16484,
+      "ts": 519747,
       "pid": "GPGMM",
       "args": {
         "Description": "Resource memory could not be allocated.",
@@ -449,41 +14213,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "i",
-      "tid": 18876,
-      "ts": 436607,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Suballocation was attempted but failed.",
-        "ID": 1
-      }
-    },
-    {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 436609,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332712b50",
-      "tid": 18876,
-      "ts": 436611,
+      "id": "0x22ababc3640",
+      "tid": 16484,
+      "ts": 519750,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332712b50",
-      "tid": 18876,
-      "ts": 436616,
+      "id": "0x22ababc3640",
+      "tid": 16484,
+      "ts": 519756,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -492,29 +14236,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 436618,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332713840",
-      "tid": 18876,
-      "ts": 438861,
+      "id": "0x22ababc2950",
+      "tid": 16484,
+      "ts": 520664,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332713840",
-      "tid": 18876,
-      "ts": 438901,
+      "id": "0x22ababc2950",
+      "tid": 16484,
+      "ts": 520696,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -529,9 +14265,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332713840",
-      "tid": 18876,
-      "ts": 438922,
+      "id": "0x22ababc2950",
+      "tid": 16484,
+      "ts": 520713,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -543,28 +14279,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 438924,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 438927,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332713840",
-      "tid": 18876,
-      "ts": 438943,
+      "id": "0x22ababc2950",
+      "tid": 16484,
+      "ts": 520732,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -573,7 +14293,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x29332712b50"
+            "id_ref": "0x22ababc3640"
           }
         }
       }
@@ -582,9 +14302,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332713840",
-      "tid": 18876,
-      "ts": 438980,
+      "id": "0x22ababc2950",
+      "tid": 16484,
+      "ts": 520806,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -593,7 +14313,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x29332712b50"
+            "id_ref": "0x22ababc3640"
           }
         }
       }
@@ -602,18 +14322,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332722fc0",
-      "tid": 18876,
-      "ts": 438982,
+      "id": "0x22abad78fb0",
+      "tid": 16484,
+      "ts": 520808,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332722fc0",
-      "tid": 18876,
-      "ts": 438997,
+      "id": "0x22abad78fb0",
+      "tid": 16484,
+      "ts": 520823,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -622,7 +14342,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x29332713840"
+            "id_ref": "0x22ababc2950"
           }
         }
       }
@@ -630,17 +14350,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 438999,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 439125,
+      "tid": 16484,
+      "ts": 520937,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -667,44 +14379,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 439127,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 439129,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 439136,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 439141,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x2932f6eeaa8",
-      "tid": 18876,
-      "ts": 439158,
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 520954,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -713,29 +14393,12 @@
       }
     },
     {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 439161,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x29332714140",
-      "tid": 18876,
-      "ts": 439162,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332714140",
-      "tid": 18876,
-      "ts": 439167,
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 520960,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -744,29 +14407,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 439168,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332712490",
-      "tid": 18876,
-      "ts": 439864,
+      "id": "0x22ababc2a70",
+      "tid": 16484,
+      "ts": 521291,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332712490",
-      "tid": 18876,
-      "ts": 439883,
+      "id": "0x22ababc2a70",
+      "tid": 16484,
+      "ts": 521321,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -781,9 +14436,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332712490",
-      "tid": 18876,
-      "ts": 439899,
+      "id": "0x22ababc2a70",
+      "tid": 16484,
+      "ts": 521338,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -795,28 +14450,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 439908,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 439909,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x2932f6eeaa8",
-      "tid": 18876,
-      "ts": 439916,
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 521348,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -825,36 +14464,12 @@
       }
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 439919,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 439920,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 439921,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332712490",
-      "tid": 18876,
-      "ts": 439936,
+      "id": "0x22ababc2a70",
+      "tid": 16484,
+      "ts": 521368,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -863,7 +14478,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x29332714140"
+            "id_ref": "0x22abacb5820"
           }
         }
       }
@@ -872,9 +14487,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332712490",
-      "tid": 18876,
-      "ts": 439962,
+      "id": "0x22ababc2a70",
+      "tid": 16484,
+      "ts": 521460,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -883,7 +14498,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x29332714140"
+            "id_ref": "0x22abacb5820"
           }
         }
       }
@@ -892,18 +14507,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x293327228e0",
-      "tid": 18876,
-      "ts": 439964,
+      "id": "0x22abad79ed0",
+      "tid": 16484,
+      "ts": 521463,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327228e0",
-      "tid": 18876,
-      "ts": 439978,
+      "id": "0x22abad79ed0",
+      "tid": 16484,
+      "ts": 521477,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -912,7 +14527,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332712490"
+            "id_ref": "0x22ababc2a70"
           }
         }
       }
@@ -920,17 +14535,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 439980,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 440097,
+      "tid": 16484,
+      "ts": 521603,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -957,27 +14564,11 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 440099,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 440100,
-      "pid": "GPGMM"
-    },
-    {
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 440119,
+      "tid": 16484,
+      "ts": 521622,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -985,19 +14576,11 @@
       }
     },
     {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 440120,
-      "pid": "GPGMM"
-    },
-    {
       "name": "ResourceAllocator.TryAllocateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 440133,
+      "tid": 16484,
+      "ts": 521635,
       "pid": "GPGMM",
       "args": {
         "Description": "Resource memory could not be allocated.",
@@ -1005,32 +14588,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "i",
-      "tid": 18876,
-      "ts": 440146,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Suballocation was attempted but failed.",
-        "ID": 1
-      }
-    },
-    {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 440148,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332712b50",
-      "tid": 18876,
-      "ts": 440153,
+      "id": "0x22ababc3640",
+      "tid": 16484,
+      "ts": 521642,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1039,29 +14602,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 440154,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332713720",
-      "tid": 18876,
-      "ts": 445858,
+      "id": "0x22ababc3be0",
+      "tid": 16484,
+      "ts": 522535,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332713720",
-      "tid": 18876,
-      "ts": 445899,
+      "id": "0x22ababc3be0",
+      "tid": 16484,
+      "ts": 522566,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1076,9 +14631,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332713720",
-      "tid": 18876,
-      "ts": 445920,
+      "id": "0x22ababc3be0",
+      "tid": 16484,
+      "ts": 522583,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1090,28 +14645,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 445922,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 445925,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332713720",
-      "tid": 18876,
-      "ts": 445941,
+      "id": "0x22ababc3be0",
+      "tid": 16484,
+      "ts": 522601,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1120,7 +14659,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x29332712b50"
+            "id_ref": "0x22ababc3640"
           }
         }
       }
@@ -1129,9 +14668,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332713720",
-      "tid": 18876,
-      "ts": 445979,
+      "id": "0x22ababc3be0",
+      "tid": 16484,
+      "ts": 522672,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1140,7 +14679,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x29332712b50"
+            "id_ref": "0x22ababc3640"
           }
         }
       }
@@ -1149,18 +14688,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332723ac0",
-      "tid": 18876,
-      "ts": 445982,
+      "id": "0x22abad795e0",
+      "tid": 16484,
+      "ts": 522674,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332723ac0",
-      "tid": 18876,
-      "ts": 445996,
+      "id": "0x22abad795e0",
+      "tid": 16484,
+      "ts": 522689,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1169,42 +14708,18 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x29332713720"
+            "id_ref": "0x22ababc3be0"
           }
         }
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 445998,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 446090,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 446091,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327130f0",
-      "tid": 18876,
-      "ts": 446113,
+      "id": "0x22ababc2290",
+      "tid": 16484,
+      "ts": 522792,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1213,36 +14728,20 @@
       }
     },
     {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 446114,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332723540",
-      "tid": 18876,
-      "ts": 446119,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 446119,
+      "id": "0x22abad78da0",
+      "tid": 16484,
+      "ts": 522850,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 446171,
+      "tid": 16484,
+      "ts": 522903,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1269,44 +14768,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 446173,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 446176,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 446183,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 446188,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x2932f6ee6a8",
-      "tid": 18876,
-      "ts": 446202,
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 522920,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1315,29 +14782,12 @@
       }
     },
     {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 446204,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x29332712e20",
-      "tid": 18876,
-      "ts": 446206,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332712e20",
-      "tid": 18876,
-      "ts": 446210,
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 522927,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1346,29 +14796,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 446212,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x293327137b0",
-      "tid": 18876,
-      "ts": 446864,
+      "id": "0x22ababc2e60",
+      "tid": 16484,
+      "ts": 523255,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327137b0",
-      "tid": 18876,
-      "ts": 446884,
+      "id": "0x22ababc2e60",
+      "tid": 16484,
+      "ts": 523286,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1383,9 +14825,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327137b0",
-      "tid": 18876,
-      "ts": 446900,
+      "id": "0x22ababc2e60",
+      "tid": 16484,
+      "ts": 523302,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1397,28 +14839,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 446902,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 446904,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x2932f6ee6a8",
-      "tid": 18876,
-      "ts": 446910,
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 523312,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1427,36 +14853,12 @@
       }
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 446912,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 446914,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 446915,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327137b0",
-      "tid": 18876,
-      "ts": 446930,
+      "id": "0x22ababc2e60",
+      "tid": 16484,
+      "ts": 523333,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1465,7 +14867,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x29332712e20"
+            "id_ref": "0x22abacb4bc0"
           }
         }
       }
@@ -1474,9 +14876,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327137b0",
-      "tid": 18876,
-      "ts": 446962,
+      "id": "0x22ababc2e60",
+      "tid": 16484,
+      "ts": 523412,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1485,7 +14887,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x29332712e20"
+            "id_ref": "0x22abacb4bc0"
           }
         }
       }
@@ -1494,18 +14896,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x293327222b0",
-      "tid": 18876,
-      "ts": 446964,
+      "id": "0x22abad79ab0",
+      "tid": 16484,
+      "ts": 523414,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327222b0",
-      "tid": 18876,
-      "ts": 446978,
+      "id": "0x22abad79ab0",
+      "tid": 16484,
+      "ts": 523429,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1514,42 +14916,18 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x293327137b0"
+            "id_ref": "0x22ababc2e60"
           }
         }
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 446981,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 447070,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 447071,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332712b50",
-      "tid": 18876,
-      "ts": 447083,
+      "id": "0x22ababc3640",
+      "tid": 16484,
+      "ts": 523539,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1558,36 +14936,20 @@
       }
     },
     {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 447102,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332722fc0",
-      "tid": 18876,
-      "ts": 447105,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 447106,
+      "id": "0x22abad78fb0",
+      "tid": 16484,
+      "ts": 523587,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 447155,
+      "tid": 16484,
+      "ts": 523638,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1614,44 +14976,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 447156,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 447157,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 447161,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 447165,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x2932f6eeaa8",
-      "tid": 18876,
-      "ts": 447174,
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 523653,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1660,20 +14990,12 @@
       }
     },
     {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 447176,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332714140",
-      "tid": 18876,
-      "ts": 447181,
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 523660,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1682,29 +15004,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 447182,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332713b10",
-      "tid": 18876,
-      "ts": 447812,
+      "id": "0x22ababc2560",
+      "tid": 16484,
+      "ts": 523986,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332713b10",
-      "tid": 18876,
-      "ts": 447831,
+      "id": "0x22ababc2560",
+      "tid": 16484,
+      "ts": 524016,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1719,9 +15033,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332713b10",
-      "tid": 18876,
-      "ts": 447846,
+      "id": "0x22ababc2560",
+      "tid": 16484,
+      "ts": 524033,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1733,28 +15047,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 447848,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 447850,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x2932f6eeaa8",
-      "tid": 18876,
-      "ts": 447856,
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 524043,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1763,36 +15061,12 @@
       }
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 447858,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 447860,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 447861,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332713b10",
-      "tid": 18876,
-      "ts": 447875,
+      "id": "0x22ababc2560",
+      "tid": 16484,
+      "ts": 524062,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1801,7 +15075,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x29332714140"
+            "id_ref": "0x22abacb5820"
           }
         }
       }
@@ -1810,9 +15084,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332713b10",
-      "tid": 18876,
-      "ts": 447900,
+      "id": "0x22ababc2560",
+      "tid": 16484,
+      "ts": 524140,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1821,7 +15095,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x29332714140"
+            "id_ref": "0x22abacb5820"
           }
         }
       }
@@ -1830,18 +15104,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332723f90",
-      "tid": 18876,
-      "ts": 447903,
+      "id": "0x22abad7a450",
+      "tid": 16484,
+      "ts": 524142,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332723f90",
-      "tid": 18876,
-      "ts": 447917,
+      "id": "0x22abad7a450",
+      "tid": 16484,
+      "ts": 524157,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1850,7 +15124,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332713b10"
+            "id_ref": "0x22ababc2560"
           }
         }
       }
@@ -1858,17 +15132,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 447919,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 448035,
+      "tid": 16484,
+      "ts": 524277,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1895,44 +15161,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 448039,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 448040,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 448044,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 448047,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x2932f6ef2a8",
-      "tid": 18876,
-      "ts": 448060,
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 524299,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1941,29 +15175,12 @@
       }
     },
     {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 448062,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x29332713ba0",
-      "tid": 18876,
-      "ts": 448063,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332713ba0",
-      "tid": 18876,
-      "ts": 448067,
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 524306,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1972,29 +15189,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 448069,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332712f40",
-      "tid": 18876,
-      "ts": 448753,
+      "id": "0x22abad87220",
+      "tid": 16484,
+      "ts": 524753,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332712f40",
-      "tid": 18876,
-      "ts": 448772,
+      "id": "0x22abad87220",
+      "tid": 16484,
+      "ts": 524784,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2009,9 +15218,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332712f40",
-      "tid": 18876,
-      "ts": 448788,
+      "id": "0x22abad87220",
+      "tid": 16484,
+      "ts": 524813,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2023,28 +15232,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 448789,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 448791,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x2932f6ef2a8",
-      "tid": 18876,
-      "ts": 448797,
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 524824,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2053,36 +15246,12 @@
       }
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 448800,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 448801,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 448802,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332712f40",
-      "tid": 18876,
-      "ts": 448816,
+      "id": "0x22abad87220",
+      "tid": 16484,
+      "ts": 524856,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2091,7 +15260,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x29332713ba0"
+            "id_ref": "0x22abacb4080"
           }
         }
       }
@@ -2100,9 +15269,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332712f40",
-      "tid": 18876,
-      "ts": 448841,
+      "id": "0x22abad87220",
+      "tid": 16484,
+      "ts": 524974,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2111,7 +15280,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x29332713ba0"
+            "id_ref": "0x22abacb4080"
           }
         }
       }
@@ -2120,18 +15289,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332722360",
-      "tid": 18876,
-      "ts": 448844,
+      "id": "0x22abad78820",
+      "tid": 16484,
+      "ts": 524977,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332722360",
-      "tid": 18876,
-      "ts": 448858,
+      "id": "0x22abad78820",
+      "tid": 16484,
+      "ts": 524991,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2140,7 +15309,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332712f40"
+            "id_ref": "0x22abad87220"
           }
         }
       }
@@ -2148,17 +15317,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 448860,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 448974,
+      "tid": 16484,
+      "ts": 525112,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -2185,52 +15346,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 448976,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 448977,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 448979,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 448981,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 448982,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332712490",
-      "tid": 18876,
-      "ts": 448997,
+      "id": "0x22ababc2a70",
+      "tid": 16484,
+      "ts": 525133,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2239,7 +15360,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 3,
           "MemoryPool": {
-            "id_ref": "0x29332714140"
+            "id_ref": "0x22abacb5820"
           }
         }
       }
@@ -2248,9 +15369,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332712490",
-      "tid": 18876,
-      "ts": 449032,
+      "id": "0x22ababc2a70",
+      "tid": 16484,
+      "ts": 525215,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2259,7 +15380,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 3,
           "MemoryPool": {
-            "id_ref": "0x29332714140"
+            "id_ref": "0x22abacb5820"
           }
         }
       }
@@ -2268,18 +15389,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332722a40",
-      "tid": 18876,
-      "ts": 449034,
+      "id": "0x22ababbf5d0",
+      "tid": 16484,
+      "ts": 525219,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332722a40",
-      "tid": 18876,
-      "ts": 449048,
+      "id": "0x22ababbf5d0",
+      "tid": 16484,
+      "ts": 525233,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2288,82 +15409,26 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332712490"
+            "id_ref": "0x22ababc2a70"
           }
         }
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 449050,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 449104,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 449105,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 449106,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 449106,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 449107,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x293327228e0",
-      "tid": 18876,
-      "ts": 449110,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 449111,
+      "id": "0x22abad79ed0",
+      "tid": 16484,
+      "ts": 525343,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 449158,
+      "tid": 16484,
+      "ts": 525397,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -2390,27 +15455,11 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 449159,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 449160,
-      "pid": "GPGMM"
-    },
-    {
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 449178,
+      "tid": 16484,
+      "ts": 525416,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -2418,19 +15467,11 @@
       }
     },
     {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 449180,
-      "pid": "GPGMM"
-    },
-    {
       "name": "ResourceAllocator.TryAllocateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 449193,
+      "tid": 16484,
+      "ts": 525436,
       "pid": "GPGMM",
       "args": {
         "Description": "Resource memory could not be allocated.",
@@ -2438,32 +15479,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "i",
-      "tid": 18876,
-      "ts": 449205,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Suballocation was attempted but failed.",
-        "ID": 1
-      }
-    },
-    {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 449208,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332712b50",
-      "tid": 18876,
-      "ts": 449213,
+      "id": "0x22ababc3640",
+      "tid": 16484,
+      "ts": 525444,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2472,20 +15493,12 @@
       }
     },
     {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 449215,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332713840",
-      "tid": 18876,
-      "ts": 449230,
+      "id": "0x22ababc2950",
+      "tid": 16484,
+      "ts": 525461,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2494,7 +15507,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x29332712b50"
+            "id_ref": "0x22ababc3640"
           }
         }
       }
@@ -2503,9 +15516,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332713840",
-      "tid": 18876,
-      "ts": 449254,
+      "id": "0x22ababc2950",
+      "tid": 16484,
+      "ts": 525531,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2514,7 +15527,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x29332712b50"
+            "id_ref": "0x22ababc3640"
           }
         }
       }
@@ -2523,18 +15536,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332723750",
-      "tid": 18876,
-      "ts": 449256,
+      "id": "0x22abad93820",
+      "tid": 16484,
+      "ts": 525534,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332723750",
-      "tid": 18876,
-      "ts": 449270,
+      "id": "0x22abad93820",
+      "tid": 16484,
+      "ts": 525548,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2543,42 +15556,18 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x29332713840"
+            "id_ref": "0x22ababc2950"
           }
         }
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 449272,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 449331,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 449331,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332712b50",
-      "tid": 18876,
-      "ts": 449339,
+      "id": "0x22ababc3640",
+      "tid": 16484,
+      "ts": 525623,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2587,53 +15576,21 @@
       }
     },
     {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 449340,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332723ac0",
-      "tid": 18876,
-      "ts": 449349,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 449349,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 449370,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 449370,
+      "id": "0x22abad795e0",
+      "tid": 16484,
+      "ts": 525670,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332712b50",
-      "tid": 18876,
-      "ts": 449377,
+      "id": "0x22ababc3640",
+      "tid": 16484,
+      "ts": 525704,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2642,69 +15599,21 @@
       }
     },
     {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 449379,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332723750",
-      "tid": 18876,
-      "ts": 449380,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 449380,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 449421,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 449421,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 449422,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 449423,
+      "id": "0x22abad93820",
+      "tid": 16484,
+      "ts": 525748,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x2932f6eeaa8",
-      "tid": 18876,
-      "ts": 449430,
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 525805,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2713,115 +15622,35 @@
       }
     },
     {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 449432,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332714140",
-      "tid": 18876,
-      "ts": 449440,
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 525820,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "PoolSize": 4194304
         }
       }
-    },
-    {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 449442,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 449442,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 449443,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 449448,
-      "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332722a40",
-      "tid": 18876,
-      "ts": 449450,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 449450,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 449492,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 449492,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 449493,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 449494,
+      "id": "0x22ababbf5d0",
+      "tid": 16484,
+      "ts": 525867,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x2932f6eeaa8",
-      "tid": 18876,
-      "ts": 449505,
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 525927,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2830,20 +15659,12 @@
       }
     },
     {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 449506,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332714140",
-      "tid": 18876,
-      "ts": 449512,
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 525935,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2852,93 +15673,58 @@
       }
     },
     {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
+      "name": "GPUMemoryAllocation",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 449514,
+      "ph": "D",
+      "id": "0x22abad7a450",
+      "tid": 16484,
+      "ts": 525985,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 449514,
-      "pid": "GPGMM"
+      "ph": "O",
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 526044,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 4194304
+        }
+      }
     },
     {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 449515,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 449518,
-      "pid": "GPGMM"
+      "ph": "O",
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 526058,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 4194304
+        }
+      }
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332723f90",
-      "tid": 18876,
-      "ts": 449519,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 449520,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 449561,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 449561,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 449562,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 449563,
+      "id": "0x22abad78820",
+      "tid": 16484,
+      "ts": 526104,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x2932f6ef2a8",
-      "tid": 18876,
-      "ts": 449572,
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 526163,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2947,380 +15733,260 @@
       }
     },
     {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 449574,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332713ba0",
-      "tid": 18876,
-      "ts": 449584,
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 526177,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "PoolSize": 4194304
         }
       }
-    },
-    {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 449620,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 449620,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 449621,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 449624,
-      "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332722360",
-      "tid": 18876,
-      "ts": 449626,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 449626,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 449669,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 449669,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 449670,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 449671,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x2932f6ee6a8",
-      "tid": 18876,
-      "ts": 449683,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 4194304
-        }
-      }
-    },
-    {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 449684,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x29332712e20",
-      "tid": 18876,
-      "ts": 449692,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 4194304
-        }
-      }
-    },
-    {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 449694,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 449694,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 449694,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 449698,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x293327222b0",
-      "tid": 18876,
-      "ts": 449700,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 449700,
+      "id": "0x22abad79ab0",
+      "tid": 16484,
+      "ts": 526224,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "D",
-      "id": "0x2932f64b8e0",
-      "tid": 18876,
-      "ts": 449711,
+      "id": "0x22abadf1280",
+      "tid": 16484,
+      "ts": 526236,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x2932f6ef2a8",
-      "tid": 18876,
-      "ts": 449718,
+      "id": "0x22abadfc568",
+      "tid": 16484,
+      "ts": 526250,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332712f40",
-      "tid": 18876,
-      "ts": 449721,
+      "id": "0x22abad87220",
+      "tid": 16484,
+      "ts": 526252,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332713ba0",
-      "tid": 18876,
-      "ts": 449865,
+      "id": "0x22abacb4080",
+      "tid": 16484,
+      "ts": 526401,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x2932f6ee6a8",
-      "tid": 18876,
-      "ts": 449868,
+      "id": "0x22abadfd568",
+      "tid": 16484,
+      "ts": 526424,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x293327137b0",
-      "tid": 18876,
-      "ts": 449870,
+      "id": "0x22ababc2e60",
+      "tid": 16484,
+      "ts": 526426,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332712e20",
-      "tid": 18876,
-      "ts": 449958,
+      "id": "0x22abacb4bc0",
+      "tid": 16484,
+      "ts": 526561,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x2932f6eeaa8",
-      "tid": 18876,
-      "ts": 449962,
+      "id": "0x22abadfbf68",
+      "tid": 16484,
+      "ts": 526582,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332713b10",
-      "tid": 18876,
-      "ts": 449963,
+      "id": "0x22ababc2560",
+      "tid": 16484,
+      "ts": 526584,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332712490",
-      "tid": 18876,
-      "ts": 450058,
+      "id": "0x22ababc2a70",
+      "tid": 16484,
+      "ts": 526716,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332714140",
-      "tid": 18876,
-      "ts": 450137,
+      "id": "0x22abacb5820",
+      "tid": 16484,
+      "ts": 526850,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x2932f6ef4a8",
-      "tid": 18876,
-      "ts": 450140,
+      "id": "0x22abadfc468",
+      "tid": 16484,
+      "ts": 526870,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x2932f6efca8",
-      "tid": 18876,
-      "ts": 450142,
+      "id": "0x22abacb5280",
+      "tid": 16484,
+      "ts": 526872,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x2932f6efda8",
-      "tid": 18876,
-      "ts": 450145,
+      "id": "0x22abadfcb68",
+      "tid": 16484,
+      "ts": 526889,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x2932f6ef3a8",
-      "tid": 18876,
-      "ts": 450147,
+      "id": "0x22abacb5700",
+      "tid": 16484,
+      "ts": 526890,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x2932f6ef5a8",
-      "tid": 18876,
-      "ts": 450150,
+      "id": "0x22abadfca68",
+      "tid": 16484,
+      "ts": 526907,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x22abacb5c10",
+      "tid": 16484,
+      "ts": 526908,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x22abadfd868",
+      "tid": 16484,
+      "ts": 526924,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x22ababc3b50",
+      "tid": 16484,
+      "ts": 526925,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x22abadfd768",
+      "tid": 16484,
+      "ts": 526940,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x22ababc40f0",
+      "tid": 16484,
+      "ts": 526941,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332712d00",
-      "tid": 18876,
-      "ts": 450154,
+      "id": "0x22ababc2320",
+      "tid": 16484,
+      "ts": 526955,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x293327130f0",
-      "tid": 18876,
-      "ts": 450295,
+      "id": "0x22ababc2290",
+      "tid": 16484,
+      "ts": 527088,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332713840",
-      "tid": 18876,
-      "ts": 450297,
+      "id": "0x22ababc2950",
+      "tid": 16484,
+      "ts": 527091,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332713720",
-      "tid": 18876,
-      "ts": 450410,
+      "id": "0x22ababc3be0",
+      "tid": 16484,
+      "ts": 527222,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332712b50",
-      "tid": 18876,
-      "ts": 450554,
+      "id": "0x22ababc3640",
+      "tid": 16484,
+      "ts": 527358,
       "pid": "GPGMM"
     }
   ]

--- a/src/tests/capture_replay_tests/traces/webnn_resnet50v2_nchw.json
+++ b/src/tests/capture_replay_tests/traces/webnn_resnet50v2_nchw.json
@@ -5,94 +5,13958 @@
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "N",
-      "id": "0x2932f64b8e0",
-      "tid": 18876,
-      "ts": 478127,
+      "id": "0x22abadf0600",
+      "tid": 16484,
+      "ts": 667048,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x2932f6d2358",
-      "tid": 18876,
-      "ts": 478137,
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 667060,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "N",
-      "id": "0x2932f6d2758",
-      "tid": 18876,
-      "ts": 478147,
-      "pid": "GPGMM"
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 667123,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x2932f6d3558",
-      "tid": 18876,
-      "ts": 478156,
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 667127,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "N",
-      "id": "0x2932f6d2a58",
-      "tid": 18876,
-      "ts": 478161,
-      "pid": "GPGMM"
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 667133,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 667166,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 667189,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 667217,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 667231,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 667243,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 667260,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 667266,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 667290,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 667328,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 667341,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 667399,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 667408,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 667445,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 667474,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 667496,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 667528,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 667534,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 667579,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 667592,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 667610,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 667627,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 667644,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 667667,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 667703,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 667710,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 667726,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 667744,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 667778,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 667807,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 667829,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 667845,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 667851,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 667874,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 667887,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 667893,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 667910,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 667916,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 667938,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 667951,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 667958,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 667974,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 667980,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 668003,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 668016,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 668022,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 668039,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 668045,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 668067,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 668080,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 668105,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 668122,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 668128,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 668151,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 668164,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 668170,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 668187,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 668193,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 668215,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 668228,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 668234,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 668251,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 668257,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 668280,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 668294,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 668300,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 668317,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 668323,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 668345,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 668359,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 668365,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 668381,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 668387,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 668410,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 668423,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 668429,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 668446,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 668452,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 668475,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 668488,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 668494,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 668511,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 668517,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 668540,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 668557,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 668563,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 668580,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 668586,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 668609,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 668627,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 668633,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 668650,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 668656,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 668679,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 668695,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 668701,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 668718,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 668724,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 668747,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 668763,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 668769,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 668854,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 668861,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 668884,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 668902,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 668908,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 668925,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 668931,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 668954,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 668970,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 668976,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 668993,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 668999,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 669015,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 669022,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 669044,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 669061,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 669078,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 669094,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 669111,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 669127,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 669144,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 669160,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 669176,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 669193,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 669209,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 669226,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x2932f6d3f58",
-      "tid": 18876,
-      "ts": 478168,
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 669232,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "N",
-      "id": "0x2932f6d2b58",
-      "tid": 18876,
-      "ts": 478174,
-      "pid": "GPGMM"
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 669253,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x2932f6d3758",
-      "tid": 18876,
-      "ts": 478190,
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 669256,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 669261,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 669278,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 669284,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 669309,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 669322,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 669328,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 669345,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 669351,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 669374,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 669387,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 669393,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 669410,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 669416,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 669439,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 669452,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 669458,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 669475,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 669481,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 669503,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 669517,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 669523,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 669539,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 669545,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 669568,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 669581,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 669587,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 669604,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 669621,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 669655,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 669668,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 669674,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 669691,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 669697,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 669720,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 669732,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 669739,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 669755,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 669761,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 669784,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 669797,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 669803,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 669820,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 669826,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 669849,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 669862,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 669868,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 669885,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 669890,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 669913,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 669926,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 669932,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 669949,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 669955,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 669977,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 669990,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 669996,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 670013,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 670019,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 670042,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 670054,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 670061,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 670077,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 670083,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 670106,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 670119,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 670125,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 670141,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 670147,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 670170,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 670183,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 670189,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 670205,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 670211,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 670234,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 670247,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 670253,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 670270,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 670276,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 670299,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 670312,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 670455,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 670473,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 670479,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 670502,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 670519,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 670526,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 670543,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 670549,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 670572,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 670589,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 670596,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 670612,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 670618,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 670641,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 670657,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 670663,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 670680,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 670686,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 670709,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 670725,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 670731,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 670748,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 670754,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 670777,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 670794,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 670800,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 670817,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 670823,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 670846,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 670862,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 670868,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 670885,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 670891,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 670907,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 670913,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 670935,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 670952,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 670969,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 670985,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 671002,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 671018,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 671035,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 671051,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 671067,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 671084,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 671100,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 671117,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
       "ph": "N",
-      "id": "0x2932f6d3358",
-      "tid": 18876,
-      "ts": 478195,
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 671123,
       "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 671145,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 671148,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 671153,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 671170,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 671176,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 671200,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 671214,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 671221,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 671237,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 671243,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 671266,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 671279,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 671285,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 671303,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 671309,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 671332,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 671345,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 671351,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 671368,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 671374,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 671396,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 671409,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 671415,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 671432,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 671438,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 671460,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 671474,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 671480,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 671496,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 671502,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 671525,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 671538,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 671544,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 671561,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 671567,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 671590,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 671602,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 671609,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 671625,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 671631,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 671654,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 671667,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 671673,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 671689,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 671695,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 671718,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 671731,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 671737,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 671753,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 671759,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 671782,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 671795,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 671801,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 671817,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 671823,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 671846,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 671859,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 671865,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 671882,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 671888,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 671910,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 671923,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 671929,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 671946,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 671952,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 671974,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 671987,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 671993,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 672010,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 672016,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 672039,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 672052,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 672058,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 672074,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 672080,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 672103,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 672116,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 672122,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 672139,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 672145,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 672167,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 672181,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 672187,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 672203,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 672209,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 672232,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 672250,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 672256,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 672273,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 672279,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 672304,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 672321,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 672328,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 672344,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 672350,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 672373,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 672389,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 672396,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 672413,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 672419,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 672442,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 672457,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 672464,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 672480,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 672486,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 672509,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 672526,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 672533,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 672549,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 672555,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 672578,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 672594,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 672600,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 672617,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 672623,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 672639,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 672645,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 672667,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 672684,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 672700,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 672717,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 672733,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 672749,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 672766,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 672782,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 672798,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 672815,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 672831,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 672848,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 672854,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 672874,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 672877,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 672882,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 672899,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 672905,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 672928,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 672942,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 672948,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 672964,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 672970,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 672993,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 673006,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 673012,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 673029,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 673035,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 673057,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 673070,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 673076,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 673093,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 673099,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 673122,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 673135,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 673141,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 673158,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 673164,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 673187,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 673200,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 673206,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 673223,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 673229,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 673251,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 673264,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 673270,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 673287,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 673306,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 673329,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 673343,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 673349,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 673366,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 673372,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 673660,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 673673,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 673680,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 673696,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 673703,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 673725,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 673738,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 673744,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 673761,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 673767,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 673789,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 673802,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 673808,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 673825,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 673831,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 673854,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 673867,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 673873,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 673889,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 673895,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 673918,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 673931,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 673937,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 673953,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 673959,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 673982,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 673995,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 674001,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 674017,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 674024,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 674046,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 674059,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 674065,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 674082,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 674088,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 674111,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 674123,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 674129,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 674146,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 674152,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 674174,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 674188,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 674194,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 674210,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 674216,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 674239,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 674257,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 674263,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 674280,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 674286,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 674310,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 674328,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 674334,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 674351,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 674357,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 674380,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 674396,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 674403,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 674419,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 674425,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 674448,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 674468,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 674475,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 674491,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 674498,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 674520,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 674537,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 674544,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 674560,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 674567,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 674589,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 674605,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 674612,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 674628,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 674635,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 674651,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 674657,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 674679,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 674696,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 674713,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 674729,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 674746,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 674762,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 674778,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 674795,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 674811,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 674827,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 674844,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 674860,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 674866,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 674887,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 674890,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 674895,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 674912,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 674919,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 674942,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 674955,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 674961,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 674978,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 674984,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 675007,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 675020,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 675026,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 675043,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 675049,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 675072,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 675084,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 675091,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 675107,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 675113,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 675136,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 675149,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 675155,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 675171,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 675177,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 675200,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 675213,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 675219,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 675236,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 675242,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 675264,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 675277,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 675284,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 675302,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 675309,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 675331,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 675344,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 675350,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 675367,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 675373,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 675396,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 675408,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 675415,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 675431,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 675438,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 675460,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 675473,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 675479,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 675496,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 675502,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 675524,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 675537,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 675544,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 675560,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 675566,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 675589,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 675602,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 675608,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 675624,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 675631,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 675653,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 675666,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 675672,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 675689,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 675695,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 675717,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 675730,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 675737,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 675753,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 675759,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 675782,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 675795,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 675801,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 675818,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 675824,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 675846,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 675859,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 675865,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 675882,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 675888,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 675910,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 675923,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 675930,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 675946,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 675953,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 675975,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 675992,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 675998,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 676015,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 676021,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 676043,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 676061,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 676067,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 676083,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 676089,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 676112,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 676128,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 676135,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 676152,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 676158,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 676180,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 676196,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 676203,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 676219,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 676226,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 676253,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 676272,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 676278,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 676296,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 676302,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 676326,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 676343,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 676349,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 676366,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 676372,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 676389,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 676395,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 676417,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 676433,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 676451,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 676468,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 676484,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 676501,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 676517,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 676533,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 676550,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 676566,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 676583,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 676599,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 676605,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 676626,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 676628,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 676633,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 676650,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 676657,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 676682,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 676695,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 676701,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 676718,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 676724,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 676748,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 676761,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 676767,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 676784,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 676790,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 676813,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 676826,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 676832,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 676849,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 676855,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 676878,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 676891,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 676897,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 676914,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 676920,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 676943,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 676956,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 676962,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 676979,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 676985,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 677008,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 677021,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 677027,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 677044,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 677050,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 677074,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 677087,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 677093,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 677110,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 677116,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 677139,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 677152,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 677158,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 677175,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 677181,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 677204,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 677217,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 677224,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 677240,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 677246,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 677269,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 677282,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 677290,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 677307,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 677313,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 677336,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 677349,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 677356,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 677372,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 677378,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 677401,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 677415,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 677421,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 677437,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 677444,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 677467,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 677480,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 677486,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 677503,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 677509,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 677532,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 677545,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 677551,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 677568,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 677574,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 677598,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 677611,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 677617,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 677633,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 677640,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 677663,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 677677,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 677683,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 677699,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 677705,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 677729,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 677747,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 677753,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 677770,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 677775,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 677798,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 677816,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 677822,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 677839,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 677845,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 677868,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 677884,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 677891,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 677907,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 677913,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 677936,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 677952,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 677958,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 677975,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 677981,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 678004,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 678021,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 678027,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 678044,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 678050,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 678073,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 678089,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 678095,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 678112,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 678118,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 678134,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 678141,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 678162,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 678179,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 678196,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 678213,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 678229,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 678245,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 678262,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 678278,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 678296,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 678312,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 678329,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 678345,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 678352,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 678374,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 678376,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 678381,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 678399,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 678405,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 678429,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 678442,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 678448,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 678465,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 678471,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 678494,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 678507,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 678513,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 678530,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 678536,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 678559,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 678572,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 678578,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 678595,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 678601,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 678623,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 678636,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 678642,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 678659,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 678665,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 678688,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 678701,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 678707,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 678724,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 678730,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 678752,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 678765,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 678771,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 678788,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 678794,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 678817,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 678830,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 678836,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 678852,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 678859,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 678881,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 678894,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 678900,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 678917,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 678923,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 678945,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 678958,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 678965,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 678981,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 678987,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 679010,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 679023,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 679029,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 679046,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 679052,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 679075,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 679087,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 679094,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 679120,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 679126,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 679148,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 679160,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 679166,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 679183,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 679188,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 679210,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 679223,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 679229,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 679245,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 679251,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 679273,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 679287,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 679293,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 679309,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 679315,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 679337,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 679349,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 679356,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 679867,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 679874,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 679897,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 679910,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 679916,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 679932,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 679938,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 679960,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 679976,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 679983,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 679999,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 680005,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 680027,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 680044,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 680051,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 680067,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 680073,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 680095,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 680111,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 680117,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 680134,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 680140,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 680162,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 680179,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 680186,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 680202,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 680208,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 680230,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 680247,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 680253,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 680269,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 680275,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 680299,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 680314,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 680320,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 680337,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 680343,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 680359,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 680365,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 680386,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 680402,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 680419,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 680435,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 680451,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 680468,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 680484,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 680500,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 680518,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 680534,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 680550,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 680566,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 680572,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 680592,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "N",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 680595,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 680600,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 680617,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 680623,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 680645,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 680658,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 680664,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 680681,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 680687,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 680709,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 680721,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 680727,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 680743,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 680749,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 680771,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 680783,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 680789,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 680806,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 680812,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 680834,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 680858,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 680864,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 680881,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 680887,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 680909,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 680922,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 680929,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 680957,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 680963,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 680997,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 681021,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 681027,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 681045,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 681062,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 681085,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 681097,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 681104,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 681120,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 681126,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 681149,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 681162,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 681168,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 681185,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 681191,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 681214,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 681227,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 681233,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 681250,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 681256,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 681279,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 681293,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 681299,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 681316,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 681322,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 681344,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 681358,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 681364,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 681380,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 681386,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 681420,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 681435,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 681442,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 681459,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 681476,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 681515,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 681528,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 681535,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 681563,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 681569,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 681591,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 681604,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 681610,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 681627,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 681644,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 681668,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 681691,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 681698,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 681725,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 681732,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 681765,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 681790,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 681796,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 681824,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 681845,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 681868,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 65536 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 681886,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 681893,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 681944,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 681950,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 681985,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 131072 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 682016,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 682022,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 682038,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 682044,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 682066,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 262144 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 682082,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 682088,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 682104,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 682110,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 682132,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 524288 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 682147,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 682154,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 682170,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 682176,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 682198,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 1048576 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 682214,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 682220,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 682237,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 682243,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabBlockAllocator.AllocateBlock",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 682265,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Allocation alignment is not a multiple of the block size. (4194304 vs 2097152 bytes).",
+        "ID": 1
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 682280,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 682287,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 682330,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 682337,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 682354,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "O",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 682360,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 0
+        }
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 682383,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 682400,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 682428,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (8388608 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 682456,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 682472,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 682500,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 682543,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 682560,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 682576,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (33554432 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 682593,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 682609,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
+    },
+    {
+      "name": "SlabMemoryAllocator.TryAllocateMemory",
+      "cat": "0",
+      "ph": "i",
+      "tid": 16484,
+      "ts": 682625,
+      "pid": "GPGMM",
+      "args": {
+        "Description": "Aligned allocation size exceeded the slab size (67108864 vs 4194304 bytes).",
+        "ID": 0
+      }
     },
     {
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 478282,
+      "tid": 16484,
+      "ts": 682654,
       "pid": "GPGMM",
       "args": {
         "Flags": 0,
         "RecordOptions": {
-          "Flags": 1
+          "Flags": 6
         },
         "IsUMA": 1,
         "ResourceHeapTier": 2,
@@ -107,8 +13971,8 @@
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 478353,
+      "tid": 16484,
+      "ts": 682714,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -135,27 +13999,11 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 478355,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 478357,
-      "pid": "GPGMM"
-    },
-    {
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 478376,
+      "tid": 16484,
+      "ts": 682732,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (134217728 vs 4194304 bytes).",
@@ -163,19 +14011,11 @@
       }
     },
     {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 478379,
-      "pid": "GPGMM"
-    },
-    {
       "name": "ResourceAllocator.TryAllocateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 478392,
+      "tid": 16484,
+      "ts": 682747,
       "pid": "GPGMM",
       "args": {
         "Description": "Resource memory could not be allocated.",
@@ -183,41 +14023,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "i",
-      "tid": 18876,
-      "ts": 478406,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Suballocation was attempted but failed.",
-        "ID": 1
-      }
-    },
-    {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 478411,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332715a50",
-      "tid": 18876,
-      "ts": 478411,
+      "id": "0x22ababb58b0",
+      "tid": 16484,
+      "ts": 682749,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332715a50",
-      "tid": 18876,
-      "ts": 478417,
+      "id": "0x22ababb58b0",
+      "tid": 16484,
+      "ts": 682754,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -226,29 +14046,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 478419,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332717160",
-      "tid": 18876,
-      "ts": 518123,
+      "id": "0x22ababb50d0",
+      "tid": 16484,
+      "ts": 683109,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332717160",
-      "tid": 18876,
-      "ts": 518161,
+      "id": "0x22ababb50d0",
+      "tid": 16484,
+      "ts": 683141,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -263,9 +14075,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332717160",
-      "tid": 18876,
-      "ts": 518182,
+      "id": "0x22ababb50d0",
+      "tid": 16484,
+      "ts": 683163,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -277,28 +14089,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 518184,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 518186,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332717160",
-      "tid": 18876,
-      "ts": 518202,
+      "id": "0x22ababb50d0",
+      "tid": 16484,
+      "ts": 683182,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -307,7 +14103,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x29332715a50"
+            "id_ref": "0x22ababb58b0"
           }
         }
       }
@@ -316,9 +14112,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332717160",
-      "tid": 18876,
-      "ts": 518239,
+      "id": "0x22ababb50d0",
+      "tid": 16484,
+      "ts": 683260,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -327,7 +14123,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x29332715a50"
+            "id_ref": "0x22ababb58b0"
           }
         }
       }
@@ -336,18 +14132,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332722d00",
-      "tid": 18876,
-      "ts": 518242,
+      "id": "0x22ababbe340",
+      "tid": 16484,
+      "ts": 683263,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332722d00",
-      "tid": 18876,
-      "ts": 518256,
+      "id": "0x22ababbe340",
+      "tid": 16484,
+      "ts": 683279,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -356,7 +14152,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x29332717160"
+            "id_ref": "0x22ababb50d0"
           }
         }
       }
@@ -364,17 +14160,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 518258,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 518380,
+      "tid": 16484,
+      "ts": 683446,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -401,27 +14189,11 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 518382,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 518389,
-      "pid": "GPGMM"
-    },
-    {
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 518410,
+      "tid": 16484,
+      "ts": 683466,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (134217728 vs 4194304 bytes).",
@@ -429,19 +14201,11 @@
       }
     },
     {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 518412,
-      "pid": "GPGMM"
-    },
-    {
       "name": "ResourceAllocator.TryAllocateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 518424,
+      "tid": 16484,
+      "ts": 683480,
       "pid": "GPGMM",
       "args": {
         "Description": "Resource memory could not be allocated.",
@@ -449,41 +14213,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "i",
-      "tid": 18876,
-      "ts": 518438,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Suballocation was attempted but failed.",
-        "ID": 1
-      }
-    },
-    {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 518440,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332716ce0",
-      "tid": 18876,
-      "ts": 518441,
+      "id": "0x22ababb43e0",
+      "tid": 16484,
+      "ts": 683483,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332716ce0",
-      "tid": 18876,
-      "ts": 518447,
+      "id": "0x22ababb43e0",
+      "tid": 16484,
+      "ts": 683488,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -492,29 +14236,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 518449,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332715540",
-      "tid": 18876,
-      "ts": 559634,
+      "id": "0x22ababb4590",
+      "tid": 16484,
+      "ts": 683777,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332715540",
-      "tid": 18876,
-      "ts": 559677,
+      "id": "0x22ababb4590",
+      "tid": 16484,
+      "ts": 683808,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -529,9 +14265,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332715540",
-      "tid": 18876,
-      "ts": 559699,
+      "id": "0x22ababb4590",
+      "tid": 16484,
+      "ts": 683826,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -543,28 +14279,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 559701,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 559704,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332715540",
-      "tid": 18876,
-      "ts": 559721,
+      "id": "0x22ababb4590",
+      "tid": 16484,
+      "ts": 683844,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -573,7 +14293,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x29332716ce0"
+            "id_ref": "0x22ababb43e0"
           }
         }
       }
@@ -582,9 +14302,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332715540",
-      "tid": 18876,
-      "ts": 559761,
+      "id": "0x22ababb4590",
+      "tid": 16484,
+      "ts": 683920,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -593,7 +14313,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x29332716ce0"
+            "id_ref": "0x22ababb43e0"
           }
         }
       }
@@ -602,18 +14322,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x293327226d0",
-      "tid": 18876,
-      "ts": 559764,
+      "id": "0x22ababbfec0",
+      "tid": 16484,
+      "ts": 683923,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327226d0",
-      "tid": 18876,
-      "ts": 559779,
+      "id": "0x22ababbfec0",
+      "tid": 16484,
+      "ts": 683938,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -622,7 +14342,7 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x29332715540"
+            "id_ref": "0x22ababb4590"
           }
         }
       }
@@ -630,17 +14350,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 559781,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 559925,
+      "tid": 16484,
+      "ts": 684053,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -667,44 +14379,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 559927,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 559929,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 559935,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 559941,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x2932f6d3558",
-      "tid": 18876,
-      "ts": 559953,
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 684069,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -713,29 +14393,12 @@
       }
     },
     {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 559956,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x29332716f20",
-      "tid": 18876,
-      "ts": 559957,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332716f20",
-      "tid": 18876,
-      "ts": 559962,
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 684076,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -744,29 +14407,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 559964,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x293327168f0",
-      "tid": 18876,
-      "ts": 560602,
+      "id": "0x22ababb5550",
+      "tid": 16484,
+      "ts": 684429,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327168f0",
-      "tid": 18876,
-      "ts": 560621,
+      "id": "0x22ababb5550",
+      "tid": 16484,
+      "ts": 684449,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -781,9 +14436,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327168f0",
-      "tid": 18876,
-      "ts": 560637,
+      "id": "0x22ababb5550",
+      "tid": 16484,
+      "ts": 684467,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -795,28 +14450,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 560647,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 560648,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x2932f6d3558",
-      "tid": 18876,
-      "ts": 560655,
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 684477,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -825,36 +14464,12 @@
       }
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 560657,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 560659,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 560660,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327168f0",
-      "tid": 18876,
-      "ts": 560674,
+      "id": "0x22ababb5550",
+      "tid": 16484,
+      "ts": 684497,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -863,7 +14478,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x29332716f20"
+            "id_ref": "0x22ab65b4c80"
           }
         }
       }
@@ -872,9 +14487,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327168f0",
-      "tid": 18876,
-      "ts": 560700,
+      "id": "0x22ababb5550",
+      "tid": 16484,
+      "ts": 684573,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -883,7 +14498,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x29332716f20"
+            "id_ref": "0x22ab65b4c80"
           }
         }
       }
@@ -892,18 +14507,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332723540",
-      "tid": 18876,
-      "ts": 560702,
+      "id": "0x22ababbf310",
+      "tid": 16484,
+      "ts": 684576,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332723540",
-      "tid": 18876,
-      "ts": 560716,
+      "id": "0x22ababbf310",
+      "tid": 16484,
+      "ts": 684591,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -912,7 +14527,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x293327168f0"
+            "id_ref": "0x22ababb5550"
           }
         }
       }
@@ -920,17 +14535,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 560718,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 560832,
+      "tid": 16484,
+      "ts": 684717,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -957,27 +14564,11 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 560833,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 560834,
-      "pid": "GPGMM"
-    },
-    {
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 560853,
+      "tid": 16484,
+      "ts": 684737,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (134217728 vs 4194304 bytes).",
@@ -985,19 +14576,11 @@
       }
     },
     {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 560855,
-      "pid": "GPGMM"
-    },
-    {
       "name": "ResourceAllocator.TryAllocateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 560867,
+      "tid": 16484,
+      "ts": 684751,
       "pid": "GPGMM",
       "args": {
         "Description": "Resource memory could not be allocated.",
@@ -1005,32 +14588,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "i",
-      "tid": 18876,
-      "ts": 560879,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Suballocation was attempted but failed.",
-        "ID": 1
-      }
-    },
-    {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 560881,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332716ce0",
-      "tid": 18876,
-      "ts": 560886,
+      "id": "0x22ababb43e0",
+      "tid": 16484,
+      "ts": 684758,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1039,29 +14602,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 560888,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332715ed0",
-      "tid": 18876,
-      "ts": 600422,
+      "id": "0x22ababb59d0",
+      "tid": 16484,
+      "ts": 685049,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332715ed0",
-      "tid": 18876,
-      "ts": 600460,
+      "id": "0x22ababb59d0",
+      "tid": 16484,
+      "ts": 685069,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1076,9 +14631,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332715ed0",
-      "tid": 18876,
-      "ts": 600480,
+      "id": "0x22ababb59d0",
+      "tid": 16484,
+      "ts": 685087,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1090,28 +14645,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 600482,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 600485,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332715ed0",
-      "tid": 18876,
-      "ts": 600500,
+      "id": "0x22ababb59d0",
+      "tid": 16484,
+      "ts": 685105,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1120,7 +14659,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x29332716ce0"
+            "id_ref": "0x22ababb43e0"
           }
         }
       }
@@ -1129,9 +14668,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332715ed0",
-      "tid": 18876,
-      "ts": 600537,
+      "id": "0x22ababb59d0",
+      "tid": 16484,
+      "ts": 685179,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1140,7 +14679,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x29332716ce0"
+            "id_ref": "0x22ababb43e0"
           }
         }
       }
@@ -1149,18 +14688,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332722c50",
-      "tid": 18876,
-      "ts": 600539,
+      "id": "0x22ababbf940",
+      "tid": 16484,
+      "ts": 685182,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332722c50",
-      "tid": 18876,
-      "ts": 600553,
+      "id": "0x22ababbf940",
+      "tid": 16484,
+      "ts": 685196,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1169,42 +14708,18 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x29332715ed0"
+            "id_ref": "0x22ababb59d0"
           }
         }
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 600556,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 600712,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 600713,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332715a50",
-      "tid": 18876,
-      "ts": 600756,
+      "id": "0x22ababb58b0",
+      "tid": 16484,
+      "ts": 685300,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1213,36 +14728,20 @@
       }
     },
     {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 600758,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332722d00",
-      "tid": 18876,
-      "ts": 600764,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 600765,
+      "id": "0x22ababbe340",
+      "tid": 16484,
+      "ts": 685359,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 600875,
+      "tid": 16484,
+      "ts": 685414,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1269,44 +14768,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 600876,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 600879,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 600885,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 600890,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x2932f6d2758",
-      "tid": 18876,
-      "ts": 600917,
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 685430,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1315,29 +14782,12 @@
       }
     },
     {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 600919,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x29332716d70",
-      "tid": 18876,
-      "ts": 600920,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332716d70",
-      "tid": 18876,
-      "ts": 600940,
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 685437,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1346,29 +14796,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 600942,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332716a10",
-      "tid": 18876,
-      "ts": 601618,
+      "id": "0x22ababb4350",
+      "tid": 16484,
+      "ts": 685796,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332716a10",
-      "tid": 18876,
-      "ts": 601637,
+      "id": "0x22ababb4350",
+      "tid": 16484,
+      "ts": 685816,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1383,9 +14825,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332716a10",
-      "tid": 18876,
-      "ts": 601653,
+      "id": "0x22ababb4350",
+      "tid": 16484,
+      "ts": 685833,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1397,28 +14839,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 601655,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 601657,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x2932f6d2758",
-      "tid": 18876,
-      "ts": 601663,
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 685843,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1427,36 +14853,12 @@
       }
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 601665,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 601667,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 601668,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332716a10",
-      "tid": 18876,
-      "ts": 601682,
+      "id": "0x22ababb4350",
+      "tid": 16484,
+      "ts": 685865,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1465,7 +14867,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x29332716d70"
+            "id_ref": "0x22ab65b3180"
           }
         }
       }
@@ -1474,9 +14876,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332716a10",
-      "tid": 18876,
-      "ts": 601709,
+      "id": "0x22ababb4350",
+      "tid": 16484,
+      "ts": 685940,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1485,7 +14887,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x29332716d70"
+            "id_ref": "0x22ab65b3180"
           }
         }
       }
@@ -1494,18 +14896,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332722d00",
-      "tid": 18876,
-      "ts": 601711,
+      "id": "0x22ababbe290",
+      "tid": 16484,
+      "ts": 685942,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332722d00",
-      "tid": 18876,
-      "ts": 601725,
+      "id": "0x22ababbe290",
+      "tid": 16484,
+      "ts": 685957,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1514,42 +14916,18 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332716a10"
+            "id_ref": "0x22ababb4350"
           }
         }
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 601727,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 601869,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 601869,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332716ce0",
-      "tid": 18876,
-      "ts": 601879,
+      "id": "0x22ababb43e0",
+      "tid": 16484,
+      "ts": 686071,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1558,36 +14936,20 @@
       }
     },
     {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 601913,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x293327226d0",
-      "tid": 18876,
-      "ts": 601932,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 601933,
+      "id": "0x22ababbfec0",
+      "tid": 16484,
+      "ts": 686120,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 601979,
+      "tid": 16484,
+      "ts": 686174,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1614,44 +14976,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 601981,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 601982,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 601985,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 601988,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x2932f6d3558",
-      "tid": 18876,
-      "ts": 601997,
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 686189,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1660,20 +14990,12 @@
       }
     },
     {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 601999,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332716f20",
-      "tid": 18876,
-      "ts": 602003,
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 686196,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1682,29 +15004,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 602004,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x293327156f0",
-      "tid": 18876,
-      "ts": 602690,
+      "id": "0x22ababb4d70",
+      "tid": 16484,
+      "ts": 686556,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327156f0",
-      "tid": 18876,
-      "ts": 602709,
+      "id": "0x22ababb4d70",
+      "tid": 16484,
+      "ts": 686576,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1719,9 +15033,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327156f0",
-      "tid": 18876,
-      "ts": 602725,
+      "id": "0x22ababb4d70",
+      "tid": 16484,
+      "ts": 686594,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1733,28 +15047,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 602726,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 602728,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x2932f6d3558",
-      "tid": 18876,
-      "ts": 602734,
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 686604,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1763,36 +15061,12 @@
       }
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 602736,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 602738,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 602739,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327156f0",
-      "tid": 18876,
-      "ts": 602753,
+      "id": "0x22ababb4d70",
+      "tid": 16484,
+      "ts": 686625,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1801,7 +15075,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x29332716f20"
+            "id_ref": "0x22ab65b4c80"
           }
         }
       }
@@ -1810,9 +15084,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327156f0",
-      "tid": 18876,
-      "ts": 602777,
+      "id": "0x22ababb4d70",
+      "tid": 16484,
+      "ts": 686700,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1821,7 +15095,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x29332716f20"
+            "id_ref": "0x22ab65b4c80"
           }
         }
       }
@@ -1830,18 +15104,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x293327231d0",
-      "tid": 18876,
-      "ts": 602779,
+      "id": "0x22ababbfec0",
+      "tid": 16484,
+      "ts": 686703,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327231d0",
-      "tid": 18876,
-      "ts": 602793,
+      "id": "0x22ababbfec0",
+      "tid": 16484,
+      "ts": 686717,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1850,7 +15124,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x293327156f0"
+            "id_ref": "0x22ababb4d70"
           }
         }
       }
@@ -1858,17 +15132,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 602795,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 602905,
+      "tid": 16484,
+      "ts": 686855,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -1895,44 +15161,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 602909,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 602910,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 602914,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 602917,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x2932f6d2358",
-      "tid": 18876,
-      "ts": 602930,
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 686873,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1941,29 +15175,12 @@
       }
     },
     {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 602932,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "N",
-      "id": "0x293327166b0",
-      "tid": 18876,
-      "ts": 602933,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327166b0",
-      "tid": 18876,
-      "ts": 602937,
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 686881,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -1972,29 +15189,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 602939,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332715780",
-      "tid": 18876,
-      "ts": 603480,
+      "id": "0x22abaac0ce0",
+      "tid": 16484,
+      "ts": 687252,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332715780",
-      "tid": 18876,
-      "ts": 603499,
+      "id": "0x22abaac0ce0",
+      "tid": 16484,
+      "ts": 687272,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2009,9 +15218,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332715780",
-      "tid": 18876,
-      "ts": 603514,
+      "id": "0x22abaac0ce0",
+      "tid": 16484,
+      "ts": 687292,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2023,28 +15232,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 603516,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 603518,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x2932f6d2358",
-      "tid": 18876,
-      "ts": 603523,
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 687303,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2053,36 +15246,12 @@
       }
     },
     {
-      "name": "BuddyMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 603526,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 603527,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 603528,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332715780",
-      "tid": 18876,
-      "ts": 603542,
+      "id": "0x22abaac0ce0",
+      "tid": 16484,
+      "ts": 687324,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2091,7 +15260,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x293327166b0"
+            "id_ref": "0x22ab65b39f0"
           }
         }
       }
@@ -2100,9 +15269,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332715780",
-      "tid": 18876,
-      "ts": 603571,
+      "id": "0x22abaac0ce0",
+      "tid": 16484,
+      "ts": 687397,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2111,7 +15280,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 2,
           "MemoryPool": {
-            "id_ref": "0x293327166b0"
+            "id_ref": "0x22ab65b39f0"
           }
         }
       }
@@ -2120,18 +15289,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332722830",
-      "tid": 18876,
-      "ts": 603573,
+      "id": "0x22ababbe600",
+      "tid": 16484,
+      "ts": 687400,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332722830",
-      "tid": 18876,
-      "ts": 603587,
+      "id": "0x22ababbe600",
+      "tid": 16484,
+      "ts": 687415,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2140,7 +15309,7 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x29332715780"
+            "id_ref": "0x22abaac0ce0"
           }
         }
       }
@@ -2148,17 +15317,9 @@
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 603589,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 603698,
+      "tid": 16484,
+      "ts": 687536,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -2185,52 +15346,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 603699,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 603700,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 603702,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 603704,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 603705,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327168f0",
-      "tid": 18876,
-      "ts": 603719,
+      "id": "0x22ababb5550",
+      "tid": 16484,
+      "ts": 687559,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2239,7 +15360,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 3,
           "MemoryPool": {
-            "id_ref": "0x29332716f20"
+            "id_ref": "0x22ab65b4c80"
           }
         }
       }
@@ -2248,9 +15369,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327168f0",
-      "tid": 18876,
-      "ts": 603743,
+      "id": "0x22ababb5550",
+      "tid": 16484,
+      "ts": 687633,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2259,7 +15380,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 3,
           "MemoryPool": {
-            "id_ref": "0x29332716f20"
+            "id_ref": "0x22ab65b4c80"
           }
         }
       }
@@ -2268,18 +15389,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332722a40",
-      "tid": 18876,
-      "ts": 603746,
+      "id": "0x22ababb1830",
+      "tid": 16484,
+      "ts": 687636,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332722a40",
-      "tid": 18876,
-      "ts": 603759,
+      "id": "0x22ababb1830",
+      "tid": 16484,
+      "ts": 687651,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2288,82 +15409,26 @@
           "OffsetFromResource": 0,
           "Method": 2,
           "ResourceHeap": {
-            "id_ref": "0x293327168f0"
+            "id_ref": "0x22ababb5550"
           }
         }
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 603761,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 603811,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 603811,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 603812,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 603813,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 603813,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332723540",
-      "tid": 18876,
-      "ts": 603816,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 603816,
+      "id": "0x22ababbf310",
+      "tid": 16484,
+      "ts": 687763,
       "pid": "GPGMM"
     },
     {
       "name": "ResourceAllocator.CreateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 603860,
+      "tid": 16484,
+      "ts": 687816,
       "pid": "GPGMM",
       "args": {
         "allocationDescriptor": {
@@ -2390,27 +15455,11 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 603861,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 603862,
-      "pid": "GPGMM"
-    },
-    {
       "name": "SlabMemoryAllocator.TryAllocateMemory",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 603880,
+      "tid": 16484,
+      "ts": 687835,
       "pid": "GPGMM",
       "args": {
         "Description": "Aligned allocation size exceeded the slab size (16777216 vs 4194304 bytes).",
@@ -2418,19 +15467,11 @@
       }
     },
     {
-      "name": "SlabCacheAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 603881,
-      "pid": "GPGMM"
-    },
-    {
       "name": "ResourceAllocator.TryAllocateResource",
       "cat": "0",
       "ph": "i",
-      "tid": 18876,
-      "ts": 603893,
+      "tid": 16484,
+      "ts": 687852,
       "pid": "GPGMM",
       "args": {
         "Description": "Resource memory could not be allocated.",
@@ -2438,41 +15479,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "i",
-      "tid": 18876,
-      "ts": 603906,
-      "pid": "GPGMM",
-      "args": {
-        "Description": "Suballocation was attempted but failed.",
-        "ID": 1
-      }
-    },
-    {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 603908,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332716bc0",
-      "tid": 18876,
-      "ts": 603909,
+      "id": "0x22abaac1af0",
+      "tid": 16484,
+      "ts": 687854,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332716bc0",
-      "tid": 18876,
-      "ts": 603913,
+      "id": "0x22abaac1af0",
+      "tid": 16484,
+      "ts": 687859,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2481,29 +15502,21 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 603915,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "N",
-      "id": "0x293327162c0",
-      "tid": 18876,
-      "ts": 605614,
+      "id": "0x22abaac0e00",
+      "tid": 16484,
+      "ts": 688854,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327162c0",
-      "tid": 18876,
-      "ts": 605633,
+      "id": "0x22abaac0e00",
+      "tid": 16484,
+      "ts": 688876,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2518,9 +15531,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327162c0",
-      "tid": 18876,
-      "ts": 605648,
+      "id": "0x22abaac0e00",
+      "tid": 16484,
+      "ts": 688896,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2532,28 +15545,12 @@
       }
     },
     {
-      "name": "ResourceAllocator.CreateResourceHeap",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 605650,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SegmentedMemoryAllocator.TryAllocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 605651,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327162c0",
-      "tid": 18876,
-      "ts": 605665,
+      "id": "0x22abaac0e00",
+      "tid": 16484,
+      "ts": 688918,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2562,7 +15559,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x29332716bc0"
+            "id_ref": "0x22abaac1af0"
           }
         }
       }
@@ -2571,9 +15568,9 @@
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327162c0",
-      "tid": 18876,
-      "ts": 605688,
+      "id": "0x22abaac0e00",
+      "tid": 16484,
+      "ts": 689015,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2582,7 +15579,7 @@
           "MemorySegmentGroup": 0,
           "SubAllocatedRefs": 0,
           "MemoryPool": {
-            "id_ref": "0x29332716bc0"
+            "id_ref": "0x22abaac1af0"
           }
         }
       }
@@ -2591,18 +15588,18 @@
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "N",
-      "id": "0x29332723330",
-      "tid": 18876,
-      "ts": 605690,
+      "id": "0x22abaacde20",
+      "tid": 16484,
+      "ts": 689018,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332723330",
-      "tid": 18876,
-      "ts": 605703,
+      "id": "0x22abaacde20",
+      "tid": 16484,
+      "ts": 689037,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2611,42 +15608,18 @@
           "OffsetFromResource": 0,
           "Method": 0,
           "ResourceHeap": {
-            "id_ref": "0x293327162c0"
+            "id_ref": "0x22abaac0e00"
           }
         }
       }
     },
     {
-      "name": "ResourceAllocator.CreateResource",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 605705,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 605783,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 605783,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332716ce0",
-      "tid": 18876,
-      "ts": 605791,
+      "id": "0x22ababb43e0",
+      "tid": 16484,
+      "ts": 689148,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2655,53 +15628,21 @@
       }
     },
     {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 605793,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332722c50",
-      "tid": 18876,
-      "ts": 605795,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 605796,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 605814,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 605815,
+      "id": "0x22ababbf940",
+      "tid": 16484,
+      "ts": 689201,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332716bc0",
-      "tid": 18876,
-      "ts": 605823,
+      "id": "0x22abaac1af0",
+      "tid": 16484,
+      "ts": 689262,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2710,69 +15651,21 @@
       }
     },
     {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 605825,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332723330",
-      "tid": 18876,
-      "ts": 605826,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 605826,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 605865,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 605866,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 605867,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 605867,
+      "id": "0x22abaacde20",
+      "tid": 16484,
+      "ts": 689314,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x2932f6d3558",
-      "tid": 18876,
-      "ts": 605874,
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 689377,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2781,115 +15674,35 @@
       }
     },
     {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 605876,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332716f20",
-      "tid": 18876,
-      "ts": 605885,
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 689389,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "PoolSize": 4194304
         }
       }
-    },
-    {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 605887,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 605887,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 605887,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 605893,
-      "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332722a40",
-      "tid": 18876,
-      "ts": 605894,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 605895,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 605934,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 605934,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 605935,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 605936,
+      "id": "0x22ababb1830",
+      "tid": 16484,
+      "ts": 689439,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x2932f6d3558",
-      "tid": 18876,
-      "ts": 605946,
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 689503,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2898,20 +15711,12 @@
       }
     },
     {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 605948,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x29332716f20",
-      "tid": 18876,
-      "ts": 605954,
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 689512,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -2920,93 +15725,58 @@
       }
     },
     {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
+      "name": "GPUMemoryAllocation",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 605955,
+      "ph": "D",
+      "id": "0x22ababbfec0",
+      "tid": 16484,
+      "ts": 689576,
       "pid": "GPGMM"
     },
     {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
+      "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 605956,
-      "pid": "GPGMM"
+      "ph": "O",
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 689660,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 4194304
+        }
+      }
     },
     {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
+      "name": "GPUMemoryPool",
       "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 605956,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 605959,
-      "pid": "GPGMM"
+      "ph": "O",
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 689672,
+      "pid": "GPGMM",
+      "args": {
+        "snapshot": {
+          "PoolSize": 4194304
+        }
+      }
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x293327231d0",
-      "tid": 18876,
-      "ts": 605961,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 605961,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 606000,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 606030,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 606031,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 606032,
+      "id": "0x22ababbe600",
+      "tid": 16484,
+      "ts": 689723,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x2932f6d2358",
-      "tid": 18876,
-      "ts": 606042,
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 689788,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
@@ -3015,398 +15785,278 @@
       }
     },
     {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 606044,
-      "pid": "GPGMM"
-    },
-    {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "O",
-      "id": "0x293327166b0",
-      "tid": 18876,
-      "ts": 606051,
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 689799,
       "pid": "GPGMM",
       "args": {
         "snapshot": {
           "PoolSize": 4194304
         }
       }
-    },
-    {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 606053,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 606053,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 606053,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 606057,
-      "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocation",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332722830",
-      "tid": 18876,
-      "ts": 606058,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 606059,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 606098,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 606098,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 606099,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 606100,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x2932f6d2758",
-      "tid": 18876,
-      "ts": 606110,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 4194304
-        }
-      }
-    },
-    {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "B",
-      "tid": 18876,
-      "ts": 606112,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryPool",
-      "cat": "0",
-      "ph": "O",
-      "id": "0x29332716d70",
-      "tid": 18876,
-      "ts": 606119,
-      "pid": "GPGMM",
-      "args": {
-        "snapshot": {
-          "PoolSize": 4194304
-        }
-      }
-    },
-    {
-      "name": "SegmentedMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 606120,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "BuddyMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 606121,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabMemoryAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 606121,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "SlabCacheAllocator.DeallocateMemory",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 606124,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "GPUMemoryAllocation",
-      "cat": "0",
-      "ph": "D",
-      "id": "0x29332722d00",
-      "tid": 18876,
-      "ts": 606125,
-      "pid": "GPGMM"
-    },
-    {
-      "name": "ResourceAllocation.Release",
-      "cat": "0",
-      "ph": "E",
-      "tid": 18876,
-      "ts": 606126,
+      "id": "0x22ababbe290",
+      "tid": 16484,
+      "ts": 689849,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryAllocator",
       "cat": "0",
       "ph": "D",
-      "id": "0x2932f64b8e0",
-      "tid": 18876,
-      "ts": 606136,
+      "id": "0x22abadf0600",
+      "tid": 16484,
+      "ts": 689862,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x2932f6d2358",
-      "tid": 18876,
-      "ts": 606142,
+      "id": "0x22abadee868",
+      "tid": 16484,
+      "ts": 689878,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332715780",
-      "tid": 18876,
-      "ts": 606145,
+      "id": "0x22abaac0ce0",
+      "tid": 16484,
+      "ts": 689881,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x293327166b0",
-      "tid": 18876,
-      "ts": 606261,
+      "id": "0x22ab65b39f0",
+      "tid": 16484,
+      "ts": 690077,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x2932f6d2758",
-      "tid": 18876,
-      "ts": 606264,
+      "id": "0x22abadefe68",
+      "tid": 16484,
+      "ts": 690102,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332716a10",
-      "tid": 18876,
-      "ts": 606266,
+      "id": "0x22ababb4350",
+      "tid": 16484,
+      "ts": 690104,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332716d70",
-      "tid": 18876,
-      "ts": 606358,
+      "id": "0x22ab65b3180",
+      "tid": 16484,
+      "ts": 690255,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x2932f6d3558",
-      "tid": 18876,
-      "ts": 606376,
+      "id": "0x22abadef568",
+      "tid": 16484,
+      "ts": 690276,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x293327156f0",
-      "tid": 18876,
-      "ts": 606378,
+      "id": "0x22ababb4d70",
+      "tid": 16484,
+      "ts": 690278,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x293327168f0",
-      "tid": 18876,
-      "ts": 606481,
+      "id": "0x22ababb5550",
+      "tid": 16484,
+      "ts": 690456,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332716f20",
-      "tid": 18876,
-      "ts": 606588,
+      "id": "0x22ab65b4c80",
+      "tid": 16484,
+      "ts": 690633,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x2932f6d2a58",
-      "tid": 18876,
-      "ts": 606591,
+      "id": "0x22abadeec68",
+      "tid": 16484,
+      "ts": 690656,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x2932f6d3f58",
-      "tid": 18876,
-      "ts": 606594,
+      "id": "0x22ab65b4020",
+      "tid": 16484,
+      "ts": 690658,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x2932f6d2b58",
-      "tid": 18876,
-      "ts": 606612,
+      "id": "0x22abadeef68",
+      "tid": 16484,
+      "ts": 690676,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x2932f6d3758",
-      "tid": 18876,
-      "ts": 606614,
+      "id": "0x22ab65b4f50",
+      "tid": 16484,
+      "ts": 690677,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x2932f6d3358",
-      "tid": 18876,
-      "ts": 606616,
+      "id": "0x22abadeff68",
+      "tid": 16484,
+      "ts": 690695,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x22ab65b42f0",
+      "tid": 16484,
+      "ts": 690696,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x22abadef668",
+      "tid": 16484,
+      "ts": 690713,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x22ababb5820",
+      "tid": 16484,
+      "ts": 690715,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x22abadeed68",
+      "tid": 16484,
+      "ts": 690732,
+      "pid": "GPGMM"
+    },
+    {
+      "name": "GPUMemoryPool",
+      "cat": "0",
+      "ph": "D",
+      "id": "0x22ababb5310",
+      "tid": 16484,
+      "ts": 690733,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332717160",
-      "tid": 18876,
-      "ts": 606620,
+      "id": "0x22ababb50d0",
+      "tid": 16484,
+      "ts": 690748,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332715a50",
-      "tid": 18876,
-      "ts": 606941,
+      "id": "0x22ababb58b0",
+      "tid": 16484,
+      "ts": 690928,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x293327162c0",
-      "tid": 18876,
-      "ts": 606943,
+      "id": "0x22abaac0e00",
+      "tid": 16484,
+      "ts": 690931,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332716bc0",
-      "tid": 18876,
-      "ts": 607085,
+      "id": "0x22abaac1af0",
+      "tid": 16484,
+      "ts": 691105,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332715ed0",
-      "tid": 18876,
-      "ts": 607086,
+      "id": "0x22ababb59d0",
+      "tid": 16484,
+      "ts": 691107,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryBlock",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332715540",
-      "tid": 18876,
-      "ts": 611715,
+      "id": "0x22ababb4590",
+      "tid": 16484,
+      "ts": 694199,
       "pid": "GPGMM"
     },
     {
       "name": "GPUMemoryPool",
       "cat": "0",
       "ph": "D",
-      "id": "0x29332716ce0",
-      "tid": 18876,
-      "ts": 637342,
+      "id": "0x22ababb43e0",
+      "tid": 16484,
+      "ts": 697696,
       "pid": "GPGMM"
     }
   ]

--- a/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
+++ b/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
@@ -145,7 +145,7 @@ TEST_F(D3D12ResourceAllocatorTests, CreateAllocator) {
 TEST_F(D3D12ResourceAllocatorTests, CreateAllocatorRecord) {
     ALLOCATOR_DESC desc = CreateBasicAllocatorDesc();
     desc.RecordOptions.Flags =
-        static_cast<ALLOCATOR_RECORD_FLAGS>(ALLOCATOR_RECORD_FLAG_TRACE_EVENTS);
+        static_cast<ALLOCATOR_RECORD_FLAGS>(ALLOCATOR_RECORD_FLAG_ALL_EVENTS);
 
     // Creating a new allocator that uses default record options should always succeed.
     {


### PR DESCRIPTION

Recording all event phases causes trace files to become too large. New recording flags were added to filter out event types based on activity (profling vs capture).