### PR TITLE
Escalate allocator event level.

### DIFF
--- a/src/gpgmm/BuddyBlockAllocator.cpp
+++ b/src/gpgmm/BuddyBlockAllocator.cpp
@@ -148,7 +148,7 @@ namespace gpgmm {
         GPGMM_CHECK_NONZERO(requestSize);
 
         if (requestSize > mMaxBlockSize) {
-            DebugEvent("BuddyBlockAllocator.TryAllocateBlock", ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED)
+            InfoEvent("BuddyBlockAllocator.TryAllocateBlock", ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED)
                 << "MemoryBlock size exceeded the max block size.";
             return nullptr;
         }
@@ -162,8 +162,7 @@ namespace gpgmm {
 
         // Error when no free blocks exist (allocator is full)
         if (currBlockLevel == kInvalidOffset) {
-            DebugEvent("BuddyBlockAllocator.TryAllocateBlock",
-                       ALLOCATOR_MESSAGE_ID_ALLOCATOR_FAILED)
+            InfoEvent("BuddyBlockAllocator.TryAllocateBlock", ALLOCATOR_MESSAGE_ID_ALLOCATOR_FAILED)
                 << "Allocator has reached capacity";
             return nullptr;
         }

--- a/src/gpgmm/BuddyMemoryAllocator.cpp
+++ b/src/gpgmm/BuddyMemoryAllocator.cpp
@@ -52,7 +52,7 @@ namespace gpgmm {
 
         // Check the unaligned size to avoid overflowing NextPowerOfTwo.
         if (requestSize > mMemorySize) {
-            DebugEvent("BuddyMemoryAllocator.TryAllocateMemory", ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED)
+            InfoEvent("BuddyMemoryAllocator.TryAllocateMemory", ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED)
                 << "Allocation size exceeded the memory size (" + std::to_string(requestSize) +
                        " vs " + std::to_string(mMemorySize) + " bytes).";
             return {};
@@ -63,7 +63,7 @@ namespace gpgmm {
 
         // Allocation cannot exceed the memory size.
         if (allocationSize > mMemorySize) {
-            DebugEvent("BuddyMemoryAllocator.TryAllocateMemory", ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED)
+            InfoEvent("BuddyMemoryAllocator.TryAllocateMemory", ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED)
                 << "Aligned allocation size exceeded the memory size (" +
                        std::to_string(allocationSize) + " vs " + std::to_string(mMemorySize) +
                        " bytes).";

--- a/src/gpgmm/SegmentedMemoryAllocator.cpp
+++ b/src/gpgmm/SegmentedMemoryAllocator.cpp
@@ -139,8 +139,8 @@ namespace gpgmm {
         GPGMM_CHECK_NONZERO(requestSize);
 
         if (alignment != mMemoryAlignment) {
-            DebugEvent("SegmentedMemoryAllocator.TryAllocateMemory",
-                       ALLOCATOR_MESSAGE_ID_ALIGNMENT_MISMATCH)
+            InfoEvent("SegmentedMemoryAllocator.TryAllocateMemory",
+                      ALLOCATOR_MESSAGE_ID_ALIGNMENT_MISMATCH)
                 << "Allocation alignment does not match memory alignment.";
             return {};
         }

--- a/src/gpgmm/SlabBlockAllocator.cpp
+++ b/src/gpgmm/SlabBlockAllocator.cpp
@@ -44,7 +44,7 @@ namespace gpgmm {
         GPGMM_CHECK_NONZERO(requestSize);
 
         if (requestSize > mBlockSize) {
-            DebugEvent("SlabBlockAllocator.TryAllocateBlock", ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED)
+            InfoEvent("SlabBlockAllocator.TryAllocateBlock", ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED)
                 << "Allocation size exceeded the block size. (" + std::to_string(requestSize) +
                        " vs " + std::to_string(mBlockSize) + " bytes).";
             return nullptr;
@@ -52,8 +52,8 @@ namespace gpgmm {
 
         // Offset must be equal to a multiple of |mBlockSize|.
         if (!IsAligned(mBlockSize, alignment)) {
-            DebugEvent("SlabBlockAllocator.TryAllocateBlock",
-                       ALLOCATOR_MESSAGE_ID_ALIGNMENT_MISMATCH)
+            InfoEvent("SlabBlockAllocator.TryAllocateBlock",
+                      ALLOCATOR_MESSAGE_ID_ALIGNMENT_MISMATCH)
                 << "Allocation alignment is not a multiple of the block size. (" +
                        std::to_string(alignment) + " vs " + std::to_string(mBlockSize) + " bytes).";
             return nullptr;

--- a/src/gpgmm/SlabMemoryAllocator.cpp
+++ b/src/gpgmm/SlabMemoryAllocator.cpp
@@ -98,7 +98,7 @@ namespace gpgmm {
         std::lock_guard<std::mutex> lock(mMutex);
 
         if (requestSize > mBlockSize) {
-            DebugEvent("SlabMemoryAllocator.TryAllocateMemory", ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED)
+            InfoEvent("SlabMemoryAllocator.TryAllocateMemory", ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED)
                 << "Allocation size exceeded the block size (" + std::to_string(requestSize) +
                        " vs " + std::to_string(mBlockSize) + " bytes).";
             return {};
@@ -106,7 +106,7 @@ namespace gpgmm {
 
         const uint64_t slabSize = ComputeSlabSize(requestSize);
         if (slabSize > mMaxSlabSize) {
-            DebugEvent("SlabMemoryAllocator.TryAllocateMemory", ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED)
+            InfoEvent("SlabMemoryAllocator.TryAllocateMemory", ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED)
                 << "Slab size exceeded the max slab size (" + std::to_string(slabSize) + " vs " +
                        std::to_string(mMaxSlabSize) + " bytes).";
             return {};

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -121,8 +121,8 @@ namespace gpgmm { namespace d3d12 {
             // required alignment is for this resource.
             if (resourceDescriptor.Alignment != 0 &&
                 resourceDescriptor.Alignment != resourceInfo.Alignment) {
-                DebugEvent("ResourceAllocator.GetResourceAllocationInfo",
-                           ALLOCATOR_MESSAGE_ID_RESOURCE_MISALIGNMENT)
+                WarnEvent("ResourceAllocator.GetResourceAllocationInfo",
+                          ALLOCATOR_MESSAGE_ID_RESOURCE_MISALIGNMENT)
                     << "Resource alignment is much larger due to D3D12 (" +
                            std::to_string(resourceDescriptor.Alignment) + " vs " +
                            std::to_string(resourceInfo.Alignment) + " bytes) for resource : " +
@@ -303,17 +303,20 @@ namespace gpgmm { namespace d3d12 {
             std::unique_ptr<MemoryAllocation> allocation = allocator->TryAllocateMemory(
                 size, alignment, neverAllocate, cacheSize, prefetchMemory);
             if (allocation == nullptr) {
-                DebugEvent("ResourceAllocator.TryAllocateResource",
-                           ALLOCATOR_MESSAGE_ID_RESOURCE_ALLOCATION_FAILED)
-                    << std::string(allocator->GetTypename()) + " failed to allocate memory.";
+                InfoEvent("ResourceAllocator.TryAllocateResource",
+                          ALLOCATOR_MESSAGE_ID_RESOURCE_ALLOCATION_FAILED)
+                    << std::string(allocator->GetTypename()) +
+                           " failed to allocate memory for resource.";
 
                 return E_FAIL;
             }
             HRESULT hr = createResourceFn(*allocation);
             if (FAILED(hr)) {
-                DebugEvent("ResourceAllocator.TryAllocateResource",
-                           ALLOCATOR_MESSAGE_ID_RESOURCE_ALLOCATION_FAILED)
-                    << "Resource failed to be created: " + GetErrorMessage(hr);
+                InfoEvent("ResourceAllocator.TryAllocateResource",
+                          ALLOCATOR_MESSAGE_ID_RESOURCE_ALLOCATION_FAILED)
+                    << std::string(allocator->GetTypename()) +
+                           " failed to create resource using allocated memory: " +
+                           GetErrorMessage(hr);
                 allocator->DeallocateMemory(std::move(allocation));
             }
             return hr;

--- a/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.cpp
@@ -58,8 +58,8 @@ namespace gpgmm { namespace d3d12 {
         // https://docs.microsoft.com/en-us/windows/win32/api/d3d12/ns-d3d12-d3d12_HEAP_INFO
         const uint64_t heapSize = AlignTo(requestSize, alignment);
         if (heapSize > requestSize) {
-            DebugEvent("ResourceHeapAllocator.TryAllocateMemory",
-                       ALLOCATOR_MESSAGE_ID_ALIGNMENT_MISMATCH)
+            InfoEvent("ResourceHeapAllocator.TryAllocateMemory",
+                      ALLOCATOR_MESSAGE_ID_ALIGNMENT_MISMATCH)
                 << "Resource heap size is larger then the requested size (" +
                        std::to_string(heapSize) + " vs " + std::to_string(requestSize) + " bytes).";
         }


### PR DESCRIPTION
Treats allocator errors as warnings such that gpgmm_enable_assert_on_warning will ASSERT during tests.