### PR TITLE
Reland "Display video memory budget metric per segment. (#261)"

### DIFF
--- a/src/gpgmm/common/Utils.h
+++ b/src/gpgmm/common/Utils.h
@@ -50,6 +50,13 @@ namespace gpgmm {
         return output.str();
     }
 
+    // Used to combine multiple ToString calls for concatenation.
+    // Eg. ToString("a", "b", "c") == "abc".
+    template <typename T, typename... Args>
+    std::string ToString(T object, Args... args) {
+        return ToString(object) + ToString(args...);
+    }
+
 }  // namespace gpgmm
 
 #endif  // GPGMM_COMMON_UTILS_H_

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.h
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.h
@@ -92,7 +92,7 @@ namespace gpgmm { namespace d3d12 {
         LRUCache* GetVideoMemorySegmentCache(const DXGI_MEMORY_SEGMENT_GROUP& memorySegmentGroup);
 
         HRESULT QueryVideoMemoryInfo(const DXGI_MEMORY_SEGMENT_GROUP& memorySegmentGroup,
-                                     DXGI_QUERY_VIDEO_MEMORY_INFO* videoMemoryInfo) const;
+                                     DXGI_QUERY_VIDEO_MEMORY_INFO* pVideoMemoryInfo) const;
 
         ComPtr<ID3D12Device> mDevice;
         ComPtr<IDXGIAdapter3> mAdapter;

--- a/src/tests/BUILD.gn
+++ b/src/tests/BUILD.gn
@@ -117,6 +117,7 @@ test("gpgmm_unittests") {
     "unittests/SegmentedMemoryAllocatorTests.cpp",
     "unittests/SlabBlockAllocatorTests.cpp",
     "unittests/SlabMemoryAllocatorTests.cpp",
+    "unittests/UtilsTest.cpp",
   ]
 
   # When building inside Chromium, use their gtest main function because it is

--- a/src/tests/unittests/UtilsTest.cpp
+++ b/src/tests/unittests/UtilsTest.cpp
@@ -1,0 +1,23 @@
+// Copyright 2021 The GPGMM Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "gpgmm/common/Utils.h"
+
+using namespace gpgmm;
+
+TEST(UtilsTest, ConcatString) {
+    EXPECT_TRUE(ToString("This ", "is ", "a ", "sentance") == std::string("This is a sentance"));
+}


### PR DESCRIPTION
This reverts commit 2b95f73f1e2585e82a34255a78fb7dc1a21369f7.