### PR TITLE
Make device leak checking a build flag. 

### DIFF
--- a/.github/workflows/win_clang_dbg_x64.yaml
+++ b/.github/workflows/win_clang_dbg_x64.yaml
@@ -54,7 +54,7 @@ jobs:
         set "PATH=%CD%\..\depot_tools;%PATH%"
         set "DEPOT_TOOLS_WIN_TOOLCHAIN=0"
         cd base
-        gn gen out\Debug --args="is_debug=true gpgmm_enable_assert_on_warning=true"
+        gn gen out\Debug --args="is_debug=true gpgmm_enable_assert_on_warning=true gpgmm_enable_device_leak_warning=true"
 
     - name: Build for main branch
       shell: cmd
@@ -68,7 +68,7 @@ jobs:
       shell: cmd
       run: |
         cd base
-        out\Debug\gpgmm_end2end_tests.exe --check-device-leaks --gtest_output=json:${{ github.workspace }}\..\baseline_end2end_tests.json
+        out\Debug\gpgmm_end2end_tests.exe --gtest_output=json:${{ github.workspace }}\..\baseline_end2end_tests.json
 
     - name: Run gpgmm_unittests
       shell: cmd
@@ -80,7 +80,7 @@ jobs:
       shell: cmd
       run: |
         cd base
-        out\Debug\gpgmm_capture_replay_tests.exe --check-device-leaks --log-level=DEBUG --gtest_output=json:${{ github.workspace }}\..\baseline_capture_replay_tests.json
+        out\Debug\gpgmm_capture_replay_tests.exe --log-level=DEBUG --gtest_output=json:${{ github.workspace }}\..\baseline_capture_replay_tests.json
 
     - uses: actions/checkout@v2
       with:
@@ -118,7 +118,7 @@ jobs:
         set "PATH=%CD%\..\depot_tools;%PATH%"
         set "DEPOT_TOOLS_WIN_TOOLCHAIN=0"
         cd test
-        gn gen out\Debug --args="is_debug=true gpgmm_enable_assert_on_warning=true"
+        gn gen out\Debug --args="is_debug=true gpgmm_enable_assert_on_warning=true gpgmm_enable_device_leak_warning=true"
 
     - name: Build for main branch (with patch)
       shell: cmd
@@ -132,7 +132,7 @@ jobs:
       shell: cmd
       run: |
         cd test
-        out\Debug\gpgmm_end2end_tests.exe --check-device-leaks --gtest_output=json:${{ github.workspace }}\..\test_end2end_tests.json || true
+        out\Debug\gpgmm_end2end_tests.exe --gtest_output=json:${{ github.workspace }}\..\test_end2end_tests.json || true
 
     - name: Run gpgmm_unittests (with patch)
       shell: cmd
@@ -144,7 +144,7 @@ jobs:
       shell: cmd
       run: |
         cd test
-        out\Debug\gpgmm_capture_replay_tests.exe --check-device-leaks --gtest_output=json:${{ github.workspace }}\..\test_capture_replay_tests.json
+        out\Debug\gpgmm_capture_replay_tests.exe --gtest_output=json:${{ github.workspace }}\..\test_capture_replay_tests.json
 
     - name: Regression check end2end tests
       run: |

--- a/.github/workflows/win_clang_rel_x64.yaml
+++ b/.github/workflows/win_clang_rel_x64.yaml
@@ -54,7 +54,7 @@ jobs:
         set "PATH=%CD%\..\depot_tools;%PATH%"
         set "DEPOT_TOOLS_WIN_TOOLCHAIN=0"
         cd base
-        gn gen out\Release --args="is_debug=false gpgmm_enable_assert_on_warning=true"
+        gn gen out\Release --args="is_debug=false gpgmm_enable_assert_on_warning=true gpgmm_enable_device_leak_warning=true"
 
     - name: Build for main branch
       shell: cmd
@@ -68,7 +68,7 @@ jobs:
       shell: cmd
       run: |
         cd base
-        out\Release\gpgmm_end2end_tests.exe --check-device-leaks --gtest_output=json:${{ github.workspace }}\..\baseline_end2end_tests.json
+        out\Release\gpgmm_end2end_tests.exe --gtest_output=json:${{ github.workspace }}\..\baseline_end2end_tests.json
 
     - name: Run gpgmm_unittests
       shell: cmd
@@ -80,7 +80,7 @@ jobs:
       shell: cmd
       run: |
         cd base
-        out\Release\gpgmm_capture_replay_tests.exe --check-device-leaks --gtest_output=json:${{ github.workspace }}\..\baseline_capture_replay_tests.json
+        out\Release\gpgmm_capture_replay_tests.exe --gtest_output=json:${{ github.workspace }}\..\baseline_capture_replay_tests.json
 
     - uses: actions/checkout@v2
       with:
