### PR TITLE
Check for small resource alignment.

### DIFF
--- a/scripts/test_d3d_resource_alignment_runner.py
+++ b/scripts/test_d3d_resource_alignment_runner.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+#
+# Copyright 2021 The GPGMM Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import glob
+import subprocess
+import sys
+import os
+import re
+import json
+from argparse import ArgumentParser
+
+parser = ArgumentParser(description='Run and analyze d3d resource alignment rejects. ' +
+'To use, build with `gpgmm_enable_d3d12_resource_alignment_warning = true` then run this script.')
+
+# Common options
+parser.add_argument("testname", type=str, nargs='?', default="dawn_end2end_tests")
+parser.add_argument('--build-dir', type=str, default="out/Debug")
+
+# dawn_end2end_tests specific options
+parser.add_argument('--dawn-backend', type=str, default="d3d12")
+parser.add_argument('--dawn-adapter-vendor-id', type=str, default="0x1414")
+parser.add_argument('--dawn-test-filter', type=str, default="*")
+
+args = vars(parser.parse_args())
+
+def run_dawn_end2end_tests(binary_path, dawn_backend, dawn_vendor_id, dawn_test_filter):
+  """ Run dawn_end2end_tests and report rejects."""
+  extra_args = ["--backend=" + dawn_backend, '--adapter-vendor-id=' + dawn_vendor_id, '--gtest_filter=' + dawn_test_filter]
+  process = subprocess.Popen([binary_path] + extra_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+  output, err = process.communicate()
+  data = output.decode("utf-8")
+
+  dict_resource_rej_count = {}
+  dict_test_rej_count = {}
+
+  curr_test_name = ""
+  for line in data.split("\r\n"):
+    test_name_regex = re.search(r'RUN.*\] (.*)\/', line)
+    if test_name_regex:
+      curr_test_name = test_name_regex.group(1)
+
+    rej_resource_desc = ""
+    rej_resource_desc_regex = re.search(r'.*Resource alignment.*resource : ({.*})', line)
+    if rej_resource_desc_regex:
+      rej_resource_desc = rej_resource_desc_regex.group(1)
+    else:
+      continue # skip
+
+    if rej_resource_desc not in dict_resource_rej_count:
+        dict_resource_rej_count[rej_resource_desc] = 0
+    dict_resource_rej_count[rej_resource_desc] += 1
+
+    if curr_test_name not in dict_test_rej_count:
+        dict_test_rej_count[curr_test_name] = 0
+    dict_test_rej_count[curr_test_name] += 1
+
+  if not len(dict_resource_rej_count):
+    print("No rejects detected.")
+    sys.exit(0)
+
+  # Occurrence by resource request
+  print("Unique resources rejected: " + str(len(dict_resource_rej_count)) + "\n")
+
+  print("Total occurrences per test (test name, occurrences):")
+  for test_name, count in sorted(dict_test_rej_count.items(), key=lambda x:x[1], reverse=True):
+    print(test_name + ", " + str(count))
+  print("")
+
+  # Occurrences by format
+  dict_format_count = {}
+  for resource_desc, count in dict_resource_rej_count.items():
+    resource_desc_json = json.loads(resource_desc)
+    resource_format = resource_desc_json['Format']
+    if resource_format not in dict_format_count:
+        dict_format_count[resource_format] = 0
+    dict_format_count[resource_format] += 1
+
+  print("Total occurrences per format (format id, occurrences):")
+  for format_id, count in sorted(dict_format_count.items(), key=lambda x:x[1], reverse=True):
+    print(str(format_id) + ", " + str(count))
+  print("")
+
+  # Occurrences by resource label (ie. <type>_WxHxD)
+  dict_resource_count = {}
+  for resource_desc, count in dict_resource_rej_count.items():
+    resource_json = json.loads(resource_desc)
+    resource_label = str(resource_json['Width']) + "x" + str(resource_json['Height']) + "x" + str(resource_json['DepthOrArraySize'])
+
+    if (dawn_backend == "d3d12"):
+        resource_label = get_d3d_resource_type(resource_json['Dimension']) + "_" + resource_label
+
+    if resource_label not in dict_resource_count:
+        dict_resource_count[resource_label] = 0
+    dict_resource_count[resource_label] += 1
+
+  print("Total occurrences per resource (resource, occurrences):")
+  for resource_label, count in sorted(dict_resource_count.items(), key=lambda x:x[1], reverse=True):
+    print(str(resource_label) + ", " + str(count))
+  print("")
+
+def get_d3d_resource_type(dimension_id):
+  """ Returns the name of the d3d resource type."""
+  if dimension_id == 0: return "Unknown"
+  elif dimension_id == 1: return "Buffer"
+  else: return "Texture"
+
+def get_binary_path(testname, build_dir):
+  """ Returns full path to test executable."""
+  base_path = os.path.abspath(
+      os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+
+  binary_name = testname
+  if sys.platform == 'win32':
+      binary_name += '.exe'
+
+  build_path = os.path.normpath(build_dir)
+  binary_path = os.path.join(base_path, build_path, binary_name)
+  return binary_path
+
+if (args['testname'] == "dawn_end2end_tests"):
+  run_dawn_end2end_tests(
+    binary_path=get_binary_path(args['testname'], args['build_dir']),
+    dawn_backend=args['dawn_backend'],
+    dawn_vendor_id=args['dawn_adapter_vendor_id'],
+    dawn_test_filter=args['dawn_test_filter'])
+else:
+  print("Unsupported test:" + args['testname'])
+  sys.exit(1)

--- a/src/gpgmm/common/Math.cpp
+++ b/src/gpgmm/common/Math.cpp
@@ -101,4 +101,11 @@ namespace gpgmm {
         return number % multiple == 0;
     }
 
+    uint64_t RoundUp(uint64_t n, uint64_t m) {
+        ASSERT(m > 0);
+        ASSERT(n > 0);
+        ASSERT(m <= std::numeric_limits<uint64_t>::max() - n);
+        return ((n + m - 1) / m) * m;
+    }
+
 }  // namespace gpgmm

--- a/src/gpgmm/common/Math.h
+++ b/src/gpgmm/common/Math.h
@@ -55,6 +55,8 @@ namespace gpgmm {
         return ((number + multipleT - 1) / multipleT) * multipleT;
     }
 
+    uint64_t RoundUp(uint64_t n, uint64_t m);
+
 }  // namespace gpgmm
 
 #endif  // GPGMM_COMMON_MATH_H_

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -34,6 +34,7 @@
 #include "gpgmm/d3d12/ResidencyManagerD3D12.h"
 #include "gpgmm/d3d12/ResourceAllocationD3D12.h"
 #include "gpgmm/d3d12/ResourceHeapAllocatorD3D12.h"
