### PR TITLE
Fix SlabMemoryAllocator failures.

### DIFF
--- a/src/gpgmm/SlabMemoryAllocator.h
+++ b/src/gpgmm/SlabMemoryAllocator.h
@@ -68,21 +68,23 @@ namespace gpgmm {
         uint64_t ComputeSlabSize(uint64_t size) const;
 
         // Slab is a node in a doubly-linked list that contains a free-list of blocks
-        // and a reference to the underlying memory.
+        // and a reference to underlying memory.
         struct Slab : public LinkNode<Slab>, public RefCounted {
             Slab(uint64_t blockCount, uint64_t blockSize)
                 : RefCounted(0), BlockCount(blockCount), Allocator(blockCount, blockSize) {
             }
+
             ~Slab() {
                 if (IsInList()) {
                     RemoveFromList();
                 }
             }
+
             bool IsFull() const {
                 return static_cast<uint32_t>(GetRefCount()) == BlockCount;
             }
 
-            double GetUsedPercent() {
+            double GetUsedPercent() const {
                 return static_cast<uint32_t>(GetRefCount()) / static_cast<double>(BlockCount);
             }
 

--- a/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
+++ b/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
@@ -806,7 +806,27 @@ TEST_F(D3D12ResourceAllocatorTests, CreateTexturePooled) {
 }
 
 // Creates a bunch of small buffers using the smallest size allowed so GPU memory is pre-fetched.
-TEST_F(D3D12ResourceAllocatorTests, CreateBufferPrefetch) {
+TEST_F(D3D12ResourceAllocatorTests, CreateBufferMany) {
+    ComPtr<ResourceAllocator> allocator;
+    ASSERT_SUCCEEDED(ResourceAllocator::CreateAllocator(CreateBasicAllocatorDesc(), &allocator));
+    ASSERT_NE(allocator, nullptr);
+
+    constexpr uint64_t kNumOfBuffers = 1000u;
+
+    std::set<ComPtr<ResourceAllocation>> allocs = {};
+    for (uint64_t i = 0; i < kNumOfBuffers; i++) {
+        ComPtr<ResourceAllocation> allocation;
+        ASSERT_SUCCEEDED(allocator->CreateResource(
+            {}, CreateBasicBufferDesc(1), D3D12_RESOURCE_STATE_COMMON, nullptr, &allocation));
+        ASSERT_NE(allocation, nullptr);
+        allocs.insert(allocation);
+    }
+
+    allocs.clear();
+}
+
+// Creates a bunch of small buffers using the smallest size allowed so GPU memory is pre-fetched.
+TEST_F(D3D12ResourceAllocatorTests, CreateBufferManyPrefetch) {
     ComPtr<ResourceAllocator> allocator;
     ASSERT_SUCCEEDED(ResourceAllocator::CreateAllocator(
         CreateBasicAllocatorDesc(/*enablePrefetch*/ true), &allocator));


### PR DESCRIPTION
When slab allocator reached capacity, it would fail to allocate a new slab until a subsequent allocation was made.