@@ -118,7 +118,7 @@ jobs:
         set "PATH=%CD%\..\depot_tools;%PATH%"
         set "DEPOT_TOOLS_WIN_TOOLCHAIN=0"
         cd test
-        gn gen out\Release --args="is_debug=false gpgmm_enable_assert_on_warning=true"
+        gn gen out\Release --args="is_debug=false gpgmm_enable_assert_on_warning=true gpgmm_enable_device_leak_warning=true"
 
     - name: Build for main branch (with patch)
       shell: cmd
@@ -132,7 +132,7 @@ jobs:
       shell: cmd
       run: |
         cd test
-        out\Release\gpgmm_end2end_tests.exe --check-device-leaks --gtest_output=json:${{ github.workspace }}\..\test_end2end_tests.json || true
+        out\Release\gpgmm_end2end_tests.exe --gtest_output=json:${{ github.workspace }}\..\test_end2end_tests.json || true
 
     - name: Run gpgmm_unittests (with patch)
       shell: cmd
@@ -144,7 +144,7 @@ jobs:
       shell: cmd
       run: |
         cd test
-        out\Release\gpgmm_capture_replay_tests.exe --check-device-leaks --gtest_output=json:${{ github.workspace }}\..\test_capture_replay_tests.json
+        out\Release\gpgmm_capture_replay_tests.exe --gtest_output=json:${{ github.workspace }}\..\test_capture_replay_tests.json
 
     - name: Regression check end2end tests
       run: |

--- a/.github/workflows/win_msvc_dbg_x64.yaml
+++ b/.github/workflows/win_msvc_dbg_x64.yaml
@@ -83,7 +83,7 @@ jobs:
       shell: cmd
       run: |
         cd test
-        out\Debug\gpgmm_end2end_tests.exe --check-device-leaks
+        out\Debug\gpgmm_end2end_tests.exe
 
     - name: Run gpgmm_unittests
       shell: cmd
@@ -95,4 +95,4 @@ jobs:
       shell: cmd
       run: |
         cd test
-        out\Debug\gpgmm_capture_replay_tests.exe --check-device-leaks --log-level=DEBUG
+        out\Debug\gpgmm_capture_replay_tests.exe --log-level=DEBUG

--- a/build_overrides/gpgmm_features.gni
+++ b/build_overrides/gpgmm_features.gni
@@ -69,4 +69,8 @@ declare_args() {
   # Enables warming of caches with common sizes.
   # Sets -dGPGMM_ENABLE_SIZE_CACHE
   gpgmm_enable_size_cache = true
+
+  # Enables warning when device leaks objects.
+  # Sets -dGPGMM_ENABLE_ASSERT_NO_DEVICE_LEAKS
+  gpgmm_enable_device_leak_warning = false
 }

--- a/src/gpgmm/BUILD.gn
+++ b/src/gpgmm/BUILD.gn
@@ -116,6 +116,10 @@ source_set("gpgmm_sources") {
     defines += [ "GPGMM_ENABLE_SIZE_CACHE" ]
   }
 
+  if (gpgmm_enable_device_leak_warning) {
+    defines += [ "GPGMM_ENABLE_DEVICE_LEAK_WARNING" ]
+  }
+
   libs = []
   data_deps = []
 

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -51,12 +51,6 @@ namespace gpgmm { namespace d3d12 {
         // Ensures resources are always within the resource budget at creation time. Mostly used
         // to debug with residency being over committed.
         ALLOCATOR_FLAG_ALWAYS_IN_BUDGET = 0x2,
-
-        // Checks for leaked device objects created by GPGMM.
-        // Requires the debug layers to be enabled by installing Graphics Tools in Windows and
-        // calling EnableDebugLayer before creation.
-        // Will assert if a leak is detected during destruction.
-        ALLOCATOR_FLAG_CHECK_DEVICE_LEAKS = 0x4,
     };
 
     using ALLOCATOR_FLAGS_TYPE = Flags<ALLOCATOR_FLAGS>;
@@ -349,8 +343,7 @@ namespace gpgmm { namespace d3d12 {
                                    uint64_t heapAlignment,
                                    Heap** resourceHeapOut);
 
-        HRESULT EnableDeviceObjectLeakChecks() const;
-        HRESULT CheckForDeviceObjectLeaks() const;
+        HRESULT ReportLiveDeviceObjects() const;
 
         // MemoryAllocator interface
         void DeallocateMemory(std::unique_ptr<MemoryAllocation> allocation) override;

--- a/src/tests/D3D12Test.cpp
+++ b/src/tests/D3D12Test.cpp
@@ -21,11 +21,9 @@ namespace gpgmm { namespace d3d12 {
     void D3D12TestBase::SetUp() {
         GPGMMTestBase::SetUp();
 
-        if (IsDeviceLeakChecksEnabled()) {
-            ComPtr<ID3D12Debug> debugController;
-            ASSERT_SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController)));
-            debugController->EnableDebugLayer();
-        }
+        ComPtr<ID3D12Debug> debugController;
+        ASSERT_SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController)));
+        debugController->EnableDebugLayer();
 
         ASSERT_SUCCEEDED(
             D3D12CreateDevice(nullptr, D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&mDevice)));
