### PR TITLE
Fix crash when flushing events to disk at exit.

### DIFF
--- a/src/gpgmm/TraceEvent.cpp
+++ b/src/gpgmm/TraceEvent.cpp
@@ -53,7 +53,7 @@ namespace gpgmm {
 
     TraceEvent::TraceEvent(char phase,
                            TraceEventCategory category,
-                           const char* name,
+                           const std::string& name,
                            uint64_t id,
                            uint32_t tid,
                            double timestamp,

--- a/src/gpgmm/TraceEvent.h
+++ b/src/gpgmm/TraceEvent.h
@@ -153,7 +153,7 @@ namespace gpgmm {
       public:
         TraceEvent(char phase,
                    TraceEventCategory category,
-                   const char* name,
+                   const std::string& name,
                    uint64_t id,
                    uint32_t tid,
                    double timestamp,
@@ -165,7 +165,7 @@ namespace gpgmm {
 
         char mPhase = 0;
         TraceEventCategory mCategory;
-        const char* mName = nullptr;
+        std::string mName;
         uint64_t mID = 0;
         uint32_t mTID = 0;
         double mTimestamp = 0;


### PR DESCRIPTION
Event "name" field references a literal within an object that could be destroy before the event writter is finished using it at program exit.

This fix ensures the "name" field is always copied whose lifetime is the same as the buffer.