### PR TITLE
Enable CRT based leak detection in GTests.

### DIFF
--- a/src/gpgmm/common/BUILD.gn
+++ b/src/gpgmm/common/BUILD.gn
@@ -157,6 +157,7 @@ if (is_win || is_linux || is_chromeos || is_mac || is_fuchsia || is_android) {
       "Math.cpp",
       "Math.h",
       "Platform.h",
+      "PlatformDebug.h",
       "PlatformTime.cpp",
       "PlatformTime.h",
       "PlatformUtils.cpp",
@@ -169,6 +170,7 @@ if (is_win || is_linux || is_chromeos || is_mac || is_fuchsia || is_android) {
 
     if (is_win) {
       sources += [
+        "WindowsPlatformDebug.cpp",
         "WindowsTime.cpp",
         "WindowsUtils.cpp",
         "WindowsUtils.h",

--- a/src/gpgmm/common/CMakeLists.txt
+++ b/src/gpgmm/common/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(gpgmm_common PRIVATE
   "Math.cpp"
   "Math.h"
   "Platform.h"
+  "PlatformDebug.h"
   "PlatformTime.cpp"
   "PlatformTime.h"
   "PlatformUtils.cpp"
@@ -40,6 +41,7 @@ target_sources(gpgmm_common PRIVATE
 
 if (WIN32)
     target_sources(gpgmm_common PRIVATE
+        "WindowsPlatformDebug.cpp"
         "WindowsTime.cpp"
         "WindowsUtils.cpp"
         "WindowsUtils.h"

--- a/src/gpgmm/common/PlatformDebug.h
+++ b/src/gpgmm/common/PlatformDebug.h
@@ -1,0 +1,42 @@
+// Copyright 2021 The GPGMM Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GPGMM_COMMON_PLATFORMDEBUG_H_
+#define GPGMM_COMMON_PLATFORMDEBUG_H_
+
+namespace gpgmm {
+
+    class DebugPlatform {
+      public:
+        // Starts memory leak checking, if supported.
+        virtual void StartMemoryCheck() {
+        }
+
+        // End memory leak checking and return true if a memory leak was detected.
+        virtual bool EndMemoryCheck() {
+            return false;
+        }
+
+        // Output or dump leak detection to console.
+        virtual void ReportMemoryLeaks() {
+        }
+
+        virtual ~DebugPlatform() = default;
+    };
+
+    DebugPlatform* CreateDebugPlatform();
+
+}  // namespace gpgmm
+
+#endif  // GPGMM_COMMON_PLATFORMDEBUG_H_

--- a/src/gpgmm/common/WindowsPlatformDebug.cpp
+++ b/src/gpgmm/common/WindowsPlatformDebug.cpp
@@ -1,0 +1,78 @@
+// Copyright 2021 The GPGMM Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "PlatformDebug.h"
+
+#include "Assert.h"
+#include "Platform.h"
+
+#include <memory>
+
+#if defined(GPGMM_PLATFORM_WIN32)
+#    include <crtdbg.h>
+#endif  // defined(GPGMM_PLATFORM_WIN32)
+
+namespace gpgmm {
+
+    class WindowsDebugPlatform : public DebugPlatform {
+      public:
+        WindowsDebugPlatform() : DebugPlatform() {
+            // Explicitly initialize so they are "used" when compiling non-debug builds.
+            mStart = {};
+            mEnd = {};
+            mDiff = {};
+        }
+
+        void StartMemoryCheck() override {
+            _CrtMemCheckpoint(&mStart);
+        }
+
+        bool EndMemoryCheck() override {
+            _CrtMemCheckpoint(&mEnd);
+            if (_CrtMemDifference(&mDiff, &mStart, &mEnd)) {
+                _CrtMemDumpStatistics(&mDiff);
+                return true;
+            }
+            return false;
+        }
+
+        void ReportMemoryLeaks() override {
+            // Send all reports to STDOUT.
+            _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE);
+            _CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDOUT);
+            _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
+            _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDOUT);
+            _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
+            _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDOUT);
+            // Perform automatic leak checking at program exit through a call to _CrtDumpMemoryLeaks
+            // and generate an error report if the application failed to free all the memory it
+            // allocated.
+            _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
+        }
+
+      private:
+        _CrtMemState mStart;
+        _CrtMemState mEnd;
+        _CrtMemState mDiff;
+    };
+
+    DebugPlatform* CreateDebugPlatform() {
+#if GPGMM_PLATFORM_WIN32
+        return new WindowsDebugPlatform();
+#else
+        return nullptr;
+#endif
+    }
+
+}  // namespace gpgmm

--- a/src/tests/GPGMMTest.cpp
+++ b/src/tests/GPGMMTest.cpp
@@ -13,40 +13,27 @@
 // limitations under the License.
 
 #include "src/tests/GPGMMTest.h"
-#include "gpgmm/common/Platform.h"
 
 #include <iostream>
 
 static GPGMMTestEnvironment* gTestEnv = nullptr;
 
-#if defined(GPGMM_PLATFORM_WIN32)
-#    include <crtdbg.h>
-#endif
-
-void ReportMemoryLeaks() {
-#if GPGMM_PLATFORM_WIN32
-    // Send all reports to STDOUT.
-    _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE);
-    _CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDOUT);
-    _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
-    _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDOUT);
-    _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
-    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDOUT);
-    // Perform automatic leak checking at program exit through a call to _CrtDumpMemoryLeaks
-    // and generate an error report if the application failed to free all the memory it
-    // allocated.
-    _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
-#endif
-}
+static std::unique_ptr<gpgmm::DebugPlatform> mDebugPlatform(gpgmm::CreateDebugPlatform());
 
 GPGMMTestBase::~GPGMMTestBase() {
 }
 
 void GPGMMTestBase::SetUp() {
-    ReportMemoryLeaks();
+    if (mDebugPlatform != nullptr) {
+        mDebugPlatform->ReportMemoryLeaks();
+    }
 }
 
 void GPGMMTestBase::TearDown() {
+}
+
+gpgmm::DebugPlatform* GPGMMTestBase::GetDebugPlatform() {
+    return mDebugPlatform.get();
 }
 
 // GPGMMTestEnvironment

