### PR TITLE
Apply ALLOCATION_FLAG_SUBALLOCATE_WITHIN_RESOURCE by default for supporting GPUs.

### DIFF
--- a/src/gpgmm/BUILD.gn
+++ b/src/gpgmm/BUILD.gn
@@ -122,6 +122,7 @@ source_set("gpgmm_sources") {
     "ConditionalMemoryAllocator.h",
     "Defaults.h",
     "Error.h",
+    "GPUInfo.h",
     "IndexedMemoryPool.cpp",
     "IndexedMemoryPool.h",
     "JSONSerializer.cpp",
@@ -186,6 +187,8 @@ source_set("gpgmm_sources") {
     sources += [
       "d3d12/BufferAllocatorD3D12.cpp",
       "d3d12/BufferAllocatorD3D12.h",
+      "d3d12/CapsD3D12.cpp",
+      "d3d12/CapsD3D12.h",
       "d3d12/DefaultsD3D12.h",
       "d3d12/ErrorD3D12.cpp",
       "d3d12/ErrorD3D12.h",

--- a/src/gpgmm/CMakeLists.txt
+++ b/src/gpgmm/CMakeLists.txt
@@ -81,6 +81,8 @@ if (GPGMM_ENABLE_D3D12)
     target_sources(gpgmm PRIVATE
         "d3d12/BufferAllocatorD3D12.cpp"
         "d3d12/BufferAllocatorD3D12.h"
+        "d3d12/CapsD3D12.cpp"
+        "d3d12/CapsD3D12.h"
         "d3d12/DefaultsD3D12.h"
         "d3d12/ErrorD3D12.cpp"
         "d3d12/ErrorD3D12.h"

--- a/src/gpgmm/GPUInfo.h
+++ b/src/gpgmm/GPUInfo.h
@@ -1,0 +1,31 @@
+// Copyright 2021 The GPGMM Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GPGMM_GPUINFO_H_
+#define GPGMM_GPUINFO_H_
+
+namespace gpgmm {
+
+    enum GPUVendor {
+        kAMD_VkVendor = 4098,
+        kARM_VkVendor = 5045,
+        kImagination_VkVendor = 4112,
+        kIntel_VkVendor = 32902,
+        kNvidia_VkVendor = 4318,
+        kQualcomm_VkVendor = 20803,
+    };
+
+}  // namespace gpgmm
+
+#endif  // GPGMM_GPUINFO_H_

--- a/src/gpgmm/d3d12/CapsD3D12.cpp
+++ b/src/gpgmm/d3d12/CapsD3D12.cpp
@@ -1,0 +1,42 @@
+// Copyright 2021 The GPGMM Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gpgmm/d3d12/CapsD3D12.h"
+
+#include "gpgmm/d3d12/ErrorD3D12.h"
+
+#include <memory>
+
+namespace gpgmm { namespace d3d12 {
+
+    // static
+    HRESULT Caps::CreateCaps(ID3D12Device* device, IDXGIAdapter* adapter, Caps** capsOut) {
+        DXGI_ADAPTER_DESC adapterDesc;
+        ReturnIfFailed(adapter->GetDesc(&adapterDesc));
+
+        Caps* caps = new Caps();
+        // Intel GPUs are always coherent.
+        if (adapterDesc.VendorId == GPUVendor::kIntel_VkVendor) {
+            caps->mIsSuballocationWithinResourceCoherent = true;
+        }
+
+        *capsOut = caps;
+        return S_OK;
+    }
+
+    bool Caps::IsSuballocationWithinResourceCoherent() const {
+        return mIsSuballocationWithinResourceCoherent;
+    }
+
+}}  // namespace gpgmm::d3d12

--- a/src/gpgmm/d3d12/CapsD3D12.h
+++ b/src/gpgmm/d3d12/CapsD3D12.h
@@ -1,0 +1,39 @@
+// Copyright 2021 The GPGMM Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GPGMM_D3D12_CAPSD3D12_H_
+#define GPGMM_D3D12_CAPSD3D12_H_
+
+#include "gpgmm/GPUInfo.h"
+#include "gpgmm/d3d12/d3d12_platform.h"
+
+namespace gpgmm { namespace d3d12 {
+
+    class Caps {
+      public:
+        static HRESULT CreateCaps(ID3D12Device* device, IDXGIAdapter* adapter, Caps** capsOut);
+
+        // On some GPUs, accessing different sub-allocations from the same resource with
+        // different queues is always coherent.
+        bool IsSuballocationWithinResourceCoherent() const;
+
+      private:
+        Caps() = default;
+
+        bool mIsSuballocationWithinResourceCoherent = false;
+    };
+
+}}  // namespace gpgmm::d3d12
+
+#endif  // GPGMM_D3D12_CAPSD3D12_H_


### PR DESCRIPTION

This flag enables resource-level re-use for small buffers which significant improves memory usage since sub-allocations within a resource are not required to be 64KB aligned.