### PR TITLE
Track and report free device memory blocks.

### DIFF
--- a/src/gpgmm/JSONSerializer.cpp
+++ b/src/gpgmm/JSONSerializer.cpp
@@ -15,6 +15,7 @@
 #include "gpgmm/JSONSerializer.h"
 
 #include "gpgmm/Allocator.h"
+#include "gpgmm/MemoryAllocator.h"
 #include "gpgmm/MemoryPool.h"
 
 #include <sstream>
@@ -46,6 +47,18 @@ namespace gpgmm {
         ss << "{ "
            << "\"Description\": \"" << desc.Description << "\", "
            << "\"ID\": " << desc.ID << " }";
+        return ss.str();
+    }
+
+    // static
+    std::string JSONSerializer::AppendTo(const MEMORY_ALLOCATOR_INFO& info) {
+        std::stringstream ss;
+        ss << "{ "
+           << "\"UsedBlockCount\": " << info.UsedBlockCount << ", "
+           << "\"UsedMemoryCount\": " << info.UsedMemoryCount << ", "
+           << "\"UsedBlockUsage\": " << info.UsedBlockUsage << ", "
+           << "\"FreeMemoryUsage\": " << info.FreeMemoryUsage << ", "
+           << "\"UsedMemoryUsage\": " << info.UsedMemoryUsage << " }";
         return ss.str();
     }
 

--- a/src/gpgmm/JSONSerializer.h
+++ b/src/gpgmm/JSONSerializer.h
@@ -23,8 +23,9 @@
 namespace gpgmm {
 
     // Forward declare common types.
-    struct POOL_DESC;
     struct ALLOCATOR_MESSAGE;
+    struct POOL_DESC;
+    struct MEMORY_ALLOCATOR_INFO;
 
     // Messages of a given severity to be recorded as events.
     void SetRecordEventLevel(const LogSeverity& level);
@@ -32,8 +33,9 @@ namespace gpgmm {
 
     class JSONSerializer {
       public:
-        static std::string AppendTo(const POOL_DESC& desc);
         static std::string AppendTo(const ALLOCATOR_MESSAGE& desc);
+        static std::string AppendTo(const MEMORY_ALLOCATOR_INFO& info);
+        static std::string AppendTo(const POOL_DESC& desc);
     };
 
     template <typename T, typename DescT, typename SerializerT = JSONSerializer>

--- a/src/gpgmm/MemoryAllocator.h
+++ b/src/gpgmm/MemoryAllocator.h
@@ -40,6 +40,9 @@ namespace gpgmm {
 
         // Total size (in bytes) of used memory.
         uint64_t UsedMemoryUsage;
+
+        // Total size (in bytes) of free memory.
+        uint64_t FreeMemoryUsage;
     };
 
     class MemoryAllocator : public AllocatorBase, public AllocatorNode<MemoryAllocator> {

--- a/src/gpgmm/PooledMemoryAllocator.cpp
+++ b/src/gpgmm/PooledMemoryAllocator.cpp
@@ -37,10 +37,13 @@ namespace gpgmm {
                              allocation);
         }
 
+        mInfo.FreeMemoryUsage -= allocation->GetSize();
+
         return allocation;
     }
 
     void PooledMemoryAllocator::DeallocateMemory(MemoryAllocation* allocation) {
+        mInfo.FreeMemoryUsage += allocation->GetSize();
         mPool->ReturnToPool(std::unique_ptr<MemoryAllocation>(allocation));
     }
 }  // namespace gpgmm

--- a/src/gpgmm/SegmentedMemoryAllocator.cpp
+++ b/src/gpgmm/SegmentedMemoryAllocator.cpp
@@ -149,9 +149,13 @@ namespace gpgmm {
                              allocation);
         }
 
-        allocation->GetMemory()->SetPool(segment);
+        MemoryBase* memory = allocation->GetMemory();
+        ASSERT(memory != nullptr);
 
