### PR TITLE
Do not make resource allocator re-entrant.

### DIFF
--- a/src/gpgmm/ConditionalMemoryAllocator.cpp
+++ b/src/gpgmm/ConditionalMemoryAllocator.cpp
@@ -42,6 +42,25 @@ namespace gpgmm {
         }
     }
 
+    MEMORY_ALLOCATOR_INFO ConditionalMemoryAllocator::QueryInfo() const {
+        MEMORY_ALLOCATOR_INFO info = {};
+        {
+            const MEMORY_ALLOCATOR_INFO& memoryInfo = mFirstAllocator->QueryInfo();
+            info.FreeMemoryUsage += memoryInfo.FreeMemoryUsage;
+            info.UsedBlockCount += memoryInfo.UsedBlockCount;
+            info.UsedMemoryUsage += memoryInfo.UsedMemoryUsage;
+            info.UsedMemoryCount += memoryInfo.UsedMemoryCount;
+        }
+        {
+            const MEMORY_ALLOCATOR_INFO& memoryInfo = mSecondAllocator->QueryInfo();
+            info.FreeMemoryUsage += memoryInfo.FreeMemoryUsage;
+            info.UsedBlockCount += memoryInfo.UsedBlockCount;
+            info.UsedMemoryUsage += memoryInfo.UsedMemoryUsage;
+            info.UsedMemoryCount += memoryInfo.UsedMemoryCount;
+        }
+        return info;
+    }
+
     void ConditionalMemoryAllocator::DeallocateMemory(
         std::unique_ptr<MemoryAllocation> allocation) {
         // ConditionalMemoryAllocator cannot allocate memory itself, so it must not deallocate.

--- a/src/gpgmm/ConditionalMemoryAllocator.h
+++ b/src/gpgmm/ConditionalMemoryAllocator.h
@@ -36,6 +36,8 @@ namespace gpgmm {
                                                             bool cacheSize) override;
         void DeallocateMemory(std::unique_ptr<MemoryAllocation> allocation) override;
 
+        MEMORY_ALLOCATOR_INFO QueryInfo() const override;
+
         MemoryAllocator* GetFirstAllocatorForTesting() const;
         MemoryAllocator* GetSecondAllocatorForTesting() const;
 

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -339,12 +339,6 @@ namespace gpgmm { namespace d3d12 {
                                         ID3D12Resource** commitedResourceOut,
                                         Heap** resourceHeapOut);
 
-        HRESULT CreateResourceHeap(uint64_t heapSize,
-                                   D3D12_HEAP_TYPE heapType,
-                                   D3D12_HEAP_FLAGS heapFlags,
-                                   uint64_t heapAlignment,
-                                   Heap** resourceHeapOut);
-
         HRESULT ReportLiveDeviceObjects() const;
 
         // MemoryAllocator interface

--- a/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.h
@@ -21,14 +21,17 @@
 
 namespace gpgmm { namespace d3d12 {
 
-    class ResourceAllocator;
+    class ResidencyManager;
 
     // Wrapper to allocate a D3D12 heap for resources of any type.
     class ResourceHeapAllocator final : public MemoryAllocator {
       public:
-        ResourceHeapAllocator(ResourceAllocator* resourceAllocator,
+        ResourceHeapAllocator(ResidencyManager* residencyManager,
+                              ID3D12Device* device,
                               D3D12_HEAP_TYPE heapType,
-                              D3D12_HEAP_FLAGS heapFlags);
+                              D3D12_HEAP_FLAGS heapFlags,
+                              bool isUMA,
+                              bool isAlwaysInBudget);
         ~ResourceHeapAllocator() override = default;
 
         // MemoryAllocator interface
@@ -39,10 +42,12 @@ namespace gpgmm { namespace d3d12 {
         void DeallocateMemory(std::unique_ptr<MemoryAllocation> allocation) override;
 
       private:
-        ResourceAllocator* const mResourceAllocator;
-
+        ResidencyManager* const mResidencyManager;
+        ID3D12Device* const mDevice;
         const D3D12_HEAP_TYPE mHeapType;
         const D3D12_HEAP_FLAGS mHeapFlags;
+        const bool mIsUMA;
+        const bool mIsAlwaysInBudget;
     };
 
 }}  // namespace gpgmm::d3d12

--- a/src/gpgmm/d3d12/UtilsD3D12.cpp
+++ b/src/gpgmm/d3d12/UtilsD3D12.cpp
@@ -18,6 +18,22 @@
 
 namespace gpgmm { namespace d3d12 {
 
+    DXGI_MEMORY_SEGMENT_GROUP GetPreferredMemorySegmentGroup(ID3D12Device* device,
+                                                             bool isUMA,
+                                                             D3D12_HEAP_TYPE heapType) {
+        if (isUMA) {
+            return DXGI_MEMORY_SEGMENT_GROUP_LOCAL;
+        }
+
+        D3D12_HEAP_PROPERTIES heapProperties = device->GetCustomHeapProperties(0, heapType);
+
+        if (heapProperties.MemoryPoolPreference == D3D12_MEMORY_POOL_L1) {
+            return DXGI_MEMORY_SEGMENT_GROUP_LOCAL;
+        }
+
+        return DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL;
+    }
+
     bool IsDepthFormat(DXGI_FORMAT format) {
         // Depth formats in order of appearance.
         // https://docs.microsoft.com/en-us/windows/win32/api/dxgiformat/ne-dxgiformat-dxgi_format

--- a/src/gpgmm/d3d12/UtilsD3D12.h
+++ b/src/gpgmm/d3d12/UtilsD3D12.h
@@ -18,6 +18,9 @@
 
 namespace gpgmm { namespace d3d12 {
 
+    DXGI_MEMORY_SEGMENT_GROUP GetPreferredMemorySegmentGroup(ID3D12Device* device,
+                                                             bool isUMA,
+                                                             D3D12_HEAP_TYPE heapType);
     bool IsDepthFormat(DXGI_FORMAT format);
     bool IsAllowedToUseSmallAlignment(const D3D12_RESOURCE_DESC& Desc);
 

--- a/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
+++ b/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
@@ -695,18 +695,23 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferPooled) {
 TEST_F(D3D12ResourceAllocatorTests, CreateBufferQueryInfo) {
     // Calculate info for a single standalone allocation.
     {
+        ComPtr<ResourceAllocator> resourceAllocator;
+        ASSERT_SUCCEEDED(
+            ResourceAllocator::CreateAllocator(CreateBasicAllocatorDesc(), &resourceAllocator));
+        ASSERT_NE(resourceAllocator, nullptr);
+
         ALLOCATION_DESC standaloneAllocationDesc = {};
         standaloneAllocationDesc.Flags = ALLOCATION_FLAG_NEVER_SUBALLOCATE_MEMORY;
 
         ComPtr<ResourceAllocation> firstAllocation;
-        ASSERT_SUCCEEDED(mDefaultAllocator->CreateResource(
+        ASSERT_SUCCEEDED(resourceAllocator->CreateResource(
             standaloneAllocationDesc, CreateBasicBufferDesc(kDefaultPreferredResourceHeapSize),
             D3D12_RESOURCE_STATE_GENERIC_READ, nullptr, &firstAllocation));
         ASSERT_NE(firstAllocation, nullptr);
         EXPECT_EQ(firstAllocation->GetMethod(), gpgmm::AllocationMethod::kStandalone);
 
         QUERY_RESOURCE_ALLOCATOR_INFO info = {};
-        ASSERT_SUCCEEDED(mDefaultAllocator->QueryResourceAllocatorInfo(&info));
+        ASSERT_SUCCEEDED(resourceAllocator->QueryResourceAllocatorInfo(&info));
 
         EXPECT_EQ(info.UsedMemoryCount, 1u);
         EXPECT_EQ(info.UsedMemoryUsage, kDefaultPreferredResourceHeapSize);


### PR DESCRIPTION

Moves resource heap creation into it's own allocator so the resource allocator does not call back into itself.