### PR TITLE
Add SafeDelete to prevent use-after-free bugs.

### DIFF
--- a/src/gpgmm/BuddyBlockAllocator.cpp
+++ b/src/gpgmm/BuddyBlockAllocator.cpp
@@ -18,6 +18,7 @@
 #include "gpgmm/Serializer.h"
 #include "gpgmm/common/Assert.h"
 #include "gpgmm/common/Math.h"
+#include "gpgmm/common/Utils.h"
 
 namespace gpgmm {
 
@@ -261,7 +262,7 @@ namespace gpgmm {
             DeleteBlock(block->split.pLeft->pBuddy);
             DeleteBlock(block->split.pLeft);
         }
-        delete block;
+        SafeDelete(block);
     }
 
 }  // namespace gpgmm

--- a/src/gpgmm/SegmentedMemoryAllocator.cpp
+++ b/src/gpgmm/SegmentedMemoryAllocator.cpp
@@ -16,6 +16,7 @@
 
 #include "gpgmm/Serializer.h"
 #include "gpgmm/common/Assert.h"
+#include "gpgmm/common/Utils.h"
 
 namespace gpgmm {
 
@@ -87,7 +88,7 @@ namespace gpgmm {
         while (curr != mFreeSegments.end()) {
             auto next = curr->next();
             ASSERT(curr != nullptr);
-            delete curr->value();
+            SafeDelete(curr->value());
             curr = next;
         }
 

--- a/src/gpgmm/SlabBlockAllocator.cpp
+++ b/src/gpgmm/SlabBlockAllocator.cpp
@@ -17,6 +17,7 @@
 #include "gpgmm/Serializer.h"
 #include "gpgmm/common/Assert.h"
 #include "gpgmm/common/Math.h"
+#include "gpgmm/common/Utils.h"
 
 namespace gpgmm {
 
@@ -33,7 +34,7 @@ namespace gpgmm {
         while (head != nullptr) {
             ASSERT(head != nullptr);
             SlabBlock* next = head->pNext;
-            delete head;
+            SafeDelete(head);
             head = next;
         }
     }

--- a/src/gpgmm/SlabMemoryAllocator.cpp
+++ b/src/gpgmm/SlabMemoryAllocator.cpp
@@ -18,6 +18,7 @@
 #include "gpgmm/Serializer.h"
 #include "gpgmm/common/Assert.h"
 #include "gpgmm/common/Math.h"
+#include "gpgmm/common/Utils.h"
 
 namespace gpgmm {
 
@@ -186,7 +187,7 @@ namespace gpgmm {
 
         Block* block = blockInSlab->pBlock;
         slab->Allocator.DeallocateBlock(block);
-        delete blockInSlab;
+        SafeDelete(blockInSlab);
 
         slabMemory->Unref();
 

--- a/src/gpgmm/TraceEvent.cpp
+++ b/src/gpgmm/TraceEvent.cpp
@@ -17,6 +17,7 @@
 #include "gpgmm/common/Assert.h"
 #include "gpgmm/common/Log.h"
 #include "gpgmm/common/PlatformTime.h"
+#include "gpgmm/common/Utils.h"
 
 #include <fstream>
 #include <sstream>
@@ -37,8 +38,7 @@ namespace gpgmm {
 
     void ShutdownEventTracer() {
         if (gEventTracer != nullptr) {
-            delete gEventTracer;
-            gEventTracer = nullptr;
+            SafeDelete(gEventTracer);
         }
     }
 

--- a/src/gpgmm/common/BUILD.gn
+++ b/src/gpgmm/common/BUILD.gn
@@ -163,6 +163,7 @@ if (is_win || is_linux || is_chromeos || is_mac || is_fuchsia || is_android) {
       "RefCount.h",
       "SystemUtils.cpp",
       "SystemUtils.h",
+      "Utils.h",
     ]
 
     if (is_win) {

--- a/src/gpgmm/common/CMakeLists.txt
+++ b/src/gpgmm/common/CMakeLists.txt
@@ -34,6 +34,7 @@ target_sources(gpgmm_common PRIVATE
   "RefCount.h"
   "SystemUtils.cpp"
   "SystemUtils.h"
+  "Utils.h"
 )
 
 if (WIN32)

--- a/src/gpgmm/common/LinkedList.h
+++ b/src/gpgmm/common/LinkedList.h
@@ -8,6 +8,7 @@
 #define GPGMM_COMMON_LINKED_LIST_H
 
 #include "Assert.h"
+#include "Utils.h"
 
 #include <utility>
 
@@ -210,7 +211,7 @@ namespace gpgmm {
             auto curr = head();
             while (curr != end()) {
                 auto next = curr->next();
-                delete curr->value();
+                SafeDelete(curr->value());
                 curr = next;
             }
             ASSERT(empty());

--- a/src/gpgmm/common/RefCount.h
+++ b/src/gpgmm/common/RefCount.h
@@ -15,6 +15,8 @@
 #ifndef GPGMM_COMMON_REFCOUNT_H_
 #define GPGMM_COMMON_REFCOUNT_H_
 
+#include "Utils.h"
+
 #include <atomic>
 #include <cstdint>
 
@@ -113,7 +115,7 @@ namespace gpgmm {
       private:
         static void SafeRelease(T* ptr) {
             if (ptr != nullptr && ptr->Unref()) {
-                delete ptr;
+                SafeDelete(ptr);
             }
         }
 

--- a/src/gpgmm/common/Utils.h
+++ b/src/gpgmm/common/Utils.h
@@ -1,0 +1,30 @@
+// Copyright 2021 The GPGMM Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GPGMM_COMMON_UTILS_H_
+#define GPGMM_COMMON_UTILS_H_
+
+template <typename T>
+void SafeDelete(T*& object) {
+    delete object;
+    object = nullptr;
+}
+
+template <typename T>
+void SafeDelete(T*&& object) {
+    T*& lvalue = object;
+    SafeDelete(lvalue);
+}
+
+#endif  // GPGMM_COMMON_UTILS_H_

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -22,6 +22,7 @@
 #include "gpgmm/SlabMemoryAllocator.h"
 #include "gpgmm/common/Log.h"
 #include "gpgmm/common/Math.h"
+#include "gpgmm/common/Utils.h"
 #include "gpgmm/d3d12/BackendD3D12.h"
 #include "gpgmm/d3d12/BufferAllocatorD3D12.h"
 #include "gpgmm/d3d12/CapsD3D12.h"
@@ -980,7 +981,7 @@ namespace gpgmm { namespace d3d12 {
         mInfo.UsedMemoryUsage -= resourceHeap->GetSize();
         mInfo.UsedMemoryCount--;
 
-        delete resourceHeap;
+        SafeDelete(resourceHeap);
     }
 
 }}  // namespace gpgmm::d3d12

--- a/src/tests/DummyMemoryAllocator.h
+++ b/src/tests/DummyMemoryAllocator.h
@@ -16,6 +16,7 @@
 #define GPGMM_DUMMYMEMORYALLOCATOR_H_
 
 #include "gpgmm/MemoryAllocator.h"
+#include "gpgmm/common/Utils.h"
 
 namespace gpgmm {
 
@@ -26,7 +27,7 @@ namespace gpgmm {
             ASSERT(allocation->GetMethod() == AllocationMethod::kStandalone);
             mInfo.UsedMemoryCount--;
             mInfo.UsedMemoryUsage -= allocation->GetSize();
-            delete allocation->GetMemory();
+            SafeDelete(allocation->GetMemory());
         }
 
         std::unique_ptr<MemoryAllocation> TryAllocateMemory(uint64_t allocationSize,


### PR DESCRIPTION

Replaces `delete ptr` with SafeDelete(ptr) to ensure `ptr` can never be accessed again.