### PR TITLE
Move standalone resource allocations into allocator type.

### DIFF
--- a/src/gpgmm/BUILD.gn
+++ b/src/gpgmm/BUILD.gn
@@ -170,6 +170,8 @@ source_set("gpgmm_sources") {
     "SlabBlockAllocator.h",
     "SlabMemoryAllocator.cpp",
     "SlabMemoryAllocator.h",
+    "StandaloneMemoryAllocator.cpp",
+    "StandaloneMemoryAllocator.h",
     "TraceEvent.cpp",
     "TraceEvent.h",
     "WorkerThread.cpp",

--- a/src/gpgmm/CMakeLists.txt
+++ b/src/gpgmm/CMakeLists.txt
@@ -54,6 +54,8 @@ target_sources(gpgmm PRIVATE
     "SlabBlockAllocator.h"
     "SlabMemoryAllocator.cpp"
     "SlabMemoryAllocator.h"
+    "StandaloneMemoryAllocator.cpp"
+    "StandaloneMemoryAllocator.h"
     "TraceEvent.cpp"
     "TraceEvent.h"
     "WorkerThread.cpp"

--- a/src/gpgmm/StandaloneMemoryAllocator.cpp
+++ b/src/gpgmm/StandaloneMemoryAllocator.cpp
@@ -1,0 +1,65 @@
+// Copyright 2021 The GPGMM Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gpgmm/StandaloneMemoryAllocator.h"
+
+#include "gpgmm/Debug.h"
+
+namespace gpgmm {
+
+    StandaloneMemoryAllocator::StandaloneMemoryAllocator(
+        std::unique_ptr<MemoryAllocator> memoryAllocator)
+        : MemoryAllocator(std::move(memoryAllocator)) {
+    }
+
+    std::unique_ptr<MemoryAllocation> StandaloneMemoryAllocator::TryAllocateMemory(
+        uint64_t size,
+        uint64_t alignment,
+        bool neverAllocate,
+        bool cacheSize,
+        bool prefetchMemory) {
+        TRACE_EVENT0(TraceEventCategory::Default, "StandaloneMemoryAllocator.TryAllocateMemory");
+
+        std::lock_guard<std::mutex> lock(mMutex);
+        std::unique_ptr<MemoryAllocation> allocation;
+        GPGMM_TRY_ASSIGN(GetFirstChild()->TryAllocateMemory(size, alignment, neverAllocate,
+                                                            cacheSize, prefetchMemory),
+                         allocation);
+
+        mInfo.UsedBlockCount++;
+        mInfo.UsedBlockUsage += size;
+
+        return std::make_unique<MemoryAllocation>(this, allocation->GetMemory(), /*offset*/ 0,
+                                                  allocation->GetMethod(),
+                                                  new MemoryBlock{0, size});
+    }
+
+    void StandaloneMemoryAllocator::DeallocateMemory(
+        std::unique_ptr<MemoryAllocation> subAllocation) {
+        TRACE_EVENT0(TraceEventCategory::Default, "StandaloneMemoryAllocator.DeallocateMemory");
+
+        std::lock_guard<std::mutex> lock(mMutex);
+        mInfo.UsedBlockCount--;
+        mInfo.UsedBlockUsage -= subAllocation->GetSize();
+        SafeDelete(subAllocation->GetBlock());
+        GetFirstChild()->DeallocateMemory(std::move(subAllocation));
+    }
+
+    MEMORY_ALLOCATOR_INFO StandaloneMemoryAllocator::QueryInfo() const {
+        std::lock_guard<std::mutex> lock(mMutex);
+        MEMORY_ALLOCATOR_INFO result = mInfo;
+        result += GetFirstChild()->QueryInfo();
+        return result;
+    }
+}  // namespace gpgmm

--- a/src/gpgmm/StandaloneMemoryAllocator.h
+++ b/src/gpgmm/StandaloneMemoryAllocator.h
@@ -1,0 +1,42 @@
+// Copyright 2021 The GPGMM Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GPGMM_STANDALONEMEMORYALLOCATOR_H_
+#define GPGMM_STANDALONEMEMORYALLOCATOR_H_
+
+#include "gpgmm/MemoryAllocator.h"
+
+#include <memory>
+
+namespace gpgmm {
+
+    // StandaloneMemoryAllocator sub-allocates memory with exactly one block.
+    class StandaloneMemoryAllocator final : public MemoryAllocator {
+      public:
+        StandaloneMemoryAllocator(std::unique_ptr<MemoryAllocator> memoryAllocator);
+
+        // MemoryAllocator interface
+        std::unique_ptr<MemoryAllocation> TryAllocateMemory(uint64_t size,
+                                                            uint64_t alignment,
+                                                            bool neverAllocate,
+                                                            bool cacheSize,
+                                                            bool prefetchMemory) override;
+        void DeallocateMemory(std::unique_ptr<MemoryAllocation> subAllocation) override;
+
+        MEMORY_ALLOCATOR_INFO QueryInfo() const override;
+    };
+
+}  // namespace gpgmm
+
+#endif  // GPGMM_STANDALONEMEMORYALLOCATOR_H_

--- a/src/gpgmm/d3d12/ResourceAllocationD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocationD3D12.cpp
@@ -43,32 +43,12 @@ namespace gpgmm { namespace d3d12 {
                                            MemoryAllocator* allocator,
                                            uint64_t offsetFromHeap,
                                            MemoryBlock* block,
+                                           AllocationMethod method,
                                            ComPtr<ID3D12Resource> placedResource,
                                            Heap* resourceHeap)
-        : MemoryAllocation(allocator,
-                           resourceHeap,
-                           offsetFromHeap,
-                           AllocationMethod::kSubAllocated,
-                           block),
+        : MemoryAllocation(allocator, resourceHeap, offsetFromHeap, method, block),
           mResidencyManager(residencyManager),
           mResource(std::move(placedResource)),
-          mOffsetFromResource(0) {
-        ASSERT(resourceHeap != nullptr);
-        GPGMM_TRACE_EVENT_OBJECT_NEW(this);
-    }
-
-    ResourceAllocation::ResourceAllocation(ResidencyManager* residencyManager,
-                                           MemoryAllocator* allocator,
-                                           uint64_t offsetFromHeap,
-                                           ComPtr<ID3D12Resource> resource,
-                                           Heap* resourceHeap)
-        : MemoryAllocation(allocator,
-                           resourceHeap,
-                           offsetFromHeap,
-                           AllocationMethod::kStandalone,
-                           /*block*/ nullptr),
-          mResidencyManager(residencyManager),
-          mResource(std::move(resource)),
           mOffsetFromResource(0) {
         ASSERT(resourceHeap != nullptr);
         GPGMM_TRACE_EVENT_OBJECT_NEW(this);

--- a/src/gpgmm/d3d12/ResourceAllocationD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocationD3D12.h
@@ -41,22 +41,16 @@ namespace gpgmm { namespace d3d12 {
                                                   public NonCopyable,
                                                   public IUnknownImpl {
       public:
-        // Constructs a sub-allocated heap containing one or more resources.
+        // Constructs a resource allocation from memory containing one or more resources.
         ResourceAllocation(ResidencyManager* residencyManager,
                            MemoryAllocator* allocator,
                            uint64_t offsetFromHeap,
                            MemoryBlock* block,
+                           AllocationMethod method,
                            ComPtr<ID3D12Resource> placedResource,
                            Heap* resourceHeap);
 
-        // Constructs a heap with only one resource.
-        ResourceAllocation(ResidencyManager* residencyManager,
-                           MemoryAllocator* allocator,
-                           uint64_t offsetFromHeap,
-                           ComPtr<ID3D12Resource> resource,
-                           Heap* resourceHeap);
-
-        // Constructs a sub-allocated resource within itself.
+        // Constructs a resource allocation within a resource.
         ResourceAllocation(ResidencyManager* residencyManager,
                            MemoryAllocator* allocator,
                            MemoryBlock* block,

--- a/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
+++ b/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
@@ -704,8 +704,6 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferQueryInfo) {
         QUERY_RESOURCE_ALLOCATOR_INFO info = resourceAllocator->QueryInfo();
         EXPECT_EQ(info.UsedMemoryCount, 1u);
         EXPECT_EQ(info.UsedMemoryUsage, kDefaultPreferredResourceHeapSize);
-        EXPECT_EQ(info.UsedBlockCount, 0u);
-        EXPECT_EQ(info.UsedBlockUsage, 0u);
     }
 
     // Calculate info for two pooled standalone allocations.
@@ -730,8 +728,6 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferQueryInfo) {
         QUERY_RESOURCE_ALLOCATOR_INFO info = resourceAllocator->QueryInfo();
         EXPECT_EQ(info.UsedMemoryCount, 1u);
         EXPECT_EQ(info.UsedMemoryUsage, kDefaultPreferredResourceHeapSize);
-        EXPECT_EQ(info.UsedBlockCount, 0u);
-        EXPECT_EQ(info.UsedBlockUsage, 0u);
 
         ComPtr<ResourceAllocation> secondAllocation;
         ASSERT_SUCCEEDED(resourceAllocator->CreateResource(
@@ -743,8 +739,6 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferQueryInfo) {
         info = resourceAllocator->QueryInfo();
         EXPECT_EQ(info.UsedMemoryCount, 2u);
         EXPECT_EQ(info.UsedMemoryUsage, kDefaultPreferredResourceHeapSize * 2);
-        EXPECT_EQ(info.UsedBlockCount, 0u);
-        EXPECT_EQ(info.UsedBlockUsage, 0u);
     }
 
     // Calculate info for two sub-allocations.


### PR DESCRIPTION

Allows standalone usage to be accurately tracked.