### PR TITLE
Fix bug where pool heaps were always used.

### DIFF
--- a/src/gpgmm/MemoryAllocator.cpp
+++ b/src/gpgmm/MemoryAllocator.cpp
@@ -20,6 +20,14 @@ namespace gpgmm {
         AppendChild(std::move(childAllocator));
     }
 
+    std::unique_ptr<MemoryAllocation> MemoryAllocator::TryAllocateMemory(uint64_t allocationSize,
+                                                                         uint64_t alignment,
+                                                                         bool neverAllocate,
+                                                                         bool cacheSize) {
+        ASSERT(false);
+        return {};
+    }
+
     void MemoryAllocator::ReleaseMemory() {
         for (auto alloc = mChildren.head(); alloc != mChildren.end(); alloc = alloc->next()) {
             alloc->value()->ReleaseMemory();

--- a/src/gpgmm/MemoryAllocator.h
+++ b/src/gpgmm/MemoryAllocator.h
@@ -61,7 +61,7 @@ namespace gpgmm {
         virtual std::unique_ptr<MemoryAllocation> TryAllocateMemory(uint64_t allocationSize,
                                                                     uint64_t alignment,
                                                                     bool neverAllocate,
-                                                                    bool cacheSize) = 0;
+                                                                    bool cacheSize);
 
         // Free the allocation by deallocating the block used to sub-allocate it and the underlying
         // memory block used with it. The |allocation| will be considered invalid after

--- a/src/gpgmm/SlabMemoryAllocator.cpp
+++ b/src/gpgmm/SlabMemoryAllocator.cpp
@@ -311,18 +311,11 @@ namespace gpgmm {
 
     MEMORY_ALLOCATOR_INFO SlabCacheAllocator::QueryInfo() const {
         MEMORY_ALLOCATOR_INFO info = {};
-        // Underlying memory allocator is weakly shared between cached slab allocators so it
-        // should only be counted once (by the SlabCacheAllocator).
         for (const auto& entry : mSizeCache) {
             const MEMORY_ALLOCATOR_INFO& childInfo = entry->GetValue().pSlabAllocator->QueryInfo();
             info.UsedBlockCount += childInfo.UsedBlockCount;
             info.UsedBlockUsage += childInfo.UsedBlockUsage;
         }
-
-        const MEMORY_ALLOCATOR_INFO& memoryInfo = mMemoryAllocator->QueryInfo();
-        info.UsedMemoryUsage += memoryInfo.UsedMemoryUsage;
-        info.UsedMemoryCount += memoryInfo.UsedMemoryCount;
-
         return info;
     }
 

--- a/src/gpgmm/d3d12/BufferAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/BufferAllocatorD3D12.cpp
@@ -65,20 +65,12 @@ namespace gpgmm { namespace d3d12 {
             return nullptr;
         }
 
-        mInfo.UsedMemoryCount++;
-        mInfo.UsedMemoryUsage += allocationSize;
-
         return std::make_unique<MemoryAllocation>(/*allocator*/ this, resourceHeap);
     }
 
     void BufferAllocator::DeallocateMemory(MemoryAllocation* allocation) {
         ASSERT(allocation != nullptr);
-        Heap* heap = ToBackend(allocation->GetMemory());
-
-        mInfo.UsedMemoryCount--;
-        mInfo.UsedMemoryUsage -= heap->GetSize();
-
-        mResourceAllocator->FreeResourceHeap(heap);
+        mResourceAllocator->DeallocateMemory(allocation);
     }
 
     uint64_t BufferAllocator::GetMemorySize() const {

--- a/src/gpgmm/d3d12/ResourceAllocationD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocationD3D12.h
@@ -41,29 +41,24 @@ namespace gpgmm { namespace d3d12 {
                                                   public NonCopyable,
                                                   public IUnknownImpl {
       public:
-        // Constructs a sub-allocation using a placed resource.
+        // Constructs a sub-allocated heap containing one or more resources.
         ResourceAllocation(ResidencyManager* residencyManager,
-                           MemoryAllocator* subAllocator,
+                           MemoryAllocator* allocator,
                            uint64_t offsetFromHeap,
                            Block* block,
                            ComPtr<ID3D12Resource> placedResource,
                            Heap* resourceHeap);
 
-        // Constructs a standalone allocation using a placed resource.
+        // Constructs a heap with only one resource.
         ResourceAllocation(ResidencyManager* residencyManager,
-                           MemoryAllocator* standaloneAllocator,
-                           ComPtr<ID3D12Resource> placedResource,
-                           Heap* resourceHeap);
-
-        // Constructs a standalone resource allocation.
-        ResourceAllocation(ResidencyManager* residencyManager,
-                           ResourceAllocator* resourceAllocator,
+                           MemoryAllocator* allocator,
+                           uint64_t offsetFromHeap,
                            ComPtr<ID3D12Resource> resource,
                            Heap* resourceHeap);
 
-        // Constructs a sub-allocated allocation within a resource.
+        // Constructs a sub-allocated resource within itself.
         ResourceAllocation(ResidencyManager* residencyManager,
-                           MemoryAllocator* subAllocator,
+                           MemoryAllocator* allocator,
                            Block* block,
                            uint64_t offsetFromResource,
                            ComPtr<ID3D12Resource> resource,
@@ -99,7 +94,6 @@ namespace gpgmm { namespace d3d12 {
         ~ResourceAllocation() override;
         void DeleteThis() override;
 
-        ResourceAllocator* const mResourceAllocator;
         ResidencyManager* const mResidencyManager;
         ComPtr<ID3D12Resource> mResource;
 

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -16,7 +16,7 @@
 #ifndef GPGMM_D3D12_RESOURCEALLOCATORD3D12_H_
 #define GPGMM_D3D12_RESOURCEALLOCATORD3D12_H_
 
-#include "gpgmm/Allocator.h"
+#include "gpgmm/MemoryAllocator.h"
 #include "gpgmm/common/Flags.h"
 #include "gpgmm/d3d12/IUnknownImplD3D12.h"
 #include "include/gpgmm_export.h"
@@ -258,7 +258,7 @@ namespace gpgmm { namespace d3d12 {
         ALLOCATOR_MESSAGE_ID ID;
     };
 
-    class GPGMM_EXPORT ResourceAllocator final : public AllocatorBase, public IUnknownImpl {
+    class GPGMM_EXPORT ResourceAllocator final : public MemoryAllocator, public IUnknownImpl {
       public:
         // Creates the allocator and residency manager instance used to manage video memory for the
         // App specified device and adapter. Residency manager only exists if this adapter at-least
@@ -334,10 +334,11 @@ namespace gpgmm { namespace d3d12 {
                                    uint64_t heapAlignment,
                                    Heap** resourceHeapOut);
 
-        void FreeResourceHeap(Heap* resourceHeap);
-
         HRESULT EnableDeviceObjectLeakChecks() const;
         HRESULT CheckForDeviceObjectLeaks() const;
+
+        // MemoryAllocator interface
+        void DeallocateMemory(MemoryAllocation* allocation) override;
 
         ComPtr<ID3D12Device> mDevice;
         ComPtr<ResidencyManager> mResidencyManager;
@@ -347,6 +348,7 @@ namespace gpgmm { namespace d3d12 {
         const bool mIsAlwaysCommitted;
         const bool mIsAlwaysInBudget;
         const uint64_t mMaxResourceHeapSize;
+        const uint64_t mMaxResourceSizeForPooling;
 
         static constexpr uint64_t kNumOfResourceHeapTypes = 8u;
 

--- a/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.cpp
@@ -49,20 +49,12 @@ namespace gpgmm { namespace d3d12 {
             return nullptr;
         }
 
-        mInfo.UsedMemoryCount++;
-        mInfo.UsedMemoryUsage += heapSize;
-
         return std::make_unique<MemoryAllocation>(/*allocator*/ this, resourceHeap);
     }
 
     void ResourceHeapAllocator::DeallocateMemory(MemoryAllocation* allocation) {
         ASSERT(allocation != nullptr);
-        Heap* heap = ToBackend(allocation->GetMemory());
-
-        mInfo.UsedMemoryCount--;
-        mInfo.UsedMemoryUsage -= heap->GetSize();
-
-        mResourceAllocator->FreeResourceHeap(heap);
+        mResourceAllocator->DeallocateMemory(allocation);
     }
 
 }}  // namespace gpgmm::d3d12


### PR DESCRIPTION
Fixes a bug when pooling was disabled (ex. MaxResourceSizeForPooling = 0) but the resource allocator (still) may choose a pool-based allocator when sub-allocation failed.