### PR TITLE
Use JSON types for encoding.

### DIFF
--- a/src/gpgmm/Serializer.cpp
+++ b/src/gpgmm/Serializer.cpp
@@ -35,62 +35,6 @@ namespace gpgmm {
         return gRecordEventLevel;
     }
 
-    // JSONDict
-
-    JSONDict::JSONDict() {
-        mSS << "{ ";
-    }
-
-    std::string JSONDict::ToString() const {
-        return mSS.str() + " }";
-    }
-
-    void JSONDict::AddItem(const std::string& name, std::string value) {
-        return AddString(name, "\"" + value + "\"");
-    }
-
-    void JSONDict::AddItem(const std::string& name, uint64_t value) {
-        return AddString(name, std::to_string(value));
-    }
-
-    void JSONDict::AddItem(const std::string& name, uint32_t value) {
-        return AddString(name, std::to_string(value));
-    }
-
-    void JSONDict::AddItem(const std::string& name, bool value) {
-        return AddString(name, std::to_string(value));
-    }
-
-    void JSONDict::AddItem(const std::string& name, float value) {
-        return AddString(name, std::to_string(value));
-    }
-
-    void JSONDict::AddItem(const std::string& name, double value) {
-        return AddString(name, std::to_string(value));
-    }
-
-    void JSONDict::AddItem(const std::string& name, int value) {
-        return AddString(name, std::to_string(value));
-    }
-
-    void JSONDict::AddItem(const std::string& name, unsigned char value) {
-        return AddItem(name, static_cast<uint32_t>(value));
-    }
-
-    void JSONDict::AddItem(const std::string& name, const JSONDict& object) {
-        return AddString(name, object.ToString());
-    }
-
-    void JSONDict::AddString(const std::string& name, const std::string& value) {
-        if (mHasItem) {
-            mSS << ", ";
-        }
-        mSS << "\"" + name + "\": " << value;
-        mHasItem = true;
-    }
-
-    // Serializer
-
     // static
     JSONDict Serializer::Serialize(const POOL_INFO& info) {
         JSONDict dict;

--- a/src/gpgmm/TraceEvent.h
+++ b/src/gpgmm/TraceEvent.h
@@ -15,6 +15,8 @@
 #ifndef GPGMM_TRACEEVENT_H_
 #define GPGMM_TRACEEVENT_H_
 
+#include "gpgmm/common/JSONEncoder.h"
+
 #include <memory>
 #include <string>
 #include <vector>
@@ -40,7 +42,7 @@
 // Specify these values when the corresponding argument of AddTraceEvent
 // is not used.
 const uint64_t kNoId = 0;
-const std::string kNoArgs = "";
+const gpgmm::JSONDict kNoArgs;
 
 #define TRACE_EVENT_CALL_SCOPED(name) \
     struct ScopedTracedCall {         \
@@ -72,7 +74,8 @@ const std::string kNoArgs = "";
 
 #define TRACE_EVENT_OBJECT_SNAPSHOT_WITH_ID(name, id, snapshot)                   \
     INTERNAL_TRACE_EVENT_ADD_WITH_ID(TRACE_EVENT_PHASE_SNAPSHOT_OBJECT, name, id, \
-                                     TRACE_EVENT_FLAG_HAS_ID, "snapshot", snapshot)
+                                     TRACE_EVENT_FLAG_HAS_ID,                     \
+                                     gpgmm::JSONDict("snapshot", snapshot))
 
 #define INTERNAL_TRACE_EVENT_ADD(phase, name, flags)                  \
     do {                                                              \
@@ -134,7 +137,7 @@ namespace gpgmm {
                    uint64_t id,
                    double timestamp,
                    uint32_t flags,
-                   std::string args);
+                   JSONDict args);
 
       private:
         friend FileEventTracer;
@@ -146,7 +149,7 @@ namespace gpgmm {
         std::string mThreadId;
         double mTimestamp = 0;
         uint32_t mFlags = TRACE_EVENT_FLAG_NONE;
-        std::string mArgs;
+        JSONDict mArgs;
     };
 
     class EventTracer {
@@ -155,7 +158,7 @@ namespace gpgmm {
                                   const char* name,
                                   uint64_t id,
                                   uint32_t flags,
-                                  std::string args = "");
+                                  JSONDict args = {});
 
         static void AddTraceEvent(char phase,
                                   const char* name,
@@ -177,7 +180,7 @@ namespace gpgmm {
                                const char* name,
                                uint64_t id,
                                uint32_t flags,
-                               std::string args);
+                               JSONDict args);
         void FlushQueuedEventsToDisk();
 
       private:

--- a/src/gpgmm/common/BUILD.gn
+++ b/src/gpgmm/common/BUILD.gn
@@ -148,6 +148,8 @@ if (is_win || is_linux || is_chromeos || is_mac || is_fuchsia || is_android) {
       "Assert.h",
       "Compiler.h",
       "Flags.h",
+      "JSONEncoder.cpp",
+      "JSONEncoder.h",
       "Limits.h",
       "LinkedList.h",
       "Log.cpp",

--- a/src/gpgmm/common/CMakeLists.txt
+++ b/src/gpgmm/common/CMakeLists.txt
@@ -19,6 +19,8 @@ target_sources(gpgmm_common PRIVATE
   "Assert.h"
   "Compiler.h"
   "Flags.h"
+  "JSONEncoder.cpp"
+  "JSONEncoder.h"
   "Limits.h"
   "LinkedList.h"
   "Log.cpp"

--- a/src/gpgmm/common/JSONEncoder.cpp
+++ b/src/gpgmm/common/JSONEncoder.cpp
@@ -1,0 +1,158 @@
+// Copyright 2021 The GPGMM Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "JSONEncoder.h"
+
+namespace gpgmm {
+
+    // JSONDict
+
+    JSONDict::JSONDict() {
+        mSS << "{ ";
+    }
+
+    JSONDict::JSONDict(const std::string& name, const JSONDict& object) {
+        mSS << "{ ";
+        AddItem(name, object);
+    }
+
+    JSONDict::JSONDict(const JSONDict& other) {
+        mSS = std::stringstream(other.mSS.str());
+        mHasItem = other.mHasItem;
+    }
+
+    std::string JSONDict::ToString() const {
+        return mSS.str() + " }";
+    }
+
+    bool JSONDict::IsEmpty() const {
+        return !mHasItem;
+    }
+
+    void JSONDict::AddItem(const std::string& name, std::string value) {
+        return AddItemInternal(name, "\"" + value + "\"");
+    }
+
+    void JSONDict::AddItem(const std::string& name, char value) {
+        return AddItemInternal(name, "\"" + std::string(1, value) + "\"");
+    }
+
+    void JSONDict::AddItem(const std::string& name, const char* value) {
+        return AddItemInternal(name, "\"" + std::string(value) + "\"");
+    }
+
+    void JSONDict::AddItem(const std::string& name, uint64_t value) {
+        return AddItemInternal(name, std::to_string(value));
+    }
+
+    void JSONDict::AddItem(const std::string& name, uint32_t value) {
+        return AddItemInternal(name, std::to_string(value));
+    }
+
+    void JSONDict::AddItem(const std::string& name, bool value) {
+        return AddItemInternal(name, std::to_string(value));
+    }
+
+    void JSONDict::AddItem(const std::string& name, float value) {
+        return AddItemInternal(name, std::to_string(value));
+    }
+
+    void JSONDict::AddItem(const std::string& name, double value) {
+        return AddItemInternal(name, std::to_string(value));
+    }
+
+    void JSONDict::AddItem(const std::string& name, int value) {
+        return AddItemInternal(name, std::to_string(value));
+    }
+
+    void JSONDict::AddItem(const std::string& name, unsigned char value) {
+        return AddItem(name, static_cast<uint32_t>(value));
+    }
+
+    void JSONDict::AddItem(const std::string& name, const JSONDict& object) {
+        return AddItemInternal(name, object.ToString());
+    }
+
+    void JSONDict::AddItem(const std::string& name, const JSONArray& object) {
+        return AddItemInternal(name, object.ToString());
+    }
+
+    void JSONDict::AddItemInternal(const std::string& name, const std::string& value) {
+        if (mHasItem) {
+            mSS << ", ";
+        }
+        mSS << "\"" + name + "\": " << value;
+        mHasItem = true;
+    }
+
+    // JSONArray
+
+    JSONArray::JSONArray() {
+        mSS << "[ ";
+    }
+
+    JSONArray::JSONArray(const JSONArray& other) {
+        mSS = std::stringstream(other.mSS.str());
+        mHasItem = other.mHasItem;
+    }
+
+    std::string JSONArray::ToString() const {
+        return mSS.str() + " ]";
+    }
+
+    void JSONArray::AddItem(const std::string& value) {
+        return AddItemInternal("\"" + value + "\"");
+    }
+
+    void JSONArray::AddItem(uint64_t value) {
+        return AddItemInternal(std::to_string(value));
+    }
+
+    void JSONArray::AddItem(uint32_t value) {
+        return AddItemInternal(std::to_string(value));
+    }
+
+    void JSONArray::AddItem(bool value) {
+        return AddItemInternal(std::to_string(value));
+    }
+
+    void JSONArray::AddItem(float value) {
+        return AddItemInternal(std::to_string(value));
+    }
+
+    void JSONArray::AddItem(double value) {
+        return AddItemInternal(std::to_string(value));
+    }
+
+    void JSONArray::AddItem(int value) {
+        return AddItemInternal(std::to_string(value));
+    }
+
+    void JSONArray::AddItem(unsigned char value) {
+        return AddItem(static_cast<uint32_t>(value));
+    }
+
+    void JSONArray::AddItem(const JSONDict& object) {
+        return AddItemInternal(object.ToString());
+    }
+
+    void JSONArray::AddItemInternal(const std::string& value) {
+        if (mHasItem) {
+            mSS << ", ";
+        }
+        mSS << value;
+        mHasItem = true;
+    }
+
+}  // namespace gpgmm

--- a/src/gpgmm/common/JSONEncoder.h
+++ b/src/gpgmm/common/JSONEncoder.h
@@ -1,0 +1,82 @@
+// Copyright 2021 The GPGMM Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GPGMM_COMMON_JSON_ENCODER_H_
+#define GPGMM_COMMON_JSON_ENCODER_H_
+
+#include <sstream>
+#include <string>
+
+namespace gpgmm {
+
+    class JSONArray;
+
+    class JSONDict {
+      public:
+        JSONDict();
+        JSONDict(const std::string& name, const JSONDict& object);
+        JSONDict(const JSONDict& other);
+
+        std::string ToString() const;
+        bool IsEmpty() const;
+
+        // Per JSON data type
+        void AddItem(const std::string& name, std::string value);
+        void AddItem(const std::string& name, char value);
+        void AddItem(const std::string& name, const char* value);
+        void AddItem(const std::string& name, uint64_t value);
+        void AddItem(const std::string& name, uint32_t value);
+        void AddItem(const std::string& name, bool value);
+        void AddItem(const std::string& name, float value);
+        void AddItem(const std::string& name, double value);
+        void AddItem(const std::string& name, int value);
+        void AddItem(const std::string& name, unsigned char value);
+        void AddItem(const std::string& name, const JSONDict& object);
+        void AddItem(const std::string& name, const JSONArray& object);
+
+      private:
+        void AddItemInternal(const std::string& name, const std::string& value);
+
+        bool mHasItem = false;
+        std::stringstream mSS;
+    };
+
+    class JSONArray {
+      public:
+        JSONArray();
+        JSONArray(const JSONArray& other);
+
+        std::string ToString() const;
+
+        // Per JSON data type
+        void AddItem(const std::string& value);
+        void AddItem(uint64_t value);
+        void AddItem(uint32_t value);
+        void AddItem(bool value);
+        void AddItem(float value);
+        void AddItem(double value);
+        void AddItem(int value);
+        void AddItem(unsigned char value);
+        void AddItem(const JSONDict& object);
+
+      private:
+        void AddItemInternal(const std::string& value);
+
+        bool mHasItem = false;
+        std::stringstream mSS;
+    };
+
+}  // namespace gpgmm
+
+#endif  // GPGMM_COMMON_JSON_ENCODER_H_


### PR DESCRIPTION

Replaces using raw strings in favor of safer JSON types for trace event encoding.