### PR TITLE
Fix leak in memory cache.

### DIFF
--- a/src/gpgmm/MemoryCache.h
+++ b/src/gpgmm/MemoryCache.h
@@ -18,6 +18,7 @@
 #include "gpgmm/common/Assert.h"
 #include "gpgmm/common/NonCopyable.h"
 #include "gpgmm/common/RefCount.h"
+#include "gpgmm/common/Utils.h"
 
 #include <unordered_set>
 
@@ -187,9 +188,9 @@ namespace gpgmm {
         void RemoveAndDeleteAll() {
             for (auto it = mCache.begin(); it != mCache.end();) {
                 if ((*it)->Unref()) {
-                    auto curr = it;
+                    CacheEntryT* item = (*it);
                     it++;
-                    RemoveCacheEntry(*curr);
+                    SafeDelete(item);
                 } else {
                     it++;
                 }

--- a/src/tests/GPGMMTest.cpp
+++ b/src/tests/GPGMMTest.cpp
@@ -13,15 +13,37 @@
 // limitations under the License.
 
 #include "src/tests/GPGMMTest.h"
+#include "gpgmm/common/Platform.h"
 
 #include <iostream>
 
 static GPGMMTestEnvironment* gTestEnv = nullptr;
 
+#if defined(GPGMM_PLATFORM_WIN32)
+#    include <crtdbg.h>
+#endif
+
+void ReportMemoryLeaks() {
+#if GPGMM_PLATFORM_WIN32
+    // Send all reports to STDOUT.
+    _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDOUT);
+    _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDOUT);
+    _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDOUT);
+    // Perform automatic leak checking at program exit through a call to _CrtDumpMemoryLeaks
+    // and generate an error report if the application failed to free all the memory it
+    // allocated.
+    _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
+#endif
+}
+
 GPGMMTestBase::~GPGMMTestBase() {
 }
 
 void GPGMMTestBase::SetUp() {
+    ReportMemoryLeaks();
 }
 
 void GPGMMTestBase::TearDown() {


### PR DESCRIPTION
MemoryCache was creating a cached entry without destroying it upon cache destruction, the entry itself was only being unlinked or removed from the cache.

To prevent future mistakes, the end2end test harness enables leak detection by default.

Fixes otcshare/webnn-native#1034