--- a/src/tests/GPGMMTest.h
+++ b/src/tests/GPGMMTest.h
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 
 #include "gpgmm/common/Log.h"
+#include "gpgmm/common/PlatformDebug.h"
 
 #define GPGMM_SKIP_TEST_IF(expr)                            \
     do {                                                    \
@@ -28,12 +29,28 @@
         }                                                   \
     } while (0)
 
+#define GPGMM_TEST_MEMORY_LEAK_START()          \
+    do {                                        \
+        GetDebugPlatform()->StartMemoryCheck(); \
+    } while (0)
+
+#define GPGMM_TEST_MEMORY_LEAK_END()                        \
+    do {                                                    \
+        EXPECT_FALSE(GetDebugPlatform()->EndMemoryCheck()); \
+    } while (0)
+
+namespace gpgmm {
+    class DebugPlatform;
+}  // namespace gpgmm
+
 class GPGMMTestBase {
   protected:
     virtual ~GPGMMTestBase();
 
     void SetUp();
     void TearDown();
+
+    gpgmm::DebugPlatform* GetDebugPlatform();
 };
 
 void InitGPGMMEnd2EndTestEnvironment(int argc, char** argv);

--- a/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
+++ b/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
@@ -85,6 +85,15 @@ TEST_F(D3D12ResourceAllocatorTests, CreateAllocator) {
     }
 }
 
+TEST_F(D3D12ResourceAllocatorTests, CreateAllocatorNoLeak) {
+    GPGMM_TEST_MEMORY_LEAK_START();
+    {
+        ComPtr<ResourceAllocator> resourceAllocator;
+        ResourceAllocator::CreateAllocator(CreateBasicAllocatorDesc(), &resourceAllocator);
+    }
+    GPGMM_TEST_MEMORY_LEAK_END();
+}
+
 // Exceeding the max resource heap size should always fail.
 TEST_F(D3D12ResourceAllocatorTests, CreateBufferOversized) {
     ComPtr<ResourceAllocator> resourceAllocator;


### PR DESCRIPTION
A pair of start/end macros are introduced to decorate what GTest code to leak test. Since GTest macros themselves "leak" memory for debugging purposes, they cannot be used within this region.