### PR TITLE
Disable sub-allocation within by default.

### DIFF
--- a/src/gpgmm/d3d12/CapsD3D12.cpp
+++ b/src/gpgmm/d3d12/CapsD3D12.cpp
@@ -47,20 +47,11 @@ namespace gpgmm { namespace d3d12 {
         ReturnIfFailed(adapter->GetDesc(&adapterDesc));
 
         Caps* caps = new Caps();
-        // Intel GPUs are always coherent.
-        if (adapterDesc.VendorId == GPUVendor::kIntel_VkVendor) {
-            caps->mIsSuballocationWithinResourceCoherent = true;
-        }
-
         ReturnIfFailed(SetMaxResourceSize(device, &caps->mMaxResourceSize));
         ReturnIfFailed(SetMaxResourceHeapSize(device, &caps->mMaxResourceHeapSize));
 
         *capsOut = caps;
         return S_OK;
-    }
-
-    bool Caps::IsSuballocationWithinResourceCoherent() const {
-        return mIsSuballocationWithinResourceCoherent;
     }
 
     uint64_t Caps::GetMaxResourceSize() const {

--- a/src/gpgmm/d3d12/CapsD3D12.h
+++ b/src/gpgmm/d3d12/CapsD3D12.h
@@ -26,10 +26,6 @@ namespace gpgmm { namespace d3d12 {
       public:
         static HRESULT CreateCaps(ID3D12Device* device, IDXGIAdapter* adapter, Caps** capsOut);
 
-        // On some GPUs, accessing different sub-allocations from the same resource with
-        // different queues is always coherent.
-        bool IsSuballocationWithinResourceCoherent() const;
-
         // Largest resource size that this device can make available.
         uint64_t GetMaxResourceSize() const;
 
@@ -39,7 +35,6 @@ namespace gpgmm { namespace d3d12 {
       private:
         Caps() = default;
 
-        bool mIsSuballocationWithinResourceCoherent = false;
         uint64_t mMaxResourceSize = 0;
         uint64_t mMaxResourceHeapSize = 0;
     };

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -593,8 +593,7 @@ namespace gpgmm { namespace d3d12 {
         // strategy only works in a few cases (ex. small constant buffers uploads) so it should be
         // tried before sub-allocating resource heaps.
         // The time and space complexity of is defined by the sub-allocation algorithm used.
-        if ((mCaps->IsSuballocationWithinResourceCoherent() ||
-             allocationDescriptor.Flags & ALLOCATION_FLAG_ALWAYS_SUBALLOCATE_WITHIN_RESOURCE) &&
+        if (allocationDescriptor.Flags & ALLOCATION_FLAG_ALLOW_SUBALLOCATE_WITHIN_RESOURCE &&
             resourceInfo.Alignment > newResourceDesc.Width &&
             newResourceDesc.Dimension == D3D12_RESOURCE_DIMENSION_BUFFER &&
             GetInitialResourceState(allocationDescriptor.HeapType) == initialResourceState &&

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -213,11 +213,13 @@ namespace gpgmm { namespace d3d12 {
         // Sub-allocate a resource allocation within the same resource. The resource alignment
         // is allowed to be byte-aligned instead of being resource-aligned, which significantly
         // reduces app memory usage (1B vs 64KB per allocation). Since the resource can only be in
-        // one state at a time, this is mostly restricted for constant buffers (index and vertex
-        // buffers) which will stay read-only after creation. This flag is automatically
-        // enabled for devices that already guarentee command queue accesses are always coherent
-        // between sub-allocations within the same resource.
-        ALLOCATION_FLAG_ALWAYS_SUBALLOCATE_WITHIN_RESOURCE = 0x2,
+        // one state at a time, this is mostly restricted to constant buffers (index and vertex
+        // buffers which will stay read-only after creation). The app developer must use offsets
+        // from the start of the allocation (vs subresource) by using GetOffsetFromResource().
+        // Since all devices guarentee command queue accesses are coherent between sub-allocations
+        // within the same resource. The app developer must check if the adapter is supported OR
+        // ensure only a command single queue is used.
+        ALLOCATION_FLAG_ALLOW_SUBALLOCATE_WITHIN_RESOURCE = 0x2,
 
         // Forbids allowing multiple resource allocations to be created from the same resource
         // heap. The created resource will always be allocated with it's own resource heap.

--- a/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
+++ b/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
@@ -424,7 +424,7 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferNeverAllocate) {
 
 TEST_F(D3D12ResourceAllocatorTests, CreateBufferSuballocatedWithin) {
     ALLOCATION_DESC desc = {};
-    desc.Flags = ALLOCATION_FLAG_ALWAYS_SUBALLOCATE_WITHIN_RESOURCE;
+    desc.Flags = ALLOCATION_FLAG_ALLOW_SUBALLOCATE_WITHIN_RESOURCE;
     desc.HeapType = D3D12_HEAP_TYPE_UPLOAD;
 
     constexpr uint32_t kSubAllocationSize = 4u;
@@ -796,7 +796,7 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferQueryInfo) {
         ASSERT_NE(resourceAllocator, nullptr);
 
         ALLOCATION_DESC allocationWithinDesc = {};
-        allocationWithinDesc.Flags = ALLOCATION_FLAG_ALWAYS_SUBALLOCATE_WITHIN_RESOURCE;
+        allocationWithinDesc.Flags = ALLOCATION_FLAG_ALLOW_SUBALLOCATE_WITHIN_RESOURCE;
         allocationWithinDesc.HeapType = D3D12_HEAP_TYPE_UPLOAD;
 
         constexpr uint32_t kBufferSize = 4u;  // Must less than 64KB


### PR DESCRIPTION

Feature needs to be opt-in since GPGMM does not know whether or not the developer is using adjusted allocation offsets. For example, calling CopyBufferRegion would incorrectly use subresource relative offsets which need to be adjusted by the sub-allocation offset to work.