### PR TITLE
Depreciate ResourceAllocator::GetResidencyManager().

### DIFF
--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -912,10 +912,6 @@ namespace gpgmm { namespace d3d12 {
         return S_OK;
     }
 
-    ResidencyManager* ResourceAllocator::GetResidencyManager() const {
-        return mResidencyManager.Get();
-    }
-
     HRESULT ResourceAllocator::QueryResourceAllocatorInfo(
         QUERY_RESOURCE_ALLOCATOR_INFO* resourceAllocationInfoOut) const {
         TRACE_EVENT_CALL_SCOPED("ResourceAllocator.QueryResourceAllocatorInfo");

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -295,11 +295,6 @@ namespace gpgmm { namespace d3d12 {
         HRESULT CreateResource(ComPtr<ID3D12Resource> committedResource,
                                ResourceAllocation** resourceAllocationOut);
 
-        // Return the residency manager. The lifetime of the residency manager is fully owned by the
-        // allocator. CreateResource enables the returned resource allocation to be residency
-        // managed when non-null.
-        ResidencyManager* GetResidencyManager() const;
-
         // When pooling is enabled, the allocator will retain resource heaps in order to speed-up
         // subsequent resource allocation requests. These resource allocations count against the
         // app's memory usage and in general, will lead to increased memory usage by the overall


### PR DESCRIPTION

Must pass a residency manager into CreateAllocator instead.