### PR TITLE
Enable event tracing until app termination.

### DIFF
--- a/build_overrides/gpgmm_features.gni
+++ b/build_overrides/gpgmm_features.gni
@@ -53,4 +53,8 @@ declare_args() {
   # Enables runtime warnings when D3D12 resource alignment is suboptimal.
   # Sets -dGPGMM_ENABLE_D3D12_RESOURCE_ALIGNMENT_WARNING
   gpgmm_enable_d3d12_resource_alignment_warning = false
+
+  # Enables recording until program termination.
+  # Sets -dGPGMM_ENABLE_TRACING_UNTIL_TERMINATION
+  gpgmm_enable_recording_until_termination = false
 }

--- a/src/gpgmm/BUILD.gn
+++ b/src/gpgmm/BUILD.gn
@@ -100,6 +100,10 @@ source_set("gpgmm_sources") {
     defines += [ "GPGMM_ALWAYS_RECORD" ]
   }
 
+  if (gpgmm_enable_recording_until_termination) {
+    defines += [ "GPGMM_ENABLE_RECORDING_UNTIL_TERMINATION" ]
+  }
+
   libs = []
   data_deps = []
 

--- a/src/gpgmm/TraceEvent.cpp
+++ b/src/gpgmm/TraceEvent.cpp
@@ -26,20 +26,22 @@
 
 namespace gpgmm {
 
-    FileEventTracer* gEventTracer = nullptr;
+    std::unique_ptr<FileEventTracer> gEventTracer;
 
     void StartupEventTracer(const std::string& traceFile,
                             bool skipDurationEvents,
                             bool skipObjectEvents,
                             bool skipInstantEvents) {
-        gEventTracer =
-            new FileEventTracer(traceFile, skipDurationEvents, skipObjectEvents, skipInstantEvents);
+        if (gEventTracer == nullptr) {
+            gEventTracer = std::make_unique<FileEventTracer>(traceFile, skipDurationEvents,
+                                                             skipObjectEvents, skipInstantEvents);
+        }
     }
 
     void ShutdownEventTracer() {
-        if (gEventTracer != nullptr) {
-            SafeDelete(gEventTracer);
-        }
+#if !defined(GPGMM_ENABLE_RECORDING_UNTIL_TERMINATION)
+        gEventTracer.release();
+#endif
     }
 
     bool IsEventTracerEnabled() {


### PR DESCRIPTION

Previously, the tracer would start/stop per allocator instance which resulted in traces being overwritten (tests re-create allocator).