@@ -64,10 +62,6 @@ namespace gpgmm { namespace d3d12 {
         desc.Device = mDevice;
         desc.IsUMA = mIsUMA;
         desc.ResourceHeapTier = mResourceHeapTier;
-
-        if (IsDeviceLeakChecksEnabled()) {
-            desc.Flags = ALLOCATOR_FLAG_CHECK_DEVICE_LEAKS;
-        }
 
 #if defined(NDEBUG)
         desc.MinLogLevel = ALLOCATOR_MESSAGE_SEVERITY_WARNING;

--- a/src/tests/GPGMMTest.cpp
+++ b/src/tests/GPGMMTest.cpp
@@ -27,26 +27,11 @@ void GPGMMTestBase::SetUp() {
 void GPGMMTestBase::TearDown() {
 }
 
-bool GPGMMTestBase::IsDeviceLeakChecksEnabled() const {
-    return gTestEnv->IsDeviceLeakChecksEnabled();
-}
-
 // GPGMMTestEnvironment
 
 void InitGPGMMEnd2EndTestEnvironment(int argc, char** argv) {
-    gTestEnv = new GPGMMTestEnvironment(argc, argv);
+    gTestEnv = new GPGMMTestEnvironment();
     testing::AddGlobalTestEnvironment(gTestEnv);
-}
-
-GPGMMTestEnvironment::GPGMMTestEnvironment(int argc, char** argv) {
-    for (int i = 1; i < argc; ++i) {
-        if (strcmp("--check-device-leaks", argv[i]) == 0) {
-            mEnableDeviceLeakChecks = true;
-            continue;
-        }
-    }
-
-    PrintTestEnviromentSettings();
 }
 
 // static
@@ -55,16 +40,4 @@ void GPGMMTestEnvironment::SetEnvironment(GPGMMTestEnvironment* env) {
 }
 
 void GPGMMTestEnvironment::SetUp() {
-}
-
-bool GPGMMTestEnvironment::IsDeviceLeakChecksEnabled() const {
-    return mEnableDeviceLeakChecks;
-}
-
-void GPGMMTestEnvironment::PrintTestEnviromentSettings() const {
-    std::cout << "Test enviroment settings\n"
-                 "------------------------\n"
-              << "Enable device leak checks: " << (mEnableDeviceLeakChecks ? "true" : "false")
-              << "\n"
-              << std::endl;
 }

--- a/src/tests/GPGMMTest.h
+++ b/src/tests/GPGMMTest.h
@@ -34,26 +34,17 @@ class GPGMMTestBase {
 
     void SetUp();
     void TearDown();
-
-    bool IsDeviceLeakChecksEnabled() const;
 };
 
 void InitGPGMMEnd2EndTestEnvironment(int argc, char** argv);
 
 class GPGMMTestEnvironment : public testing::Environment {
   public:
-    GPGMMTestEnvironment(int argc, char** argv);
+    GPGMMTestEnvironment() = default;
 
     static void SetEnvironment(GPGMMTestEnvironment* env);
 
     void SetUp() override;
-
-    bool IsDeviceLeakChecksEnabled() const;
-
-  private:
-    void PrintTestEnviromentSettings() const;
-
-    bool mEnableDeviceLeakChecks = false;
 };
 
 #endif  // TESTS_GPGMMTEST_H_

--- a/src/tests/capture_replay_tests/GPGMMCaptureReplayTests.cpp
+++ b/src/tests/capture_replay_tests/GPGMMCaptureReplayTests.cpp
@@ -82,8 +82,7 @@ void InitGPGMMCaptureReplayTestEnvironment(int argc, char** argv) {
     testing::AddGlobalTestEnvironment(gTestEnv);
 }
 
-GPGMMCaptureReplayTestEnvironment::GPGMMCaptureReplayTestEnvironment(int argc, char** argv)
-    : GPGMMTestEnvironment(argc, argv) {
+GPGMMCaptureReplayTestEnvironment::GPGMMCaptureReplayTestEnvironment(int argc, char** argv) {
     for (int i = 1; i < argc; ++i) {
         constexpr const char kIterationArg[] = "--iterations=";
         size_t arglen = sizeof(kIterationArg) - 1;


### PR DESCRIPTION

Device leak checking must be enabled per flag since the device may be kept alive beyond the allocator.