### PR TITLE
Trace call before locking thread.

### DIFF
--- a/src/gpgmm/PooledMemoryAllocator.cpp
+++ b/src/gpgmm/PooledMemoryAllocator.cpp
@@ -32,9 +32,9 @@ namespace gpgmm {
         bool neverAllocate,
         bool cacheSize,
         bool prefetchMemory) {
-        std::lock_guard<std::mutex> lock(mMutex);
-
         TRACE_EVENT0(TraceEventCategory::Default, "PooledMemoryAllocator.TryAllocateMemory");
+
+        std::lock_guard<std::mutex> lock(mMutex);
 
         std::unique_ptr<MemoryAllocation> allocation = mPool->AcquireFromPool();
         if (allocation == nullptr) {
@@ -55,9 +55,9 @@ namespace gpgmm {
     }
 
     void PooledMemoryAllocator::DeallocateMemory(std::unique_ptr<MemoryAllocation> allocation) {
-        std::lock_guard<std::mutex> lock(mMutex);
-
         TRACE_EVENT0(TraceEventCategory::Default, "PooledMemoryAllocator.DeallocateMemory");
+
+        std::lock_guard<std::mutex> lock(mMutex);
 
         const uint64_t& allocationSize = allocation->GetSize();
         mInfo.FreeMemoryUsage += allocationSize;

--- a/src/gpgmm/SegmentedMemoryAllocator.cpp
+++ b/src/gpgmm/SegmentedMemoryAllocator.cpp
@@ -132,9 +132,10 @@ namespace gpgmm {
         bool neverAllocate,
         bool cacheSize,
         bool prefetchMemory) {
+        TRACE_EVENT0(TraceEventCategory::Default, "SegmentedMemoryAllocator.TryAllocateMemory");
+
         std::lock_guard<std::mutex> lock(mMutex);
 
-        TRACE_EVENT0(TraceEventCategory::Default, "SegmentedMemoryAllocator.TryAllocateMemory");
         GPGMM_CHECK_NONZERO(size);
 
         if (alignment != mMemoryAlignment) {
@@ -168,9 +169,9 @@ namespace gpgmm {
     }
 
     void SegmentedMemoryAllocator::DeallocateMemory(std::unique_ptr<MemoryAllocation> allocation) {
-        std::lock_guard<std::mutex> lock(mMutex);
-
         TRACE_EVENT0(TraceEventCategory::Default, "SegmentedMemoryAllocator.DeallocateMemory");
+
+        std::lock_guard<std::mutex> lock(mMutex);
 
         ASSERT(allocation != nullptr);
 

--- a/src/gpgmm/SlabMemoryAllocator.cpp
+++ b/src/gpgmm/SlabMemoryAllocator.cpp
@@ -93,9 +93,9 @@ namespace gpgmm {
                                                                              bool neverAllocate,
                                                                              bool cacheSize,
                                                                              bool prefetchMemory) {
-        std::lock_guard<std::mutex> lock(mMutex);
-
         TRACE_EVENT0(TraceEventCategory::Default, "SlabMemoryAllocator.TryAllocateMemory");
+
+        std::lock_guard<std::mutex> lock(mMutex);
 
         if (size > mBlockSize) {
             DebugEvent("SlabMemoryAllocator.TryAllocateMemory", ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED)
@@ -203,9 +203,9 @@ namespace gpgmm {
     }
 
     void SlabMemoryAllocator::DeallocateMemory(std::unique_ptr<MemoryAllocation> subAllocation) {
-        std::lock_guard<std::mutex> lock(mMutex);
-
         TRACE_EVENT0(TraceEventCategory::Default, "SlabMemoryAllocator.DeallocateMemory");
+
+        std::lock_guard<std::mutex> lock(mMutex);
 
         const BlockInSlab* blockInSlab = static_cast<BlockInSlab*>(subAllocation->GetBlock());
         ASSERT(blockInSlab != nullptr);
@@ -299,9 +299,10 @@ namespace gpgmm {
                                                                             bool neverAllocate,
                                                                             bool cacheSize,
                                                                             bool prefetchMemory) {
+        TRACE_EVENT0(TraceEventCategory::Default, "SlabCacheAllocator.TryAllocateMemory");
+
         std::lock_guard<std::mutex> lock(mMutex);
 
-        TRACE_EVENT0(TraceEventCategory::Default, "SlabCacheAllocator.TryAllocateMemory");
         GPGMM_CHECK_NONZERO(size);
 
         const uint64_t blockSize = AlignTo(size, mMinBlockSize);
@@ -335,9 +336,9 @@ namespace gpgmm {
     }
 
     void SlabCacheAllocator::DeallocateMemory(std::unique_ptr<MemoryAllocation> subAllocation) {
-        std::lock_guard<std::mutex> lock(mMutex);
-
         TRACE_EVENT0(TraceEventCategory::Default, "SlabCacheAllocator.DeallocateMemory");
+
+        std::lock_guard<std::mutex> lock(mMutex);
 
         auto entry =
             mSizeCache.GetOrCreate(SlabAllocatorCacheEntry(subAllocation->GetSize()), false);

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
@@ -229,9 +229,9 @@ namespace gpgmm { namespace d3d12 {
         const DXGI_MEMORY_SEGMENT_GROUP& memorySegmentGroup,
         uint64_t reservation,
         uint64_t* reservationOut) {
-        std::lock_guard<std::recursive_mutex> lock(mMutex);
-
         TRACE_EVENT0(TraceEventCategory::Default, "ResidencyManager.SetVideoMemoryReservation");
+
+        std::lock_guard<std::recursive_mutex> lock(mMutex);
 
         DXGI_QUERY_VIDEO_MEMORY_INFO* videoMemorySegmentInfo =
             GetVideoMemorySegmentInfo(memorySegmentGroup);
@@ -283,9 +283,9 @@ namespace gpgmm { namespace d3d12 {
     HRESULT ResidencyManager::Evict(uint64_t sizeToMakeResident,
                                     const DXGI_MEMORY_SEGMENT_GROUP& memorySegmentGroup,
                                     uint64_t* sizeEvictedOut) {
-        std::lock_guard<std::recursive_mutex> lock(mMutex);
-
         TRACE_EVENT0(TraceEventCategory::Default, "ResidencyManager.Evict");
+
+        std::lock_guard<std::recursive_mutex> lock(mMutex);
 
         DXGI_QUERY_VIDEO_MEMORY_INFO* videoMemorySegmentInfo =
             GetVideoMemorySegmentInfo(memorySegmentGroup);
@@ -356,14 +356,14 @@ namespace gpgmm { namespace d3d12 {
                                                   ID3D12CommandList* const* commandLists,
                                                   ResidencySet* const* residencySets,
                                                   uint32_t count) {
+        TRACE_EVENT0(TraceEventCategory::Default, "ResidencyManager.ExecuteCommandLists");
+
         std::lock_guard<std::recursive_mutex> lock(mMutex);
 
         // TODO: support multiple command lists.
         if (count > 1) {
             return E_NOTIMPL;
         }
-
-        TRACE_EVENT0(TraceEventCategory::Default, "ResidencyManager.ExecuteCommandLists");
 
         ID3D12CommandList* commandList = commandLists[0];
         ResidencySet* residencySet = residencySets[0];

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -589,8 +589,6 @@ namespace gpgmm { namespace d3d12 {
                                               D3D12_RESOURCE_STATES initialResourceState,
                                               const D3D12_CLEAR_VALUE* clearValue,
                                               ResourceAllocation** resourceAllocationOut) {
-        std::lock_guard<std::mutex> lock(mMutex);
-
         if (!resourceAllocationOut) {
             return E_POINTER;
         }
@@ -601,6 +599,8 @@ namespace gpgmm { namespace d3d12 {
         GPGMM_TRACE_EVENT_OBJECT_CALL("ResourceAllocator.CreateResource", args);
 
         TRACE_EVENT0(TraceEventCategory::Default, "ResourceAllocator.CreateResource");
+
+        std::lock_guard<std::mutex> lock(mMutex);
 
         std::unique_ptr<gpgmm::PlatformTime> timer(CreatePlatformTime());
         timer->StartElapsedTime();
@@ -857,8 +857,6 @@ namespace gpgmm { namespace d3d12 {
                                                     const D3D12_CLEAR_VALUE* clearValue,
                                                     D3D12_RESOURCE_STATES initialResourceState,
                                                     ID3D12Resource** placedResourceOut) {
-        ASSERT(resourceHeap != nullptr);
-
         TRACE_EVENT0(TraceEventCategory::Default, "ResourceAllocator.CreatePlacedResource");
 
         // Before calling CreatePlacedResource, we must ensure the target heap is resident or
@@ -1008,9 +1006,9 @@ namespace gpgmm { namespace d3d12 {
     }
 
     void ResourceAllocator::DeallocateMemory(std::unique_ptr<MemoryAllocation> allocation) {
-        std::lock_guard<std::mutex> lock(mMutex);
-
         TRACE_EVENT0(TraceEventCategory::Default, "ResourceAllocator.DeallocateMemory");
+
+        std::lock_guard<std::mutex> lock(mMutex);
 
         mInfo.UsedMemoryUsage -= allocation->GetSize();
         mInfo.UsedMemoryCount--;

--- a/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.cpp
@@ -45,9 +45,9 @@ namespace gpgmm { namespace d3d12 {
         bool neverAllocate,
         bool cacheSize,
         bool prefetchMemory) {
-        std::lock_guard<std::mutex> lock(mMutex);
-
         TRACE_EVENT0(TraceEventCategory::Default, "ResourceHeapAllocator.TryAllocateMemory");
+
+        std::lock_guard<std::mutex> lock(mMutex);
 
         if (neverAllocate) {
             return {};

--- a/src/tests/DummyMemoryAllocator.h
+++ b/src/tests/DummyMemoryAllocator.h
@@ -28,9 +28,9 @@ namespace gpgmm {
                                                             bool neverAllocate,
                                                             bool cacheSize,
                                                             bool prefetchMemory) override {
-            std::lock_guard<std::mutex> lock(mMutex);
-
             TRACE_EVENT0(TraceEventCategory::Default, "DummyMemoryAllocator.TryAllocateMemory");
+
+            std::lock_guard<std::mutex> lock(mMutex);
 
             if (neverAllocate) {
                 return {};
@@ -42,9 +42,9 @@ namespace gpgmm {
         }
 
         void DeallocateMemory(std::unique_ptr<MemoryAllocation> allocation) override {
-            std::lock_guard<std::mutex> lock(mMutex);
-
             TRACE_EVENT0(TraceEventCategory::Default, "DummyMemoryAllocator.DeallocateMemory");
+
+            std::lock_guard<std::mutex> lock(mMutex);
 
             mInfo.UsedMemoryCount--;
             mInfo.UsedMemoryUsage -= allocation->GetSize();


### PR DESCRIPTION

Ensures CPU time spent under lock will be reported in event traces.