### PR TITLE
Disable event tracing in release builds.

### DIFF
--- a/.github/workflows/win_clang_rel_x64.yaml
+++ b/.github/workflows/win_clang_rel_x64.yaml
@@ -54,7 +54,7 @@ jobs:
         set "PATH=%CD%\..\depot_tools;%PATH%"
         set "DEPOT_TOOLS_WIN_TOOLCHAIN=0"
         cd base
-        gn gen out\Release --args="is_debug=false gpgmm_enable_assert_on_warning=true gpgmm_enable_device_leak_warning=true"
+        gn gen out\Release --args="is_debug=false gpgmm_enable_assert_on_warning=true gpgmm_enable_device_leak_warning=true gpgmm_force_tracing=true"
 
     - name: Build for main branch
       shell: cmd
@@ -118,7 +118,7 @@ jobs:
         set "PATH=%CD%\..\depot_tools;%PATH%"
         set "DEPOT_TOOLS_WIN_TOOLCHAIN=0"
         cd test
-        gn gen out\Release --args="is_debug=false gpgmm_enable_assert_on_warning=true gpgmm_enable_device_leak_warning=true"
+        gn gen out\Release --args="is_debug=false gpgmm_enable_assert_on_warning=true gpgmm_enable_device_leak_warning=true gpgmm_force_tracing=true"
 
     - name: Build for main branch (with patch)
       shell: cmd

--- a/.github/workflows/win_msvc_rel_x64.yaml
+++ b/.github/workflows/win_msvc_rel_x64.yaml
@@ -69,7 +69,7 @@ jobs:
         set "PATH=%CD%\..\depot_tools;%PATH%"
         set "DEPOT_TOOLS_WIN_TOOLCHAIN=0"
         cd test
-        gn gen out\Release --args="is_debug=false is_clang=false"
+        gn gen out\Release --args="is_debug=false is_clang=false gpgmm_force_tracing=true"
 
     - name: Build for main branch (with patch)
       shell: cmd

--- a/build_overrides/gpgmm_features.gni
+++ b/build_overrides/gpgmm_features.gni
@@ -33,11 +33,11 @@ declare_args() {
   # Sets -dGPGMM_ENABLE_ASSERTS
   gpgmm_always_assert = false
 
-  # Enables GPGMM's memory tracing even if disabled by recording flags.
-  # Sets -dGPGMM_ALWAYS_RECORD
-  gpgmm_always_record = false
+  # Enables event tracing even in release builds.
+  # Sets -dGPGMM_FORCE_TRACING
+  gpgmm_force_tracing = false
 
-  # Enables the compilation of the D3D12 backend
+  # Enables the compilation of the D3D12 backend.
   gpgmm_enable_d3d12 = is_win
 
   # Enables compilation of Dawn's end2end tests.

--- a/src/gpgmm/BUILD.gn
+++ b/src/gpgmm/BUILD.gn
@@ -96,8 +96,8 @@ source_set("gpgmm_sources") {
     defines += [ "GPGMM_SHARED_LIBRARY" ]
   }
 
-  if (gpgmm_always_record) {
-    defines += [ "GPGMM_ALWAYS_RECORD" ]
+  if (!is_debug && !gpgmm_force_tracing) {
+    defines += [ "GPGMM_DISABLE_TRACING" ]
   }
 
   if (gpgmm_enable_recording_until_termination) {

--- a/src/gpgmm/TraceEvent.cpp
+++ b/src/gpgmm/TraceEvent.cpp
@@ -42,7 +42,7 @@ namespace gpgmm {
     void InitializeThreadName(const char* name) {
         JSONDict args;
         args.AddItem("name", name);
-        TRACE_EVENT_METADATA("thread_name", args);
+        TRACE_EVENT_METADATA1("thread_name", args);
     }
 
     bool IsEventTraceEnabled() {

--- a/src/gpgmm/TraceEvent.h
+++ b/src/gpgmm/TraceEvent.h
@@ -41,6 +41,17 @@
 #define TRACE_EVENT_FLAG_HAS_LOCAL_ID (static_cast<unsigned int>(1 << 11))
 #define TRACE_EVENT_FLAG_HAS_GLOBAL_ID (static_cast<unsigned int>(1 << 12))
 
+#define TRACE_EMPTY do {} while (0)
+
+#ifdef GPGMM_DISABLE_TRACING
+
+#define TRACE_EVENT0(category_group, name) TRACE_EMPTY
+#define TRACE_EVENT_INSTANT0(category_group, name, scope, args) TRACE_EMPTY
+#define TRACE_COUNTER1(category_group, name, value) TRACE_EMPTY
+#define TRACE_EVENT_METADATA1(name, args) TRACE_EMPTY
+
+#else // !GPGMM_DISABLE_TRACING
+
 // Specify these values when the corresponding argument of AddTraceEvent
 // is not used.
 const uint64_t kNoId = 0;
@@ -49,14 +60,14 @@ const uint64_t kNoId = 0;
 // Name parameter must have program lifetime (statics or literals).
 #define TRACE_EVENT0(category_group, name) INTERNAL_TRACE_EVENT_ADD_SCOPED(category_group, name)
 
-#define TRACE_EVENT_METADATA(name, args) \
+#define TRACE_EVENT_METADATA1(name, args) \
     INTERNAL_TRACE_EVENT_ADD(TRACE_EVENT_PHASE_METADATA, TraceEventCategory::Metadata, name, args)
 
 #define TRACE_COUNTER1(category_group, name, value)                                    \
     INTERNAL_TRACE_EVENT_ADD(TRACE_EVENT_PHASE_COUNTER, category_group, name, "value", \
                              static_cast<int>(value))
 
-#define TRACE_EVENT_INSTANT(category_group, name, args) \
+#define TRACE_EVENT_INSTANT1(category_group, name, args) \
     INTERNAL_TRACE_EVENT_ADD(TRACE_EVENT_PHASE_INSTANT, category_group, name, args)
 
 #define TRACE_EVENT_BEGIN(category_group, name) \
@@ -99,6 +110,8 @@ const uint64_t kNoId = 0;
         gpgmm::TraceBuffer::AddTraceEvent(phase, category_group, name, kNoId,  \
                                           TRACE_EVENT_FLAG_NONE, __VA_ARGS__); \
     } while (false)
+
+#endif
 
 namespace gpgmm {
 
@@ -159,7 +172,7 @@ namespace gpgmm {
         uint64_t mID = 0;
         uint32_t mTID = 0;
         double mTimestamp = 0;
-        uint32_t mFlags = TRACE_EVENT_FLAG_NONE;
+        uint32_t mFlags = 0;
         JSONDict mArgs;
     };
 

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -27,6 +27,7 @@
 
 namespace gpgmm {
     class MemoryAllocator;
+    class PlatformTime;
 }  // namespace gpgmm
 
 namespace gpgmm { namespace d3d12 {
@@ -372,6 +373,7 @@ namespace gpgmm { namespace d3d12 {
             mBufferAllocatorOfType;
 
         std::unique_ptr<DebugResourceAllocator> mDebugAllocator;
+        std::unique_ptr<PlatformTime> mAllocationTimer;
     };
 
 }}  // namespace gpgmm::d3d12


### PR DESCRIPTION

Adds option gpgmm_force_tracing to force event tracing to be compiled-in.