### PR TITLE
Check allocator's fixed memory size before attempting resource creation.

### DIFF
--- a/src/gpgmm/MemoryAllocator.cpp
+++ b/src/gpgmm/MemoryAllocator.cpp
@@ -35,12 +35,10 @@ namespace gpgmm {
     }
 
     uint64_t MemoryAllocator::GetMemorySize() const {
-        ASSERT(false);
         return kInvalidSize;
     }
 
     uint64_t MemoryAllocator::GetMemoryAlignment() const {
-        ASSERT(false);
         return kInvalidOffset;
     }
 

--- a/src/gpgmm/MemoryAllocator.h
+++ b/src/gpgmm/MemoryAllocator.h
@@ -75,10 +75,14 @@ namespace gpgmm {
         // Used to reuse memory blocks between calls to TryAllocateMemory.
         virtual void ReleaseMemory();
 
-        // Return the fixed-size or alignment of this memory allocator. If the parent allocator
-        // always calls TryAllocateMemory with the same memory |size| and |alignment|, they do not
-        // need to be overridden by the child allocator.
+        // If this allocator only allocates memory blocks using the same size, this value
+        // must be specified. Otherwise, kInvalidSize is returned to denote any alignment is
+        // allowed.
         virtual uint64_t GetMemorySize() const;
+
+        // If this allocator only allocates memory blocks using the same alignment, this value
+        // must be specified. Otherwise, kInvalidOffset is returned to denote any alignment is
+        // allowed.
         virtual uint64_t GetMemoryAlignment() const;
 
         // Collect and return the number and size of memory blocks allocated by this allocator.

--- a/src/gpgmm/SlabMemoryAllocator.cpp
+++ b/src/gpgmm/SlabMemoryAllocator.cpp
@@ -318,6 +318,10 @@ namespace gpgmm {
         return info;
     }
 
+    uint64_t SlabCacheAllocator::GetMemorySize() const {
+        return GetFirstChild()->GetMemorySize();
+    }
+
     uint64_t SlabCacheAllocator::GetSlabCacheSizeForTesting() const {
         uint64_t count = 0;
         for (const auto& entry : mSizeCache) {

--- a/src/gpgmm/SlabMemoryAllocator.h
+++ b/src/gpgmm/SlabMemoryAllocator.h
@@ -134,6 +134,8 @@ namespace gpgmm {
 
         MEMORY_ALLOCATOR_INFO QueryInfo() const override;
 
+        uint64_t GetMemorySize() const override;
+
         uint64_t GetSlabCacheSizeForTesting() const;
 
       private:

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -285,6 +285,14 @@ namespace gpgmm { namespace d3d12 {
                                     bool neverAllocate,
                                     bool cacheSize,
                                     CreateResourceFn&& createResourceFn) {
+            // Do not attempt to allocate if the requested size already exceeds the fixed
+            // memory size allowed by the allocator. Otherwise, both the memory and resource would
+            // be created, immediately released, then likely re-allocated all over again once
+            // TryAllocateResource returns.
+            if (allocator->GetMemorySize() != kInvalidSize && size > allocator->GetMemorySize()) {
+                return E_FAIL;
+            }
+
             std::unique_ptr<MemoryAllocation> allocation =
                 allocator->TryAllocateMemory(size, alignment, neverAllocate, cacheSize);
             if (allocation == nullptr) {


### PR DESCRIPTION

Avoids re-issuing allocation requests should the underlying allocator's memory size be too small.