-        return std::make_unique<MemoryAllocation>(this, allocation->GetMemory());
+        memory->SetPool(segment);
+        mInfo.FreeMemoryUsage -= memory->GetSize();
+
+        return std::make_unique<MemoryAllocation>(this, memory);
     }
 
     void SegmentedMemoryAllocator::DeallocateMemory(MemoryAllocation* allocation) {
@@ -164,6 +168,8 @@ namespace gpgmm {
 
         MemoryPool* pool = memory->GetPool();
         ASSERT(pool != nullptr);
+
+        mInfo.FreeMemoryUsage += memory->GetSize();
 
         pool->ReturnToPool(std::make_unique<MemoryAllocation>(GetFirstChild(), memory));
     }

--- a/src/gpgmm/d3d12/JSONSerializerD3D12.cpp
+++ b/src/gpgmm/d3d12/JSONSerializerD3D12.cpp
@@ -172,17 +172,6 @@ namespace gpgmm { namespace d3d12 {
         return ss.str();
     }
 
-    // static
-    std::string JSONSerializer::AppendTo(const QUERY_RESOURCE_ALLOCATOR_INFO& desc) {
-        std::stringstream ss;
-        ss << "{ "
-           << "\"UsedBlockCount\": " << desc.UsedBlockCount << ", "
-           << "\"UsedResourceHeapCount\": " << desc.UsedResourceHeapCount << ", "
-           << "\"UsedBlockUsage\": " << desc.UsedBlockUsage << ", "
-           << "\"UsedResourceHeapUsage\": " << desc.UsedResourceHeapUsage << " }";
-        return ss.str();
-    }
-
     std::string JSONSerializer::AppendTo(const ALLOCATOR_MESSAGE& desc) {
         std::stringstream ss;
         ss << "{ "

--- a/src/gpgmm/d3d12/JSONSerializerD3D12.h
+++ b/src/gpgmm/d3d12/JSONSerializerD3D12.h
@@ -27,7 +27,6 @@ namespace gpgmm { namespace d3d12 {
     struct CREATE_RESOURCE_DESC;
     struct HEAP_DESC;
     struct RESOURCE_ALLOCATION_DESC;
-    struct QUERY_RESOURCE_ALLOCATOR_INFO;
     struct ALLOCATOR_MESSAGE;
 
     class JSONSerializer {
@@ -38,7 +37,6 @@ namespace gpgmm { namespace d3d12 {
         static std::string AppendTo(const D3D12_RESOURCE_DESC& desc);
         static std::string AppendTo(const HEAP_DESC& desc);
         static std::string AppendTo(const RESOURCE_ALLOCATION_DESC& desc);
-        static std::string AppendTo(const QUERY_RESOURCE_ALLOCATOR_INFO& desc);
         static std::string AppendTo(const ALLOCATOR_MESSAGE& desc);
 
       private:
@@ -55,7 +53,9 @@ namespace gpgmm { namespace d3d12 {
     }
 
     template <typename... Args>
-    static void LogAllocatorMessage(const LogSeverity& severity, const char* name, const Args&... args) {
+    static void LogAllocatorMessage(const LogSeverity& severity,
+                                    const char* name,
+                                    const Args&... args) {
         return gpgmm::LogCommon<ALLOCATOR_MESSAGE, JSONSerializer>(severity, name, args...);
     }
 

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -868,7 +868,7 @@ namespace gpgmm { namespace d3d12 {
         QUERY_RESOURCE_ALLOCATOR_INFO* resorceAllocationInfoOut) const {
         TRACE_EVENT_CALL_SCOPED("ResourceAllocator.QueryResourceAllocatorInfo");
 
-        QUERY_RESOURCE_ALLOCATOR_INFO infoOut = {};
+        MEMORY_ALLOCATOR_INFO infoOut = {};
         for (const auto& allocator : mResourceAllocatorOfType) {
             const MEMORY_ALLOCATOR_INFO& info = allocator->QueryInfo();
             infoOut.UsedBlockCount += info.UsedBlockCount;
@@ -881,10 +881,16 @@ namespace gpgmm { namespace d3d12 {
             infoOut.UsedBlockUsage += info.UsedBlockUsage;
         }
 
-        infoOut.UsedResourceHeapUsage = mInfo.UsedMemoryUsage;
-        infoOut.UsedResourceHeapCount = mInfo.UsedMemoryCount;
+        // Only ResourceAllocator can create/destroy resource heaps.
+        infoOut.UsedMemoryUsage = mInfo.UsedMemoryUsage;
+        infoOut.UsedMemoryCount = mInfo.UsedMemoryCount;
 
-        d3d12::LogEvent("GPUMemoryAllocator", this, infoOut);
+        for (const auto& allocator : mResourceHeapAllocatorOfType) {
+            const MEMORY_ALLOCATOR_INFO& info = allocator->QueryInfo();
+            infoOut.FreeMemoryUsage += info.FreeMemoryUsage;
+        }
+
+        gpgmm::LogEvent("GPUMemoryAllocator", this, infoOut);
 
         if (resorceAllocationInfoOut != nullptr) {
             *resorceAllocationInfoOut = infoOut;

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -223,12 +223,7 @@ namespace gpgmm { namespace d3d12 {
         const D3D12_CLEAR_VALUE* clearValue;
     };
 
-    struct QUERY_RESOURCE_ALLOCATOR_INFO {
-        uint32_t UsedBlockCount;
-        uint64_t UsedBlockUsage;
-        uint32_t UsedResourceHeapCount;
-        uint64_t UsedResourceHeapUsage;
-    };
+    using QUERY_RESOURCE_ALLOCATOR_INFO = MEMORY_ALLOCATOR_INFO;
 
     enum ALLOCATOR_MESSAGE_ID {
 

--- a/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
+++ b/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
@@ -631,7 +631,7 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferPooled) {
 }
 
 TEST_F(D3D12ResourceAllocatorTests, CreateBufferQueryInfo) {
-    // Calculate stats for a single standalone allocation.
+    // Calculate info for a single standalone allocation.
     {
         ALLOCATION_DESC standaloneAllocationDesc = {};
         standaloneAllocationDesc.Flags = ALLOCATION_FLAG_NEVER_SUBALLOCATE_MEMORY;
@@ -643,16 +643,16 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferQueryInfo) {
         ASSERT_NE(firstAllocation, nullptr);
         EXPECT_EQ(firstAllocation->GetMethod(), gpgmm::AllocationMethod::kStandalone);
 
-        QUERY_RESOURCE_ALLOCATOR_INFO stats = {};
-        ASSERT_SUCCEEDED(mDefaultAllocator->QueryResourceAllocatorInfo(&stats));
+        QUERY_RESOURCE_ALLOCATOR_INFO info = {};
+        ASSERT_SUCCEEDED(mDefaultAllocator->QueryResourceAllocatorInfo(&info));
 
-        EXPECT_EQ(stats.UsedResourceHeapCount, 1u);
-        EXPECT_EQ(stats.UsedResourceHeapUsage, kDefaultPreferredResourceHeapSize);
-        EXPECT_EQ(stats.UsedBlockCount, 0u);
-        EXPECT_EQ(stats.UsedBlockUsage, 0u);
+        EXPECT_EQ(info.UsedMemoryCount, 1u);
+        EXPECT_EQ(info.UsedMemoryUsage, kDefaultPreferredResourceHeapSize);
+        EXPECT_EQ(info.UsedBlockCount, 0u);
+        EXPECT_EQ(info.UsedBlockUsage, 0u);
     }
 
-    // Calculate stats for two pooled standalone allocations.
+    // Calculate info for two pooled standalone allocations.
     {
         ALLOCATOR_DESC allocatorDesc = CreateBasicAllocatorDesc();
         allocatorDesc.MaxResourceSizeForPooling = kDefaultPreferredResourceHeapSize;
@@ -671,13 +671,13 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferQueryInfo) {
         ASSERT_NE(firstAllocation, nullptr);
         EXPECT_EQ(firstAllocation->GetMethod(), gpgmm::AllocationMethod::kStandalone);
 
-        QUERY_RESOURCE_ALLOCATOR_INFO stats = {};
-        ASSERT_SUCCEEDED(resourceAllocator->QueryResourceAllocatorInfo(&stats));
+        QUERY_RESOURCE_ALLOCATOR_INFO info = {};
+        ASSERT_SUCCEEDED(resourceAllocator->QueryResourceAllocatorInfo(&info));
 
-        EXPECT_EQ(stats.UsedResourceHeapCount, 1u);
-        EXPECT_EQ(stats.UsedResourceHeapUsage, kDefaultPreferredResourceHeapSize);
-        EXPECT_EQ(stats.UsedBlockCount, 0u);
-        EXPECT_EQ(stats.UsedBlockUsage, 0u);
+        EXPECT_EQ(info.UsedMemoryCount, 1u);
+        EXPECT_EQ(info.UsedMemoryUsage, kDefaultPreferredResourceHeapSize);
+        EXPECT_EQ(info.UsedBlockCount, 0u);
+        EXPECT_EQ(info.UsedBlockUsage, 0u);
 
         ComPtr<ResourceAllocation> secondAllocation;
         ASSERT_SUCCEEDED(resourceAllocator->CreateResource(
@@ -686,15 +686,15 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferQueryInfo) {
         ASSERT_NE(secondAllocation, nullptr);
         EXPECT_EQ(secondAllocation->GetMethod(), gpgmm::AllocationMethod::kStandalone);
 
-        ASSERT_SUCCEEDED(resourceAllocator->QueryResourceAllocatorInfo(&stats));
+        ASSERT_SUCCEEDED(resourceAllocator->QueryResourceAllocatorInfo(&info));
 
-        EXPECT_EQ(stats.UsedResourceHeapCount, 2u);
-        EXPECT_EQ(stats.UsedResourceHeapUsage, kDefaultPreferredResourceHeapSize * 2);
-        EXPECT_EQ(stats.UsedBlockCount, 0u);
-        EXPECT_EQ(stats.UsedBlockUsage, 0u);
+        EXPECT_EQ(info.UsedMemoryCount, 2u);
+        EXPECT_EQ(info.UsedMemoryUsage, kDefaultPreferredResourceHeapSize * 2);
+        EXPECT_EQ(info.UsedBlockCount, 0u);
+        EXPECT_EQ(info.UsedBlockUsage, 0u);
     }
 
-    // Calculate stats for two sub-allocations.
+    // Calculate info for two sub-allocations.
     {
         ComPtr<ResourceAllocator> resourceAllocator;
         ASSERT_SUCCEEDED(
@@ -713,13 +713,13 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferQueryInfo) {
         // TODO: Consider testing counts by allocator type.
         GPGMM_SKIP_TEST_IF(firstAllocation->GetMethod() != gpgmm::AllocationMethod::kSubAllocated);
 
-        QUERY_RESOURCE_ALLOCATOR_INFO stats = {};
-        ASSERT_SUCCEEDED(resourceAllocator->QueryResourceAllocatorInfo(&stats));
+        QUERY_RESOURCE_ALLOCATOR_INFO info = {};
+        ASSERT_SUCCEEDED(resourceAllocator->QueryResourceAllocatorInfo(&info));
 
-        EXPECT_EQ(stats.UsedResourceHeapCount, 1u);
-        EXPECT_EQ(stats.UsedResourceHeapUsage, kDefaultPreferredResourceHeapSize);
-        EXPECT_EQ(stats.UsedBlockCount, 1u);
-        EXPECT_GE(stats.UsedBlockUsage, kBufferSize);
+        EXPECT_EQ(info.UsedMemoryCount, 1u);
+        EXPECT_EQ(info.UsedMemoryUsage, kDefaultPreferredResourceHeapSize);
+        EXPECT_EQ(info.UsedBlockCount, 1u);
+        EXPECT_GE(info.UsedBlockUsage, kBufferSize);
 
         ComPtr<ResourceAllocation> secondAllocation;
         ASSERT_SUCCEEDED(resourceAllocator->CreateResource({}, CreateBasicBufferDesc(kBufferSize),
@@ -728,15 +728,15 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferQueryInfo) {
         ASSERT_NE(secondAllocation, nullptr);
         EXPECT_EQ(secondAllocation->GetMethod(), gpgmm::AllocationMethod::kSubAllocated);
 
-        ASSERT_SUCCEEDED(resourceAllocator->QueryResourceAllocatorInfo(&stats));
+        ASSERT_SUCCEEDED(resourceAllocator->QueryResourceAllocatorInfo(&info));
 
-        EXPECT_GE(stats.UsedResourceHeapCount, 1u);
-        EXPECT_GE(stats.UsedResourceHeapUsage, kDefaultPreferredResourceHeapSize);
-        EXPECT_EQ(stats.UsedBlockCount, 2u);
-        EXPECT_GE(stats.UsedBlockUsage, kBufferSize * 2);
+        EXPECT_GE(info.UsedMemoryCount, 1u);
+        EXPECT_GE(info.UsedMemoryUsage, kDefaultPreferredResourceHeapSize);
+        EXPECT_EQ(info.UsedBlockCount, 2u);
+        EXPECT_GE(info.UsedBlockUsage, kBufferSize * 2);
     }
 
-    // Calculate stats for two sub-allocations within the same resource.
+    // Calculate info for two sub-allocations within the same resource.
     {
         ComPtr<ResourceAllocator> resourceAllocator;
         ASSERT_SUCCEEDED(
@@ -756,13 +756,13 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferQueryInfo) {
         ASSERT_NE(firstAllocation, nullptr);
         EXPECT_EQ(firstAllocation->GetMethod(), gpgmm::AllocationMethod::kSubAllocatedWithin);
 
-        QUERY_RESOURCE_ALLOCATOR_INFO stats = {};
-        ASSERT_SUCCEEDED(resourceAllocator->QueryResourceAllocatorInfo(&stats));
+        QUERY_RESOURCE_ALLOCATOR_INFO info = {};
+        ASSERT_SUCCEEDED(resourceAllocator->QueryResourceAllocatorInfo(&info));
 
-        EXPECT_EQ(stats.UsedResourceHeapCount, 1u);
-        EXPECT_EQ(stats.UsedResourceHeapUsage, 64u * 1024u);
-        EXPECT_EQ(stats.UsedBlockCount, 1u);
-        EXPECT_EQ(stats.UsedBlockUsage, kBufferSize);
+        EXPECT_EQ(info.UsedMemoryCount, 1u);
+        EXPECT_EQ(info.UsedMemoryUsage, 64u * 1024u);
+        EXPECT_EQ(info.UsedBlockCount, 1u);
+        EXPECT_EQ(info.UsedBlockUsage, kBufferSize);
 
         ComPtr<ResourceAllocation> secondAllocation;
         ASSERT_SUCCEEDED(resourceAllocator->CreateResource(
@@ -771,12 +771,12 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferQueryInfo) {
         ASSERT_NE(secondAllocation, nullptr);
         EXPECT_EQ(secondAllocation->GetMethod(), gpgmm::AllocationMethod::kSubAllocatedWithin);
 
-        ASSERT_SUCCEEDED(resourceAllocator->QueryResourceAllocatorInfo(&stats));
+        ASSERT_SUCCEEDED(resourceAllocator->QueryResourceAllocatorInfo(&info));
 
-        EXPECT_EQ(stats.UsedResourceHeapCount, 1u);
-        EXPECT_EQ(stats.UsedResourceHeapUsage, 64u * 1024u);
-        EXPECT_EQ(stats.UsedBlockCount, 2u);
-        EXPECT_EQ(stats.UsedBlockUsage, kBufferSize * 2);
+        EXPECT_EQ(info.UsedMemoryCount, 1u);
+        EXPECT_EQ(info.UsedMemoryUsage, 64u * 1024u);
+        EXPECT_EQ(info.UsedBlockCount, 2u);
+        EXPECT_EQ(info.UsedBlockUsage, kBufferSize * 2);
     }
 }
 


### PR DESCRIPTION

Also, unify QUERY_RESOURCE_ALLOCATOR_INFO and MEMORY_ALLOCATOR_INFO since the info is the same.