### PR TITLE
Add GPGMM_CHECK_NONZERO macro.

### DIFF
--- a/src/gpgmm/BuddyBlockAllocator.cpp
+++ b/src/gpgmm/BuddyBlockAllocator.cpp
@@ -16,6 +16,7 @@
 #include "gpgmm/BuddyBlockAllocator.h"
 
 #include "gpgmm/Debug.h"
+#include "gpgmm/Error.h"
 #include "gpgmm/common/Assert.h"
 #include "gpgmm/common/Math.h"
 #include "gpgmm/common/Utils.h"
@@ -144,7 +145,9 @@ namespace gpgmm {
     }
 
     Block* BuddyBlockAllocator::AllocateBlock(uint64_t size, uint64_t alignment) {
-        if (size == 0 || size > mMaxBlockSize) {
+        GPGMM_VERIFY_NONZERO(size);
+
+        if (size > mMaxBlockSize) {
             RecordLogMessage(LogSeverity::Debug, "BuddyBlockAllocator.AllocateBlock",
                              "Block size exceeded the max block size.",
                              ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED);

--- a/src/gpgmm/BuddyBlockAllocator.cpp
+++ b/src/gpgmm/BuddyBlockAllocator.cpp
@@ -145,7 +145,7 @@ namespace gpgmm {
     }
 
     Block* BuddyBlockAllocator::AllocateBlock(uint64_t size, uint64_t alignment) {
-        GPGMM_VERIFY_NONZERO(size);
+        GPGMM_CHECK_NONZERO(size);
 
         if (size > mMaxBlockSize) {
             RecordLogMessage(LogSeverity::Debug, "BuddyBlockAllocator.AllocateBlock",
@@ -155,11 +155,11 @@ namespace gpgmm {
         }
 
         // Compute the level
-        const uint32_t allocationSizeToLevel = ComputeLevelFromBlockSize(size);
+        const uint32_t sizeToLevel = ComputeLevelFromBlockSize(size);
 
-        ASSERT(allocationSizeToLevel < mFreeLists.size());
+        ASSERT(sizeToLevel < mFreeLists.size());
 
-        uint64_t currBlockLevel = GetNextFreeAlignedBlock(allocationSizeToLevel, alignment);
+        uint64_t currBlockLevel = GetNextFreeAlignedBlock(sizeToLevel, alignment);
 
         // Error when no free blocks exist (allocator is full)
         if (currBlockLevel == kInvalidOffset) {
@@ -174,7 +174,7 @@ namespace gpgmm {
         // allocation.
         BuddyBlock* currBlock = mFreeLists[currBlockLevel].head;
 
-        for (; currBlockLevel < allocationSizeToLevel; currBlockLevel++) {
+        for (; currBlockLevel < sizeToLevel; currBlockLevel++) {
             ASSERT(currBlock->mState == BlockState::Free);
 
             // Remove curr block (about to be split).

--- a/src/gpgmm/BuddyMemoryAllocator.cpp
+++ b/src/gpgmm/BuddyMemoryAllocator.cpp
@@ -45,10 +45,11 @@ namespace gpgmm {
         uint64_t alignment,
         bool neverAllocate,
         bool cacheSize) {
+        GPGMM_VERIFY_NONZERO(allocationSize);
         TRACE_EVENT_CALL_SCOPED("BuddyMemoryAllocator.TryAllocateMemory");
 
         // Check the unaligned size to avoid overflowing NextPowerOfTwo.
-        if (allocationSize == 0 || allocationSize > mMemorySize) {
+        if (allocationSize > mMemorySize) {
             RecordLogMessage(LogSeverity::Debug, "BuddyMemoryAllocator.TryAllocateMemory",
                              "Allocation size exceeded the memory size (" +
                                  std::to_string(allocationSize) + " vs " +

--- a/src/gpgmm/BuddyMemoryAllocator.cpp
+++ b/src/gpgmm/BuddyMemoryAllocator.cpp
@@ -40,26 +40,24 @@ namespace gpgmm {
         return offset / mMemorySize;
     }
 
-    std::unique_ptr<MemoryAllocation> BuddyMemoryAllocator::TryAllocateMemory(
-        uint64_t allocationSize,
-        uint64_t alignment,
-        bool neverAllocate,
-        bool cacheSize) {
-        GPGMM_VERIFY_NONZERO(allocationSize);
+    std::unique_ptr<MemoryAllocation> BuddyMemoryAllocator::TryAllocateMemory(uint64_t size,
+                                                                              uint64_t alignment,
+                                                                              bool neverAllocate,
+                                                                              bool cacheSize) {
+        GPGMM_CHECK_NONZERO(size);
         TRACE_EVENT_CALL_SCOPED("BuddyMemoryAllocator.TryAllocateMemory");
 
         // Check the unaligned size to avoid overflowing NextPowerOfTwo.
-        if (allocationSize > mMemorySize) {
+        if (size > mMemorySize) {
             RecordLogMessage(LogSeverity::Debug, "BuddyMemoryAllocator.TryAllocateMemory",
-                             "Allocation size exceeded the memory size (" +
-                                 std::to_string(allocationSize) + " vs " +
-                                 std::to_string(mMemorySize) + " bytes).",
+                             "Allocation size exceeded the memory size (" + std::to_string(size) +
+                                 " vs " + std::to_string(mMemorySize) + " bytes).",
                              ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED);
             return nullptr;
         }
 
         // Round allocation size to nearest power-of-two.
-        allocationSize = NextPowerOfTwo(allocationSize);
+        const uint64_t allocationSize = NextPowerOfTwo(size);
 
         // Allocation cannot exceed the memory size.
         if (allocationSize > mMemorySize) {

--- a/src/gpgmm/BuddyMemoryAllocator.h
+++ b/src/gpgmm/BuddyMemoryAllocator.h
@@ -43,7 +43,7 @@ namespace gpgmm {
                              std::unique_ptr<MemoryAllocator> memoryAllocator);
 
         // MemoryAllocator interface
-        std::unique_ptr<MemoryAllocation> TryAllocateMemory(uint64_t allocationSize,
+        std::unique_ptr<MemoryAllocation> TryAllocateMemory(uint64_t size,
                                                             uint64_t alignment,
                                                             bool neverAllocate,
                                                             bool cacheSize) override;

--- a/src/gpgmm/ConditionalMemoryAllocator.cpp
+++ b/src/gpgmm/ConditionalMemoryAllocator.cpp
@@ -27,16 +27,14 @@ namespace gpgmm {
     }
 
     std::unique_ptr<MemoryAllocation> ConditionalMemoryAllocator::TryAllocateMemory(
-        uint64_t allocationSize,
+        uint64_t size,
         uint64_t alignment,
         bool neverAllocate,
         bool cacheSize) {
-        if (allocationSize <= mConditionalSize) {
-            return mFirstAllocator->TryAllocateMemory(allocationSize, alignment, neverAllocate,
-                                                      cacheSize);
+        if (size <= mConditionalSize) {
+            return mFirstAllocator->TryAllocateMemory(size, alignment, neverAllocate, cacheSize);
         } else {
-            return mSecondAllocator->TryAllocateMemory(allocationSize, alignment, neverAllocate,
-                                                       cacheSize);
+            return mSecondAllocator->TryAllocateMemory(size, alignment, neverAllocate, cacheSize);
         }
     }
 

--- a/src/gpgmm/ConditionalMemoryAllocator.h
+++ b/src/gpgmm/ConditionalMemoryAllocator.h
@@ -30,7 +30,7 @@ namespace gpgmm {
         ~ConditionalMemoryAllocator() override = default;
 
         // MemoryAllocator interface
-        std::unique_ptr<MemoryAllocation> TryAllocateMemory(uint64_t allocationSize,
+        std::unique_ptr<MemoryAllocation> TryAllocateMemory(uint64_t size,
                                                             uint64_t alignment,
                                                             bool neverAllocate,
                                                             bool cacheSize) override;

--- a/src/gpgmm/Error.h
+++ b/src/gpgmm/Error.h
@@ -14,13 +14,13 @@
 
 namespace gpgmm {
 
-#define GPGMM_VERIFY_NONZERO(size) \
-    {                              \
-        if (size == 0) {           \
-            return nullptr;        \
-        }                          \
-    }                              \
-    for (;;)                       \
+#define GPGMM_CHECK_NONZERO(size) \
+    {                             \
+        if (size == 0) {          \
+            return nullptr;       \
+        }                         \
+    }                             \
+    for (;;)                      \
     break
 
 #define GPGMM_TRY_ASSIGN(expr, value) \

--- a/src/gpgmm/Error.h
+++ b/src/gpgmm/Error.h
@@ -14,6 +14,15 @@
 
 namespace gpgmm {
 
+#define GPGMM_VERIFY_NONZERO(size) \
+    {                              \
+        if (size == 0) {           \
+            return nullptr;        \
+        }                          \
+    }                              \
+    for (;;)                       \
+    break
+
 #define GPGMM_TRY_ASSIGN(expr, value) \
     {                                 \
         auto result = expr;           \

--- a/src/gpgmm/MemoryAllocator.cpp
+++ b/src/gpgmm/MemoryAllocator.cpp
@@ -20,7 +20,7 @@ namespace gpgmm {
         AppendChild(std::move(childAllocator));
     }
 
-    std::unique_ptr<MemoryAllocation> MemoryAllocator::TryAllocateMemory(uint64_t allocationSize,
+    std::unique_ptr<MemoryAllocation> MemoryAllocator::TryAllocateMemory(uint64_t size,
                                                                          uint64_t alignment,
                                                                          bool neverAllocate,
                                                                          bool cacheSize) {

--- a/src/gpgmm/MemoryAllocator.h
+++ b/src/gpgmm/MemoryAllocator.h
@@ -55,13 +55,13 @@ namespace gpgmm {
         virtual ~MemoryAllocator() = default;
 
         // Attempts to allocate memory and return a allocation that is at-least of the requested
-        // |allocationSize| whose value is a multiple of |alignment|. If it cannot, return
+        // |size| whose value is a multiple of |alignment|. If it cannot, return
         // nullptr. The returned MemoryAllocation is only valid for the lifetime of this allocator.
         // When |neverAllocate| is true, the memory allocator will not allocate anything and
         // effectively no-op.
         // When |cacheSize| is true, the memory allocator may cache for the requested
         // allocation to speed-up subsequent requests of the same size.
-        virtual std::unique_ptr<MemoryAllocation> TryAllocateMemory(uint64_t allocationSize,
+        virtual std::unique_ptr<MemoryAllocation> TryAllocateMemory(uint64_t size,
                                                                     uint64_t alignment,
                                                                     bool neverAllocate,
                                                                     bool cacheSize);

--- a/src/gpgmm/PooledMemoryAllocator.cpp
+++ b/src/gpgmm/PooledMemoryAllocator.cpp
@@ -25,16 +25,15 @@ namespace gpgmm {
         ASSERT(mPool != nullptr);
     }
 
-    std::unique_ptr<MemoryAllocation> PooledMemoryAllocator::TryAllocateMemory(
-        uint64_t allocationSize,
-        uint64_t alignment,
-        bool neverAllocate,
-        bool cacheSize) {
+    std::unique_ptr<MemoryAllocation> PooledMemoryAllocator::TryAllocateMemory(uint64_t size,
+                                                                               uint64_t alignment,
+                                                                               bool neverAllocate,
+                                                                               bool cacheSize) {
         std::unique_ptr<MemoryAllocation> allocation = mPool->AcquireFromPool();
         if (allocation == nullptr) {
-            GPGMM_TRY_ASSIGN(GetFirstChild()->TryAllocateMemory(allocationSize, alignment,
-                                                                neverAllocate, cacheSize),
-                             allocation);
+            GPGMM_TRY_ASSIGN(
+                GetFirstChild()->TryAllocateMemory(size, alignment, neverAllocate, cacheSize),
+                allocation);
 
             mInfo.UsedMemoryCount++;
             mInfo.UsedMemoryUsage += allocation->GetSize();

--- a/src/gpgmm/PooledMemoryAllocator.h
+++ b/src/gpgmm/PooledMemoryAllocator.h
@@ -28,7 +28,7 @@ namespace gpgmm {
         ~PooledMemoryAllocator() override = default;
 
         // MemoryAllocator interface
-        std::unique_ptr<MemoryAllocation> TryAllocateMemory(uint64_t allocationSize,
+        std::unique_ptr<MemoryAllocation> TryAllocateMemory(uint64_t size,
                                                             uint64_t alignment,
                                                             bool neverAllocate,
                                                             bool cacheSize) override;

--- a/src/gpgmm/SegmentedMemoryAllocator.cpp
+++ b/src/gpgmm/SegmentedMemoryAllocator.cpp
@@ -132,8 +132,9 @@ namespace gpgmm {
         bool neverAllocate,
         bool cacheSize) {
         TRACE_EVENT_CALL_SCOPED("SegmentedMemoryAllocator.TryAllocateMemory");
+        GPGMM_VERIFY_NONZERO(allocationSize);
 
-        if (allocationSize == 0 || alignment != mMemoryAlignment) {
+        if (alignment != mMemoryAlignment) {
             RecordLogMessage(LogSeverity::Debug, "SegmentedMemoryAllocator.TryAllocateMemory",
                              "Allocation alignment does not match memory alignment.",
                              ALLOCATOR_MESSAGE_ID_ALIGNMENT_MISMATCH);

--- a/src/gpgmm/SegmentedMemoryAllocator.cpp
+++ b/src/gpgmm/SegmentedMemoryAllocator.cpp
@@ -127,12 +127,12 @@ namespace gpgmm {
     }
 
     std::unique_ptr<MemoryAllocation> SegmentedMemoryAllocator::TryAllocateMemory(
-        uint64_t allocationSize,
+        uint64_t size,
         uint64_t alignment,
         bool neverAllocate,
         bool cacheSize) {
         TRACE_EVENT_CALL_SCOPED("SegmentedMemoryAllocator.TryAllocateMemory");
-        GPGMM_VERIFY_NONZERO(allocationSize);
+        GPGMM_CHECK_NONZERO(size);
 
         if (alignment != mMemoryAlignment) {
             RecordLogMessage(LogSeverity::Debug, "SegmentedMemoryAllocator.TryAllocateMemory",
@@ -141,12 +141,12 @@ namespace gpgmm {
             return {};
         }
 
-        MemorySegment* segment = GetOrCreateFreeSegment(allocationSize);
+        MemorySegment* segment = GetOrCreateFreeSegment(size);
         ASSERT(segment != nullptr);
 
         std::unique_ptr<MemoryAllocation> allocation = segment->AcquireFromPool();
         if (allocation == nullptr) {
-            GPGMM_TRY_ASSIGN(GetFirstChild()->TryAllocateMemory(allocationSize, mMemoryAlignment,
+            GPGMM_TRY_ASSIGN(GetFirstChild()->TryAllocateMemory(size, mMemoryAlignment,
                                                                 neverAllocate, cacheSize),
                              allocation);
             mInfo.UsedMemoryCount++;

--- a/src/gpgmm/SegmentedMemoryAllocator.h
+++ b/src/gpgmm/SegmentedMemoryAllocator.h
@@ -39,7 +39,7 @@ namespace gpgmm {
         ~SegmentedMemoryAllocator() override;
 
         // MemoryAllocator interface
-        std::unique_ptr<MemoryAllocation> TryAllocateMemory(uint64_t allocationSize,
+        std::unique_ptr<MemoryAllocation> TryAllocateMemory(uint64_t size,
                                                             uint64_t alignment,
                                                             bool neverAllocate,
                                                             bool cacheSize) override;

--- a/src/gpgmm/SlabBlockAllocator.cpp
+++ b/src/gpgmm/SlabBlockAllocator.cpp
@@ -15,6 +15,7 @@
 #include "gpgmm/SlabBlockAllocator.h"
 
 #include "gpgmm/Debug.h"
+#include "gpgmm/Error.h"
 #include "gpgmm/common/Assert.h"
 #include "gpgmm/common/Math.h"
 #include "gpgmm/common/Utils.h"
@@ -40,7 +41,9 @@ namespace gpgmm {
     }
 
     Block* SlabBlockAllocator::AllocateBlock(uint64_t size, uint64_t alignment) {
-        if (size == 0 || size > mBlockSize) {
+        GPGMM_VERIFY_NONZERO(size);
+
+        if (size > mBlockSize) {
             RecordLogMessage(LogSeverity::Debug, "SlabBlockAllocator.AllocateBlock",
                              "Allocation size exceeded the block size. (" + std::to_string(size) +
                                  " vs " + std::to_string(mBlockSize) + " bytes).",

--- a/src/gpgmm/SlabBlockAllocator.cpp
+++ b/src/gpgmm/SlabBlockAllocator.cpp
@@ -41,7 +41,7 @@ namespace gpgmm {
     }
 
     Block* SlabBlockAllocator::AllocateBlock(uint64_t size, uint64_t alignment) {
-        GPGMM_VERIFY_NONZERO(size);
+        GPGMM_CHECK_NONZERO(size);
 
         if (size > mBlockSize) {
             RecordLogMessage(LogSeverity::Debug, "SlabBlockAllocator.AllocateBlock",

--- a/src/gpgmm/SlabMemoryAllocator.cpp
+++ b/src/gpgmm/SlabMemoryAllocator.cpp
@@ -253,11 +253,12 @@ namespace gpgmm {
                                                                             bool neverAllocate,
                                                                             bool cacheSize) {
         TRACE_EVENT_CALL_SCOPED("SlabCacheAllocator.TryAllocateMemory");
+        GPGMM_VERIFY_NONZERO(allocationSize);
 
         const uint64_t blockSize = AlignTo(allocationSize, mMinBlockSize);
 
         // Attempting to allocate a block larger then the slab will always fail.
-        if (mSlabSize != 0 && blockSize > mSlabSize) {
+        if (blockSize > mSlabSize) {
             RecordLogMessage(LogSeverity::Debug, "SlabMemoryAllocator.TryAllocateMemory",
                              "Aligned allocation size exceeded the slab size (" +
                                  std::to_string(blockSize) + " vs " + std::to_string(mSlabSize) +

--- a/src/gpgmm/SlabMemoryAllocator.h
+++ b/src/gpgmm/SlabMemoryAllocator.h
@@ -52,7 +52,7 @@ namespace gpgmm {
         ~SlabMemoryAllocator() override;
 
         // MemoryAllocator interface
-        std::unique_ptr<MemoryAllocation> TryAllocateMemory(uint64_t allocationSize,
+        std::unique_ptr<MemoryAllocation> TryAllocateMemory(uint64_t size,
                                                             uint64_t alignment,
                                                             bool neverAllocate,
                                                             bool cacheSize) override;
@@ -63,7 +63,7 @@ namespace gpgmm {
         uint64_t GetSlabSizeForTesting() const;
 
       private:
-        uint64_t ComputeSlabSize(uint64_t allocationSize) const;
+        uint64_t ComputeSlabSize(uint64_t size) const;
 
         // Slab is a node in a doubly-linked list that contains a free-list of blocks
         // and a reference to the underlying memory.
@@ -126,7 +126,7 @@ namespace gpgmm {
         ~SlabCacheAllocator() override;
 
         // MemoryAllocator interface
-        std::unique_ptr<MemoryAllocation> TryAllocateMemory(uint64_t allocationSize,
+        std::unique_ptr<MemoryAllocation> TryAllocateMemory(uint64_t size,
                                                             uint64_t alignment,
                                                             bool neverAllocate,
                                                             bool cacheSize) override;

--- a/src/gpgmm/d3d12/BufferAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/BufferAllocatorD3D12.cpp
@@ -35,19 +35,18 @@ namespace gpgmm { namespace d3d12 {
           mBufferAlignment(bufferAlignment) {
     }
 
-    std::unique_ptr<MemoryAllocation> BufferAllocator::TryAllocateMemory(uint64_t allocationSize,
+    std::unique_ptr<MemoryAllocation> BufferAllocator::TryAllocateMemory(uint64_t size,
                                                                          uint64_t alignment,
                                                                          bool neverAllocate,
                                                                          bool cacheSize) {
-        if (GetMemorySize() != allocationSize || GetMemoryAlignment() != alignment ||
-            neverAllocate) {
+        if (GetMemorySize() != size || GetMemoryAlignment() != alignment || neverAllocate) {
             return {};
         }
 
         D3D12_RESOURCE_DESC resourceDescriptor;
         resourceDescriptor.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
         resourceDescriptor.Alignment = alignment;
-        resourceDescriptor.Width = allocationSize;
+        resourceDescriptor.Width = size;
         resourceDescriptor.Height = 1;
         resourceDescriptor.DepthOrArraySize = 1;
         resourceDescriptor.MipLevels = 1;
@@ -60,7 +59,7 @@ namespace gpgmm { namespace d3d12 {
         // Optimized clear is not supported for buffers.
         Heap* resourceHeap = nullptr;
         if (FAILED(mResourceAllocator->CreateCommittedResource(
-                mHeapType, D3D12_HEAP_FLAG_NONE, allocationSize, &resourceDescriptor,
+                mHeapType, D3D12_HEAP_FLAG_NONE, size, &resourceDescriptor,
                 /*pOptimizedClearValue*/ nullptr, mInitialResourceState, /*resourceOut*/ nullptr,
                 &resourceHeap))) {
             return nullptr;

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -281,13 +281,13 @@ namespace gpgmm { namespace d3d12 {
         // Else, if the resource creation fails, the memory allocation will be cleaned up.
         template <typename CreateResourceFn>
         HRESULT TryAllocateResource(MemoryAllocator* allocator,
-                                    uint64_t allocationSize,
+                                    uint64_t size,
                                     uint64_t alignment,
                                     bool neverAllocate,
                                     bool cacheSize,
                                     CreateResourceFn&& createResourceFn) {
             std::unique_ptr<MemoryAllocation> allocation =
-                allocator->TryAllocateMemory(allocationSize, alignment, neverAllocate, cacheSize);
+                allocator->TryAllocateMemory(size, alignment, neverAllocate, cacheSize);
             if (allocation == nullptr) {
                 RecordLogMessage(LogSeverity::Debug, "ResourceAllocator.TryAllocateResource",
                                  "Resource memory could not be allocated.",

--- a/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.cpp
@@ -29,19 +29,18 @@ namespace gpgmm { namespace d3d12 {
         : mResourceAllocator(resourceAllocator), mHeapType(heapType), mHeapFlags(heapFlags) {
     }
 
-    std::unique_ptr<MemoryAllocation> ResourceHeapAllocator::TryAllocateMemory(
-        uint64_t allocationSize,
-        uint64_t alignment,
-        bool neverAllocate,
-        bool cacheSize) {
+    std::unique_ptr<MemoryAllocation> ResourceHeapAllocator::TryAllocateMemory(uint64_t size,
+                                                                               uint64_t alignment,
+                                                                               bool neverAllocate,
+                                                                               bool cacheSize) {
         if (neverAllocate) {
             return {};
         }
 
-        // D3D12 requests (but not requires) the |allocationSize| be always a multiple of
+        // D3D12 requests (but not requires) the |size| be always a multiple of
         // |alignment| to avoid wasting bytes.
         // https://docs.microsoft.com/en-us/windows/win32/api/d3d12/ns-d3d12-d3d12_HEAP_INFO
-        const uint64_t heapSize = AlignTo(allocationSize, alignment);
+        const uint64_t heapSize = AlignTo(size, alignment);
 
         Heap* resourceHeap = nullptr;
         if (FAILED(mResourceAllocator->CreateResourceHeap(heapSize, mHeapType, mHeapFlags,

--- a/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.h
@@ -32,7 +32,7 @@ namespace gpgmm { namespace d3d12 {
         ~ResourceHeapAllocator() override = default;
 
         // MemoryAllocator interface
-        std::unique_ptr<MemoryAllocation> TryAllocateMemory(uint64_t allocationSize,
+        std::unique_ptr<MemoryAllocation> TryAllocateMemory(uint64_t size,
                                                             uint64_t alignment,
                                                             bool neverAllocate,
                                                             bool cacheSize) override;

--- a/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
+++ b/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
@@ -297,6 +297,14 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBuffer) {
             allocationDesc, CreateBasicBufferDesc(kDefaultPreferredResourceHeapSize),
             D3D12_RESOURCE_STATE_COMMON, nullptr, &allocation));
     }
+
+    // Creating a zero sized buffer is not allowed.
+    {
+        ComPtr<ResourceAllocation> allocation;
+        ASSERT_FAILED(mDefaultAllocator->CreateResource(
+            {}, CreateBasicBufferDesc(0), D3D12_RESOURCE_STATE_COMMON, nullptr, &allocation));
+        ASSERT_EQ(allocation, nullptr);
+    }
 }
 
 TEST_F(D3D12ResourceAllocatorTests, CreateSmallTexture) {


### PR DESCRIPTION

Also, rename |allocationSize| to |size| since the actual allocation size usually differs to the requested (memory) size.