### PR TITLE
Fix trace regeneration.

### DIFF
--- a/src/gpgmm/SlabMemoryAllocator.cpp
+++ b/src/gpgmm/SlabMemoryAllocator.cpp
@@ -328,6 +328,15 @@ namespace gpgmm {
         // Hold onto the cached allocator until the last allocation gets deallocated.
         entry->Ref();
 
+        TRACE_COUNTER1(TraceEventCategory::Default, "GPU slabs allocated (MB)",
+                       (GetFirstChild()->GetInfo().UsedMemoryUsage) / 1e6);
+
+        TRACE_COUNTER1(TraceEventCategory::Default, "GPU slab cache miss-rate (%)",
+                       (mSizeCache.GetStats().NumOfMisses /
+                        static_cast<double>((mSizeCache.GetStats().NumOfHits +
+                                             mSizeCache.GetStats().NumOfMisses))) *
+                           100);
+
         return std::make_unique<MemoryAllocation>(
             this, subAllocation->GetMemory(), subAllocation->GetOffset(),
             subAllocation->GetMethod(), subAllocation->GetBlock());

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -615,7 +615,7 @@ namespace gpgmm { namespace d3d12 {
         const double allocationLatency = timer->EndElapsedTime() * 1e6;
         GPGMM_UNUSED(allocationLatency);
 
-        TRACE_COUNTER1(TraceEventCategory::Default, "GPU allocation latency (us)",
+        TRACE_COUNTER1(TraceEventCategory::Default, "GPU allocation hit time (us)",
                        allocationLatency);
 
         const RESOURCE_ALLOCATOR_INFO info = GetInfo();

--- a/src/tests/capture_replay_tests/D3D12EventTraceReplay.cpp
+++ b/src/tests/capture_replay_tests/D3D12EventTraceReplay.cpp
@@ -430,9 +430,9 @@ class D3D12EventTraceReplay : public D3D12TestBase, public CaptureReplayTestWith
             }
         }
 
-        ASSERT_TRUE(allocationInfoToID.empty());
-        ASSERT_TRUE(allocatorToID.empty());
-        ASSERT_TRUE(heapInfoToID.empty());
+        EXPECT_TRUE(allocationInfoToID.empty());
+        EXPECT_TRUE(allocatorToID.empty());
+        EXPECT_TRUE(heapInfoToID.empty());
     }
 
     CaptureReplayCallStats mReplayedAllocateStats;
@@ -464,31 +464,10 @@ TEST_P(D3D12EventTraceReplay, MemoryUsage) {
     EXPECT_EQ(mReplayedAllocationStats.TotalCount, mCapturedAllocationStats.TotalCount);
 }
 
-// Verify a re-generated trace will always playback the same result.
+// Re-generates traces.
 TEST_P(D3D12EventTraceReplay, Regenerate) {
     RunSingleTest(/*forceRegenerate*/ true, /*forceIsCapturedCapsCompat*/ false,
                   /*forcePrefetchMemory*/ false);
-
-    const CaptureReplayCallStats beforeReplayedAllocateStats = mReplayedAllocateStats;
-    const CaptureReplayCallStats beforeReplayedDeallocateStats = mReplayedDeallocateStats;
-    const CaptureReplayMemoryStats beforeCapturedAllocationStats = mCapturedAllocationStats;
-    const CaptureReplayMemoryStats beforeCapturedMemoryStats = mCapturedMemoryStats;
-
-    // Reset stats
-    mReplayedAllocateStats = {};
-    mReplayedDeallocateStats = {};
-    mCapturedAllocationStats = {};
-    mCapturedMemoryStats = {};
-
-    RunSingleTest(/*forceRegenerate*/ false, /*forceIsCapturedCapsCompat*/ false,
-                  /*forcePrefetchMemory*/ false);
-
-    EXPECT_EQ(beforeReplayedAllocateStats.TotalNumOfCalls, mReplayedAllocateStats.TotalNumOfCalls);
-    EXPECT_EQ(beforeReplayedDeallocateStats.TotalNumOfCalls,
-              mReplayedDeallocateStats.TotalNumOfCalls);
-
-    EXPECT_EQ(beforeCapturedAllocationStats.TotalCount, mCapturedAllocationStats.TotalCount);
-    EXPECT_EQ(beforeCapturedMemoryStats.TotalCount, mCapturedMemoryStats.TotalCount);
 }
 
 GPGMM_INSTANTIATE_CAPTURE_REPLAY_TEST(D3D12EventTraceReplay);


### PR DESCRIPTION
Regenerating a trace twice would always fail because the first re-generation would record two tests worth together then a second re-generation would only include the first test events in the second test.

This fixes the issue by making regenerate only be used to record new events.