### PR TITLE
Add option to treat D3D misalignments as warnings.

### DIFF
--- a/build_overrides/gpgmm_features.gni
+++ b/build_overrides/gpgmm_features.gni
@@ -30,9 +30,11 @@ if (!defined(checkout_webnn)) {
 
 declare_args() {
   # Enable GPGMM's ASSERTs even in release builds
+  # Sets -dGPGMM_ENABLE_ASSERTS
   gpgmm_always_assert = false
 
   # Enables GPGMM's memory tracing even if disabled by recording flags.
+  # Sets -dGPGMM_ALWAYS_RECORD
   gpgmm_always_record = false
 
   # Enables the compilation of the D3D12 backend
@@ -45,5 +47,10 @@ declare_args() {
   gpgmm_enable_webnn = checkout_webnn
 
   # Build GPGMM as a shared library.
+  # Sets -dGPGMM_SHARED_LIBRARY
   gpgmm_shared_library = false
+
+  # Enables runtime warnings when D3D12 resource alignment is suboptimal.
+  # Sets -dGPGMM_ENABLE_D3D12_RESOURCE_ALIGNMENT_WARNING
+  gpgmm_enable_d3d12_resource_alignment_warning = false
 }

--- a/src/gpgmm/BUILD.gn
+++ b/src/gpgmm/BUILD.gn
@@ -184,6 +184,11 @@ source_set("gpgmm_sources") {
 
   if (gpgmm_enable_d3d12) {
     libs += [ "dxguid.lib" ]
+
+    if (gpgmm_enable_d3d12_resource_alignment_warning) {
+      defines += [ "GPGMM_ENABLE_D3D12_RESOURCE_ALIGNMENT_WARNING" ]
+    }
+
     sources += [
       "d3d12/BufferAllocatorD3D12.cpp",
       "d3d12/BufferAllocatorD3D12.h",

--- a/src/gpgmm/BuddyBlockAllocator.cpp
+++ b/src/gpgmm/BuddyBlockAllocator.cpp
@@ -145,9 +145,9 @@ namespace gpgmm {
 
     Block* BuddyBlockAllocator::AllocateBlock(uint64_t size, uint64_t alignment) {
         if (size == 0 || size > mMaxBlockSize) {
-            RecordMessage(LogSeverity::Debug, "BuddyBlockAllocator.AllocateBlock",
-                          "Block size exceeded the max block size.",
-                          ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED);
+            RecordLogMessage(LogSeverity::Debug, "BuddyBlockAllocator.AllocateBlock",
+                             "Block size exceeded the max block size.",
+                             ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED);
             return nullptr;
         }
 
@@ -160,8 +160,9 @@ namespace gpgmm {
 
         // Error when no free blocks exist (allocator is full)
         if (currBlockLevel == kInvalidOffset) {
-            RecordMessage(LogSeverity::Debug, "BuddyBlockAllocator.AllocateBlock",
-                          "Allocator has reached capacity", ALLOCATOR_MESSAGE_ID_ALLOCATOR_FAILED);
+            RecordLogMessage(LogSeverity::Debug, "BuddyBlockAllocator.AllocateBlock",
+                             "Allocator has reached capacity",
+                             ALLOCATOR_MESSAGE_ID_ALLOCATOR_FAILED);
             return nullptr;
         }
 

--- a/src/gpgmm/BuddyMemoryAllocator.cpp
+++ b/src/gpgmm/BuddyMemoryAllocator.cpp
@@ -53,11 +53,11 @@ namespace gpgmm {
 
         // Check the unaligned size to avoid overflowing NextPowerOfTwo.
         if (allocationSize == 0 || allocationSize > mMemorySize) {
-            RecordMessage(LogSeverity::Debug, "BuddyMemoryAllocator.TryAllocateMemory",
-                          "Allocation size exceeded the memory size (" +
-                              std::to_string(allocationSize) + " vs " +
-                              std::to_string(mMemorySize) + " bytes).",
-                          ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED);
+            RecordLogMessage(LogSeverity::Debug, "BuddyMemoryAllocator.TryAllocateMemory",
+                             "Allocation size exceeded the memory size (" +
+                                 std::to_string(allocationSize) + " vs " +
+                                 std::to_string(mMemorySize) + " bytes).",
+                             ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED);
             return nullptr;
         }
 
@@ -66,11 +66,11 @@ namespace gpgmm {
 
         // Allocation cannot exceed the memory size.
         if (allocationSize > mMemorySize) {
-            RecordMessage(LogSeverity::Debug, "BuddyMemoryAllocator.TryAllocateMemory",
-                          "Aligned allocation size exceeded the memory size (" +
-                              std::to_string(allocationSize) + " vs " +
-                              std::to_string(mMemorySize) + " bytes).",
-                          ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED);
+            RecordLogMessage(LogSeverity::Debug, "BuddyMemoryAllocator.TryAllocateMemory",
+                             "Aligned allocation size exceeded the memory size (" +
+                                 std::to_string(allocationSize) + " vs " +
+                                 std::to_string(mMemorySize) + " bytes).",
+                             ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED);
 
             return nullptr;
         }

--- a/src/gpgmm/SegmentedMemoryAllocator.cpp
+++ b/src/gpgmm/SegmentedMemoryAllocator.cpp
@@ -134,9 +134,9 @@ namespace gpgmm {
         TRACE_EVENT_CALL_SCOPED("SegmentedMemoryAllocator.TryAllocateMemory");
 
         if (allocationSize == 0 || alignment != mMemoryAlignment) {
-            RecordMessage(LogSeverity::Debug, "SegmentedMemoryAllocator.TryAllocateMemory",
-                          "Allocation alignment does not match memory alignment.",
-                          ALLOCATOR_MESSAGE_ID_ALIGNMENT_MISMATCH);
+            RecordLogMessage(LogSeverity::Debug, "SegmentedMemoryAllocator.TryAllocateMemory",
+                             "Allocation alignment does not match memory alignment.",
+                             ALLOCATOR_MESSAGE_ID_ALIGNMENT_MISMATCH);
             return {};
         }
 

--- a/src/gpgmm/Serializer.cpp
+++ b/src/gpgmm/Serializer.cpp
@@ -18,6 +18,7 @@
 #include "gpgmm/MemoryAllocator.h"
 #include "gpgmm/MemoryPool.h"
 
+#include <algorithm>
 #include <sstream>
 
 namespace gpgmm {
@@ -25,15 +26,24 @@ namespace gpgmm {
     // Messages with equal or greater to severity will be logged.
     LogSeverity gRecordEventLevel = LogSeverity::Info;
 
-    LogSeverity SetRecordMessageLevel(const LogSeverity& newLevel) {
+    LogSeverity SetRecordLogMessageLevel(const LogSeverity& newLevel) {
         LogSeverity oldLevel = gRecordEventLevel;
         gRecordEventLevel = newLevel;
         return oldLevel;
     }
 
-    const LogSeverity& GetRecordMessageLevel() {
-        return gRecordEventLevel;
+    void RecordLogMessage(const LogSeverity& severity,
+                          const char* name,
+                          const std::string& description,
+                          int messageId) {
+        gpgmm::Log(severity) << name << ": " << description;
+        if (severity >= gRecordEventLevel) {
+            const LOG_MESSAGE logMessage{description, messageId};
+            TRACE_EVENT_INSTANT(name, Serializer::Serialize(logMessage));
+        }
     }
+
+    // Serializer
 
     // static
     JSONDict Serializer::Serialize(const POOL_INFO& info) {
@@ -43,7 +53,7 @@ namespace gpgmm {
     }
 
     // static
-    JSONDict Serializer::Serialize(const ALLOCATOR_MESSAGE& desc) {
+    JSONDict Serializer::Serialize(const LOG_MESSAGE& desc) {
         JSONDict dict;
         dict.AddItem("Description", desc.Description);
         dict.AddItem("ID", desc.ID);

--- a/src/gpgmm/Serializer.h
+++ b/src/gpgmm/Serializer.h
@@ -18,24 +18,26 @@
 #include "gpgmm/TraceEvent.h"
 #include "gpgmm/common/Log.h"
 
-#include <sstream>
 #include <string>
 
 namespace gpgmm {
 
     // Messages of a given severity to be recorded.
     // Set the new level and returns the previous level so it may be restored by the caller.
-    LogSeverity SetRecordMessageLevel(const LogSeverity& level);
-    const LogSeverity& GetRecordMessageLevel();
+    LogSeverity SetRecordLogMessageLevel(const LogSeverity& level);
 
     // Forward declare common types.
-    struct ALLOCATOR_MESSAGE;
     struct POOL_INFO;
     struct MEMORY_ALLOCATOR_INFO;
 
+    struct LOG_MESSAGE {
+        std::string Description;
+        int ID;
+    };
+
     class Serializer {
       public:
-        static JSONDict Serialize(const ALLOCATOR_MESSAGE& desc);
+        static JSONDict Serialize(const LOG_MESSAGE& desc);
         static JSONDict Serialize(const MEMORY_ALLOCATOR_INFO& info);
         static JSONDict Serialize(const POOL_INFO& desc);
         static JSONDict Serialize(void* objectPtr);
@@ -56,21 +58,10 @@ namespace gpgmm {
         }
     }
 
-    template <typename T, typename SerializerT, typename... Args>
-    static void RecordMessage(const LogSeverity& severity, const char* name, const Args&... args) {
-        const T& obj{args...};
-        if (severity >= GetLogMessageLevel()) {
-            gpgmm::Log(severity) << name << SerializerT::Serialize(obj).ToString();
-        }
-        if (severity >= GetRecordMessageLevel()) {
-            TRACE_EVENT_INSTANT(name, SerializerT::Serialize(obj));
-        }
-    }
-
-    template <typename... Args>
-    static void RecordMessage(const LogSeverity& severity, const char* name, const Args&... args) {
-        return gpgmm::RecordMessage<ALLOCATOR_MESSAGE, Serializer>(severity, name, args...);
-    }
+    void RecordLogMessage(const LogSeverity& severity,
+                          const char* name,
+                          const std::string& description,
+                          int messageId);
 
 }  // namespace gpgmm
 

--- a/src/gpgmm/SlabBlockAllocator.cpp
+++ b/src/gpgmm/SlabBlockAllocator.cpp
@@ -41,20 +41,20 @@ namespace gpgmm {
 
     Block* SlabBlockAllocator::AllocateBlock(uint64_t size, uint64_t alignment) {
         if (size == 0 || size > mBlockSize) {
-            RecordMessage(LogSeverity::Debug, "SlabBlockAllocator.AllocateBlock",
-                          "Allocation size exceeded the block size. (" + std::to_string(size) +
-                              " vs " + std::to_string(mBlockSize) + " bytes).",
-                          ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED);
+            RecordLogMessage(LogSeverity::Debug, "SlabBlockAllocator.AllocateBlock",
+                             "Allocation size exceeded the block size. (" + std::to_string(size) +
+                                 " vs " + std::to_string(mBlockSize) + " bytes).",
+                             ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED);
             return nullptr;
         }
 
         // Offset must be equal to a multiple of |mBlockSize|.
         if (!IsAligned(mBlockSize, alignment)) {
-            RecordMessage(LogSeverity::Debug, "SlabBlockAllocator.AllocateBlock",
-                          "Allocation alignment is not a multiple of the block size. (" +
-                              std::to_string(alignment) + " vs " + std::to_string(mBlockSize) +
-                              " bytes).",
-                          ALLOCATOR_MESSAGE_ID_ALIGNMENT_MISMATCH);
+            RecordLogMessage(LogSeverity::Debug, "SlabBlockAllocator.AllocateBlock",
+                             "Allocation alignment is not a multiple of the block size. (" +
+                                 std::to_string(alignment) + " vs " + std::to_string(mBlockSize) +
+                                 " bytes).",
+                             ALLOCATOR_MESSAGE_ID_ALIGNMENT_MISMATCH);
             return nullptr;
         }
 

--- a/src/gpgmm/SlabMemoryAllocator.cpp
+++ b/src/gpgmm/SlabMemoryAllocator.cpp
@@ -83,20 +83,20 @@ namespace gpgmm {
         bool cacheSize) {
         TRACE_EVENT_CALL_SCOPED("SlabMemoryAllocator.TryAllocateMemory");
         if (allocationSize > mBlockSize) {
-            RecordMessage(LogSeverity::Debug, "SlabMemoryAllocator.TryAllocateMemory",
-                          "Allocation size exceeded the block size (" +
-                              std::to_string(allocationSize) + " vs " + std::to_string(mBlockSize) +
-                              " bytes).",
-                          ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED);
+            RecordLogMessage(LogSeverity::Debug, "SlabMemoryAllocator.TryAllocateMemory",
+                             "Allocation size exceeded the block size (" +
+                                 std::to_string(allocationSize) + " vs " +
+                                 std::to_string(mBlockSize) + " bytes).",
+                             ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED);
             return {};
         }
 
         const uint64_t slabSize = ComputeSlabSize(allocationSize);
         if (slabSize > mMaxSlabSize) {
-            RecordMessage(LogSeverity::Debug, "SlabMemoryAllocator.TryAllocateMemory",
-                          "Slab size exceeded the max slab size (" + std::to_string(slabSize) +
-                              " vs " + std::to_string(mMaxSlabSize) + " bytes).",
-                          ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED);
+            RecordLogMessage(LogSeverity::Debug, "SlabMemoryAllocator.TryAllocateMemory",
+                             "Slab size exceeded the max slab size (" + std::to_string(slabSize) +
+                                 " vs " + std::to_string(mMaxSlabSize) + " bytes).",
+                             ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED);
             return {};
         }
 
@@ -257,11 +257,11 @@ namespace gpgmm {
 
         // Attempting to allocate a block larger then the slab will always fail.
         if (mSlabSize != 0 && blockSize > mSlabSize) {
-            RecordMessage(LogSeverity::Debug, "SlabMemoryAllocator.TryAllocateMemory",
-                          "Aligned allocation size exceeded the slab size (" +
-                              std::to_string(blockSize) + " vs " + std::to_string(mSlabSize) +
-                              " bytes).",
-                          ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED);
+            RecordLogMessage(LogSeverity::Debug, "SlabMemoryAllocator.TryAllocateMemory",
+                             "Aligned allocation size exceeded the slab size (" +
+                                 std::to_string(blockSize) + " vs " + std::to_string(mSlabSize) +
+                                 " bytes).",
+                             ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED);
             return {};
         }
 

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -108,12 +108,15 @@ namespace gpgmm { namespace d3d12 {
             // required alignment is for this resource.
             if (resourceDescriptor.Alignment != 0 &&
                 resourceDescriptor.Alignment != resourceInfo.Alignment) {
-                d3d12::RecordMessage(LogSeverity::Debug,
-                                     "ResourceAllocator.GetResourceAllocationInfo",
-                                     "Resource alignment is much larger due to D3D12 (" +
-                                         std::to_string(resourceDescriptor.Alignment) + " vs " +
-                                         std::to_string(resourceInfo.Alignment) + " bytes).",
-                                     ALLOCATOR_MESSAGE_ID_RESOURCE_MISALIGNMENT);
+                LogSeverity severity = LogSeverity::Debug;
+#ifdef GPGMM_ENABLE_D3D12_RESOURCE_ALIGNMENT_WARNING
+                severity = LogSeverity::Warning;
+#endif
+                RecordLogMessage(severity, "ResourceAllocator.GetResourceAllocationInfo",
+                                 "Resource alignment is much larger due to D3D12 (" +
+                                     std::to_string(resourceDescriptor.Alignment) + " vs " +
+                                     std::to_string(resourceInfo.Alignment) + " bytes).",
+                                 ALLOCATOR_MESSAGE_ID_RESOURCE_MISALIGNMENT);
 
                 resourceDescriptor.Alignment = 0;
                 resourceInfo = device->GetResourceAllocationInfo(0, 1, &resourceDescriptor);
@@ -281,16 +284,16 @@ namespace gpgmm { namespace d3d12 {
             std::unique_ptr<MemoryAllocation> allocation =
                 allocator->TryAllocateMemory(allocationSize, alignment, neverAllocate, cacheSize);
             if (allocation == nullptr) {
-                d3d12::RecordMessage(LogSeverity::Debug, "ResourceAllocator.TryAllocateResource",
-                                     "Resource memory could not be allocated.",
-                                     ALLOCATOR_MESSAGE_ID_RESOURCE_ALLOCATOR_FAILED);
+                RecordLogMessage(LogSeverity::Debug, "ResourceAllocator.TryAllocateResource",
+                                 "Resource memory could not be allocated.",
+                                 ALLOCATOR_MESSAGE_ID_RESOURCE_ALLOCATION_FAILED);
                 return E_FAIL;
             }
             HRESULT hr = createResourceFn(*allocation);
             if (FAILED(hr)) {
-                d3d12::RecordMessage(LogSeverity::Debug, "ResourceAllocator.TryAllocateResource",
-                                     "Resource failed to be created: " + GetErrorMessage(hr),
-                                     ALLOCATOR_MESSAGE_ID_RESOURCE_ALLOCATOR_FAILED);
+                RecordLogMessage(LogSeverity::Debug, "ResourceAllocator.TryAllocateResource",
+                                 "Resource failed to be created: " + GetErrorMessage(hr),
+                                 ALLOCATOR_MESSAGE_ID_RESOURCE_ALLOCATION_FAILED);
                 allocator->DeallocateMemory(allocation.release());
             }
             return hr;
@@ -354,7 +357,7 @@ namespace gpgmm { namespace d3d12 {
             const LogSeverity& recordMessageMinLevel =
                 static_cast<LogSeverity>(newDescriptor.RecordOptions.MinMessageLevel);
 
-            SetRecordMessageLevel(recordMessageMinLevel);
+            SetRecordLogMessageLevel(recordMessageMinLevel);
         }
 
         const LogSeverity& logLevel = static_cast<LogSeverity>(newDescriptor.MinLogLevel);
@@ -616,7 +619,7 @@ namespace gpgmm { namespace d3d12 {
                         std::move(committedResource), resourceHeap};
 
                     if (subAllocation.GetSize() > newResourceDesc.Width) {
-                        d3d12::RecordMessage(
+                        RecordLogMessage(
                             LogSeverity::Debug, "ResourceAllocator.CreateResource",
                             "Resource allocation size is larger then the resource size (" +
                                 std::to_string(subAllocation.GetSize()) + " vs " +
@@ -652,7 +655,7 @@ namespace gpgmm { namespace d3d12 {
                         std::move(placedResource), resourceHeap};
 
                     if (subAllocation.GetSize() > resourceInfo.SizeInBytes) {
-                        d3d12::RecordMessage(
+                        RecordLogMessage(
                             LogSeverity::Debug, "ResourceAllocator.CreateResource",
                             "Resource allocation size is larger then the resource size (" +
                                 std::to_string(subAllocation.GetSize()) + " vs " +
@@ -688,7 +691,7 @@ namespace gpgmm { namespace d3d12 {
                         /*offsetFromHeap*/ 0, std::move(placedResource), resourceHeap};
 
                     if (allocation.GetSize() > resourceInfo.SizeInBytes) {
-                        d3d12::RecordMessage(
+                        RecordLogMessage(
                             LogSeverity::Debug, "ResourceAllocator.CreateResource",
                             "Resource allocation size is larger then the resource size (" +
                                 std::to_string(allocation.GetSize()) + " vs " +
@@ -709,9 +712,9 @@ namespace gpgmm { namespace d3d12 {
         }
 
         if (!mIsAlwaysCommitted) {
-            d3d12::RecordMessage(LogSeverity::Debug, "ResourceAllocator.CreateResource",
-                                 "Resource allocation could not be created from memory pool.",
-                                 ALLOCATOR_MESSAGE_ID_RESOURCE_ALLOCATION_NON_POOLED);
+            RecordLogMessage(LogSeverity::Debug, "ResourceAllocator.CreateResource",
+                             "Resource allocation could not be created from memory pool.",
+                             ALLOCATOR_MESSAGE_ID_RESOURCE_ALLOCATION_NON_POOLED);
         }
 
         ComPtr<ID3D12Resource> committedResource;

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -247,7 +247,8 @@ namespace gpgmm { namespace d3d12 {
 
     enum ALLOCATOR_MESSAGE_ID {
 
-        ALLOCATOR_MESSAGE_ID_UNKNOWN,
+        // Allocator failed to allocate memory for the resource.
+        ALLOCATOR_MESSAGE_ID_RESOURCE_ALLOCATION_FAILED,
 
         // D3D12 heap was created with a size that is not a multiple of the alignment, which wastes
         // memory unknowingly. D3D12 only supports misaligned heap sizes for convenience.
@@ -257,17 +258,16 @@ namespace gpgmm { namespace d3d12 {
         // requested.
         ALLOCATOR_MESSAGE_ID_RESOURCE_MISALIGNMENT,
 
-        // Resource allocation size exceeds the D3D12 resource size, which wastes memory
+        // Allocation size exceeds the D3D12 resource size, which wastes memory
         // unknowingly. The allocator did not support allocation of a block equal to the resource
         // size.
         ALLOCATOR_MESSAGE_ID_RESOURCE_ALLOCATION_MISALIGNMENT,
 
-        // Resource allocation was unable to be pool-allocated. This introduces OS VidMM overhead
+        // D3D12 resource was unable to be pool-allocated. This introduces OS VidMM overhead
         // because non-pool allocated memory cannot be reused by the allocator.
         ALLOCATOR_MESSAGE_ID_RESOURCE_ALLOCATION_NON_POOLED,
 
-        // Resource allocator failed to allocate memory for the resource.
-        ALLOCATOR_MESSAGE_ID_RESOURCE_ALLOCATOR_FAILED,
+        ALLOCATOR_MESSAGE_ID_ALLOCATOR_MESSAGES_END,
     };
 
     struct ALLOCATOR_MESSAGE {

--- a/src/gpgmm/d3d12/SerializerD3D12.h
+++ b/src/gpgmm/d3d12/SerializerD3D12.h
@@ -48,11 +48,6 @@ namespace gpgmm { namespace d3d12 {
         static JSONDict Serialize(const DXGI_SAMPLE_DESC& desc);
     };
 
-    template <typename... Args>
-    static void RecordMessage(const LogSeverity& severity, const char* name, const Args&... args) {
-        return gpgmm::RecordMessage<ALLOCATOR_MESSAGE, Serializer>(severity, name, args...);
-    }
-
     template <typename T, typename... Args>
     static void RecordCall(const char* name, const Args&... args) {
         return gpgmm::RecordCall<T, Serializer>(name, args...);


### PR DESCRIPTION

This it so GPGMM can report occurances of using sub-optimal alignments (4KB vs 64KB) due to lack of driver support for a given format.