### PR TITLE
Put size cache behind flag.

### DIFF
--- a/build_overrides/gpgmm_features.gni
+++ b/build_overrides/gpgmm_features.gni
@@ -65,4 +65,8 @@ declare_args() {
   # Enables ASSERT on severity functionality.
   # Sets -dGPGMM_ENABLE_ASSERT_ON_WARNING
   gpgmm_enable_assert_on_warning = false
+
+  # Enables warming of caches with common sizes.
+  # Sets -dGPGMM_ENABLE_SIZE_CACHE
+  gpgmm_enable_size_cache = true
 }

--- a/src/gpgmm/BUILD.gn
+++ b/src/gpgmm/BUILD.gn
@@ -112,6 +112,10 @@ source_set("gpgmm_sources") {
     defines += [ "GPGMM_ENABLE_ASSERT_ON_WARNING" ]
   }
 
+  if (gpgmm_enable_size_cache) {
+    defines += [ "GPGMM_ENABLE_SIZE_CACHE" ]
+  }
+
   libs = []
   data_deps = []
 

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -506,6 +506,7 @@ namespace gpgmm { namespace d3d12 {
             // cached size must be requested per alignment {4KB, 64KB, or 4MB}. To avoid unbounded
             // cache growth, a known set of pre-defined sizes initializes the allocators.
 
+#if defined(GPGMM_ENABLE_SIZE_CACHE)
             // Temporary suppress log messages emitted from internal cache-miss requests.
             {
                 ScopedLogLevel scopedLogLevel(LogSeverity::Info);
@@ -526,6 +527,7 @@ namespace gpgmm { namespace d3d12 {
                         /*neverAllocate*/ true, /*cacheSize*/ true);
                 }
             }
+#endif
         }
     }
 


### PR DESCRIPTION

Size cache creates a lot of noise to filter out during debug.