+#include "gpgmm/d3d12/UtilsD3D12.h"
 
 namespace gpgmm { namespace d3d12 {
     namespace {
@@ -95,6 +96,7 @@ namespace gpgmm { namespace d3d12 {
             if ((resourceDescriptor.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE1D ||
                  resourceDescriptor.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE2D ||
                  resourceDescriptor.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE3D) &&
+                IsAllowedToUseSmallAlignment(resourceDescriptor) &&
                 (resourceDescriptor.Flags & (D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET |
                                              D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL)) == 0) {
                 resourceDescriptor.Alignment = (resourceDescriptor.SampleDesc.Count > 1)

--- a/src/gpgmm/d3d12/UtilsD3D12.cpp
+++ b/src/gpgmm/d3d12/UtilsD3D12.cpp
@@ -14,6 +14,8 @@
 
 #include "gpgmm/d3d12/UtilsD3D12.h"
 
+#include "gpgmm/common/Math.h"
+
 namespace gpgmm { namespace d3d12 {
 
     bool IsDepthFormat(DXGI_FORMAT format) {
@@ -28,6 +30,367 @@ namespace gpgmm { namespace d3d12 {
             default:
                 return false;
         }
+    }
+
+    uint64_t GetTileCount(const D3D12_RESOURCE_DESC& resourceDescriptor,
+                          const D3D12_TILE_SHAPE& tileShape) {
+        return (RoundUp(resourceDescriptor.Width, tileShape.WidthInTexels) /
+                tileShape.WidthInTexels) *
+               (RoundUp(resourceDescriptor.Height, tileShape.HeightInTexels) /
+                tileShape.HeightInTexels) *
+               (RoundUp(resourceDescriptor.DepthOrArraySize, tileShape.DepthInTexels) /
+                tileShape.DepthInTexels);
+    }
+
+    // Returns number of bits per texel "unit" (single texel or 2D texel "block").
+    uint32_t GetTextureBitsPerUnit(DXGI_FORMAT format) {
+        // List generated from <dxgiformat.h>
+        // https://docs.microsoft.com/en-us/windows/win32/api/dxgiformat/ne-dxgiformat-dxgi_format
+        switch (format) {
+            case DXGI_FORMAT_R32G32B32A32_TYPELESS:
+            case DXGI_FORMAT_R32G32B32A32_FLOAT:
+            case DXGI_FORMAT_R32G32B32A32_UINT:
+            case DXGI_FORMAT_R32G32B32A32_SINT:
+                return 128;
+
+            case DXGI_FORMAT_R32G32B32_TYPELESS:
+            case DXGI_FORMAT_R32G32B32_FLOAT:
+            case DXGI_FORMAT_R32G32B32_UINT:
+            case DXGI_FORMAT_R32G32B32_SINT:
+                return 96;
+
+            case DXGI_FORMAT_R16G16B16A16_TYPELESS:
+            case DXGI_FORMAT_R16G16B16A16_FLOAT:
+            case DXGI_FORMAT_R16G16B16A16_UNORM:
+            case DXGI_FORMAT_R16G16B16A16_UINT:
+            case DXGI_FORMAT_R16G16B16A16_SNORM:
+            case DXGI_FORMAT_R16G16B16A16_SINT:
+                return 64;
+
+            case DXGI_FORMAT_R32G32_TYPELESS:
+            case DXGI_FORMAT_R32G32_FLOAT:
+            case DXGI_FORMAT_R32G32_UINT:
+            case DXGI_FORMAT_R32G32_SINT:
+                return 64;
+
+            case DXGI_FORMAT_R32G8X24_TYPELESS:
+            case DXGI_FORMAT_D32_FLOAT_S8X24_UINT:
+            case DXGI_FORMAT_R32_FLOAT_X8X24_TYPELESS:
+            case DXGI_FORMAT_X32_TYPELESS_G8X24_UINT:
+                return 64;
+
+            case DXGI_FORMAT_R10G10B10A2_TYPELESS:
+            case DXGI_FORMAT_R10G10B10A2_UNORM:
+            case DXGI_FORMAT_R10G10B10A2_UINT:
+            case DXGI_FORMAT_R11G11B10_FLOAT:
+                return 32;
+
+            case DXGI_FORMAT_R8G8B8A8_TYPELESS:
+            case DXGI_FORMAT_R8G8B8A8_UNORM:
+            case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:
+            case DXGI_FORMAT_R8G8B8A8_UINT:
+            case DXGI_FORMAT_R8G8B8A8_SNORM:
+            case DXGI_FORMAT_R8G8B8A8_SINT:
+                return 32;
+
+            case DXGI_FORMAT_R16G16_TYPELESS:
+            case DXGI_FORMAT_R16G16_FLOAT:
+            case DXGI_FORMAT_R16G16_UNORM:
+            case DXGI_FORMAT_R16G16_UINT:
+            case DXGI_FORMAT_R16G16_SNORM:
+            case DXGI_FORMAT_R16G16_SINT:
+                return 32;
+
+            case DXGI_FORMAT_R32_TYPELESS:
+            case DXGI_FORMAT_D32_FLOAT:
+            case DXGI_FORMAT_R32_FLOAT:
+            case DXGI_FORMAT_R32_UINT:
+            case DXGI_FORMAT_R32_SINT:
+                return 32;
+
+            case DXGI_FORMAT_R24G8_TYPELESS:
+            case DXGI_FORMAT_D24_UNORM_S8_UINT:
+            case DXGI_FORMAT_R24_UNORM_X8_TYPELESS:
+            case DXGI_FORMAT_X24_TYPELESS_G8_UINT:
+                return 32;
+
+            case DXGI_FORMAT_R8G8_TYPELESS:
+            case DXGI_FORMAT_R8G8_UNORM:
+            case DXGI_FORMAT_R8G8_UINT:
+            case DXGI_FORMAT_R8G8_SNORM:
+            case DXGI_FORMAT_R8G8_SINT:
+                return 16;
+
+            case DXGI_FORMAT_R16_TYPELESS:
+            case DXGI_FORMAT_R16_FLOAT:
+            case DXGI_FORMAT_D16_UNORM:
+            case DXGI_FORMAT_R16_UNORM:
+            case DXGI_FORMAT_R16_UINT:
+            case DXGI_FORMAT_R16_SNORM:
+            case DXGI_FORMAT_R16_SINT:
+                return 16;
+
+            case DXGI_FORMAT_R8_TYPELESS:
+            case DXGI_FORMAT_R8_UNORM:
+            case DXGI_FORMAT_R8_UINT:
+            case DXGI_FORMAT_R8_SNORM:
+            case DXGI_FORMAT_R8_SINT:
+                return 8;
+
+            case DXGI_FORMAT_A8_UNORM:
+                return 8;
+
+            case DXGI_FORMAT_R1_UNORM:
+                return 1;
+
+            case DXGI_FORMAT_R9G9B9E5_SHAREDEXP:
+            case DXGI_FORMAT_R8G8_B8G8_UNORM:
+            case DXGI_FORMAT_G8R8_G8B8_UNORM:
+                return 32;
+
+            case DXGI_FORMAT_BC1_TYPELESS:
+            case DXGI_FORMAT_BC1_UNORM:
+            case DXGI_FORMAT_BC1_UNORM_SRGB:
+                return 4;
+
+            case DXGI_FORMAT_BC2_TYPELESS:
+            case DXGI_FORMAT_BC2_UNORM:
+            case DXGI_FORMAT_BC2_UNORM_SRGB:
+                return 8;
+
+            case DXGI_FORMAT_BC3_TYPELESS:
+            case DXGI_FORMAT_BC3_UNORM:
+            case DXGI_FORMAT_BC3_UNORM_SRGB:
+                return 8;
+
+            case DXGI_FORMAT_BC4_TYPELESS:
+            case DXGI_FORMAT_BC4_UNORM:
+            case DXGI_FORMAT_BC4_SNORM:
+                return 4;
+
+            case DXGI_FORMAT_BC5_TYPELESS:
+            case DXGI_FORMAT_BC5_UNORM:
+            case DXGI_FORMAT_BC5_SNORM:
+                return 8;
+
+            case DXGI_FORMAT_B5G6R5_UNORM:
+            case DXGI_FORMAT_B5G5R5A1_UNORM:
+                return 16;
+
+            case DXGI_FORMAT_B8G8R8A8_UNORM:
+            case DXGI_FORMAT_B8G8R8X8_UNORM:
+            case DXGI_FORMAT_R10G10B10_XR_BIAS_A2_UNORM:
+            case DXGI_FORMAT_B8G8R8A8_TYPELESS:
+            case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
+            case DXGI_FORMAT_B8G8R8X8_TYPELESS:
+            case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:
+                return 32;
+
+            case DXGI_FORMAT_BC6H_TYPELESS:
+            case DXGI_FORMAT_BC6H_UF16:
+            case DXGI_FORMAT_BC6H_SF16:
+                return 8;
+
+            case DXGI_FORMAT_BC7_TYPELESS:
+            case DXGI_FORMAT_BC7_UNORM:
+            case DXGI_FORMAT_BC7_UNORM_SRGB:
+                return 8;
+
+            case DXGI_FORMAT_NV12:
+                return 12;
+
+            default:
+                return 0;
+        }
+    }
+
+    bool IsTileZeroSized(const D3D12_TILE_SHAPE& tile) {
+        return tile.HeightInTexels == 0 && tile.WidthInTexels == 0 && tile.DepthInTexels == 0;
+    }
+
+    bool IsBlockCompressionFormat(DXGI_FORMAT format) {
+        // BC1 through BC7 are defined by two enum ranges in DXGIFormat.h.
+        return (format >= DXGI_FORMAT_BC1_TYPELESS && format <= DXGI_FORMAT_BC5_SNORM) ||
+               (format >= DXGI_FORMAT_BC6H_TYPELESS && format <= DXGI_FORMAT_BC7_UNORM_SRGB);
+    }
+
+    // Returns a "small" (or 4KB) tile for a given texture.
+    D3D12_TILE_SHAPE GetSmallTextureTile(DXGI_FORMAT format,
+                                         D3D12_RESOURCE_DIMENSION resourceDimension,
+                                         uint32_t sampleCount) {
+        // Tile size is determined by the bit depth of the texture used.
+        //
+        // For example, RGBA8 has a bit depth of 32 bits (8 bits per channel x 4 channels per
+        // texel).
+        //
+        // 4KB tile = WxHxD x 4B/texel, D=1
+        //          = H^2 x 4B/texel
+        //          = 1024 x 4B/texel
+        //          = 32x32x1 tile
+        //
+        const uint32_t bitsPerUnit = GetTextureBitsPerUnit(format);
+        if (bitsPerUnit == 0) {
+            return {};
+        }
+
+        D3D12_TILE_SHAPE tile = {};
+        switch (resourceDimension) {
+            case D3D12_RESOURCE_DIMENSION_TEXTURE1D: {
+                // 1D textures (and buffers) always have a weight and depth deemsnion equal to 1.
+                tile.HeightInTexels = 1;
+                tile.DepthInTexels = 1;
+
+                tile.WidthInTexels = (D3D12_SMALL_RESOURCE_PLACEMENT_ALIGNMENT * 8) / bitsPerUnit;
+
+            } break;
+
+            case D3D12_RESOURCE_DIMENSION_TEXTURE2D: {
+                // 2D textures always have a depth demension equal to 1.
+                tile.DepthInTexels = 1;
+
+                if (IsBlockCompressionFormat(format)) {
+                    return {};  // TODO
+                }
+
+                // Tile size depends on number of bits per texel (or WxHx1 x bytes/texel).
+                switch (bitsPerUnit) {
+                    // 64x64x1 x 1 bytes per texel.
+                    case 8: {
+                        tile.WidthInTexels = 64;
+                        tile.HeightInTexels = 64;
+                    } break;
+
+                    // 64x64x1 x 2 bytes per texel.
+                    case 16: {
+                        tile.WidthInTexels = 64;
+                        tile.HeightInTexels = 32;
+                    } break;
+
+                    // 32x32x1 x 4 bytes per texel.
+                    case 32: {
+                        tile.WidthInTexels = 32;
+                        tile.HeightInTexels = 32;
+                    } break;
+
+                    // 64x64x1 x 8 bytes per texel.
+                    case 64: {
+                        tile.WidthInTexels = 32;
+                        tile.HeightInTexels = 16;
+                    } break;
+
+                    // 128x128x1 x 16 bytes per texel.
+                    case 128: {
+                        tile.WidthInTexels = 16;
+                        tile.HeightInTexels = 16;
+                    } break;
+
+                    default:
+                        tile = {};
+                        break;
+                }
+
+                // Tile size also depends on the sample count (or samples x bytes/texel).
+                switch (sampleCount) {
+                    // 1x = 1x1 per texel = WxH bytes per texel (no change).
+                    case 1: {
+                    } break;
+
+                    // 2x = 2x1 per texel = W/2 x H bytes per texel.
+                    case 2: {
+                        tile.WidthInTexels /= 2;
+                        tile.HeightInTexels /= 1;
+                    } break;
+
+                    // 4x = 2x2 per texel = W/2 x H/2 bytes per texel.
+                    case 4: {
+                        tile.WidthInTexels /= 2;
+                        tile.HeightInTexels /= 2;
+                    } break;
+
+                    // 8x = 4x2 per texel = W/4 x H/2 bytes per texel.
+                    case 8: {
+                        tile.WidthInTexels /= 4;
+                        tile.HeightInTexels /= 2;
+                    } break;
+
+                    // 16x = 4x4 per texel = W/4 x H/4 bytes per texel.
+                    case 16: {
+                        tile.WidthInTexels /= 4;
+                        tile.HeightInTexels /= 4;
+                    } break;
+
+                    default:
+                        tile = {};
+                        break;
+                }
+
+            } break;
+
+            case D3D12_RESOURCE_DIMENSION_TEXTURE3D: {
+                // WxHxD x bytes/texel.
+                switch (bitsPerUnit) {
+                    // 16x16x16 x 1 bytes per texel
+                    case 8: {
+                        tile.WidthInTexels = 16;
+                        tile.HeightInTexels = 16;
+                        tile.DepthInTexels = 16;
+                    } break;
+
+                    // 16x16x8 x 2 bytes per texel
+                    case 16: {
+                        tile.WidthInTexels = 16;
+                        tile.HeightInTexels = 16;
+                        tile.DepthInTexels = 8;
+                    } break;
+
+                    // 16x8x8 x 4 bytes per texel
+                    case 32: {
+                        tile.WidthInTexels = 16;
+                        tile.HeightInTexels = 8;
+                        tile.DepthInTexels = 8;
+                    } break;
+
+                    // 8x8x8 x 8 bytes per texel
+                    case 64: {
+                        tile.WidthInTexels = 8;
+                        tile.HeightInTexels = 8;
+                        tile.DepthInTexels = 8;
+                    } break;
+
+                    // 8x8x4 x 16 bytes per texel
+                    case 128: {
+                        tile.WidthInTexels = 8;
+                        tile.HeightInTexels = 8;
+                        tile.DepthInTexels = 4;
+                    } break;
+
+                    default:
+                        tile = {};
+                        break;
+                }
+            } break;
+
+            default:
+                break;
+        }
+
+        return tile;
+    }
+
+    bool IsAllowedToUseSmallAlignment(const D3D12_RESOURCE_DESC& resourceDescriptor) {
+        // Small alignment is only possible if the resource, of size equal to the larger alignment
+        // (ex. 64KB), can be divided into small "tiles", a number equal to or greater than the size
+        // equal to the smaller alignment (ex. 4KB).
+        const D3D12_TILE_SHAPE& tile =
+            GetSmallTextureTile(resourceDescriptor.Format, resourceDescriptor.Dimension,
+                                resourceDescriptor.SampleDesc.Count);
+        // Assume it can use small alignment since the caller is responsible to get the correct
+        // (or larger) alignment anyway if cannot be granted by GetResourceAllocationInfo().
+        if (IsTileZeroSized(tile)) {
+            return true;
+        }
+
+        return GetTileCount(resourceDescriptor, tile) <= 16;
     }
 
 }}  // namespace gpgmm::d3d12

--- a/src/gpgmm/d3d12/UtilsD3D12.h
+++ b/src/gpgmm/d3d12/UtilsD3D12.h
@@ -19,6 +19,7 @@
 namespace gpgmm { namespace d3d12 {
 
     bool IsDepthFormat(DXGI_FORMAT format);
+    bool IsAllowedToUseSmallAlignment(const D3D12_RESOURCE_DESC& Desc);
 
 }}  // namespace gpgmm::d3d12
 


### PR DESCRIPTION

Eliminates duplicated calls to GetResourceAllocationInfo() by checking if the number of 4KB tiles does not exceed the 64KB limit.