### PR TITLE
Enable D3D12_HEAP_FLAG_CREATE_NOT_RESIDENT

### DIFF
--- a/src/gpgmm/d3d12/BufferAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/BufferAllocatorD3D12.cpp
@@ -24,12 +24,14 @@ namespace gpgmm { namespace d3d12 {
 
     BufferAllocator::BufferAllocator(ResourceAllocator* resourceAllocator,
                                      D3D12_HEAP_TYPE heapType,
+                                     D3D12_HEAP_FLAGS heapFlags,
                                      D3D12_RESOURCE_FLAGS resourceFlags,
                                      D3D12_RESOURCE_STATES initialResourceState,
                                      uint64_t bufferSize,
                                      uint64_t bufferAlignment)
         : mResourceAllocator(resourceAllocator),
           mHeapType(heapType),
+          mHeapFlags(heapFlags),
           mResourceFlags(resourceFlags),
           mInitialResourceState(initialResourceState),
           mBufferSize(bufferSize),
@@ -63,7 +65,7 @@ namespace gpgmm { namespace d3d12 {
         // Optimized clear is not supported for buffers.
         Heap* resourceHeap = nullptr;
         if (FAILED(mResourceAllocator->CreateCommittedResource(
-                mHeapType, D3D12_HEAP_FLAG_NONE, request.SizeInBytes, &resourceDescriptor,
+                mHeapType, mHeapFlags, request.SizeInBytes, &resourceDescriptor,
                 /*pOptimizedClearValue*/ nullptr, mInitialResourceState, /*resourceOut*/ nullptr,
                 &resourceHeap))) {
             return {};

--- a/src/gpgmm/d3d12/BufferAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/BufferAllocatorD3D12.h
@@ -27,6 +27,7 @@ namespace gpgmm { namespace d3d12 {
       public:
         BufferAllocator(ResourceAllocator* resourceAllocator,
                         D3D12_HEAP_TYPE heapType,
+                        D3D12_HEAP_FLAGS heapFlags,
                         D3D12_RESOURCE_FLAGS resourceFlags,
                         D3D12_RESOURCE_STATES initialResourceState,
                         uint64_t bufferSize,
@@ -45,6 +46,7 @@ namespace gpgmm { namespace d3d12 {
         ResourceAllocator* const mResourceAllocator;
 
         const D3D12_HEAP_TYPE mHeapType;
+        const D3D12_HEAP_FLAGS mHeapFlags;
         const D3D12_RESOURCE_FLAGS mResourceFlags;
         const D3D12_RESOURCE_STATES mInitialResourceState;
         const uint64_t mBufferSize;

--- a/src/gpgmm/d3d12/CapsD3D12.h
+++ b/src/gpgmm/d3d12/CapsD3D12.h
@@ -32,11 +32,15 @@ namespace gpgmm { namespace d3d12 {
         // Largest resource heap that this device can make available.
         uint64_t GetMaxResourceHeapSize() const;
 
+        // Allows a resource heap to be created without being resident.
+        bool IsCreateHeapNotResidentSupported() const;
+
       private:
         Caps() = default;
 
         uint64_t mMaxResourceSize = 0;
         uint64_t mMaxResourceHeapSize = 0;
+        bool mIsCreateHeapNotResidentSupported = false;
     };
 
 }}  // namespace gpgmm::d3d12

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -45,15 +45,19 @@ namespace gpgmm { namespace d3d12 {
          */
         ALLOCATOR_FLAG_NONE = 0x0,
 
-        /** \brief Disable reuse of resource memory.
+        /** \brief Disable re-use of resource heap.
 
-        Should only be used for debugging and testing purposes.
+        Mostly used for debugging and testing purposes.
         */
         ALLOCATOR_FLAG_ALWAYS_COMMITED = 0x1,
 
-        /** \brief Ensures resources are always within the resource budget at creation time.
+        /** \brief Ensures resources are always created within the budget.
 
-        Mostly used to debug with residency being over committed.
+        By default or when this flag is not set, resource creation may fail when over-budget.
+
+        GPGMM implicitly applies D3D12_HEAP_FLAG_CREATE_NOT_RESIDENT to resource heaps when
+        residency is being used in order to speed-up creation by deferring residency
+        operations until needed (ex. Map(), lock/unlock, or ExecuteCommandLists()).
         */
         ALLOCATOR_FLAG_ALWAYS_IN_BUDGET = 0x2,
 
@@ -487,6 +491,8 @@ namespace gpgmm { namespace d3d12 {
                                         Heap** resourceHeapOut);
 
         static HRESULT ReportLiveDeviceObjects(ComPtr<ID3D12Device> device);
+
+        bool IsCreateHeapNotResident() const;
 
         // MemoryAllocator interface
         void DeallocateMemory(std::unique_ptr<MemoryAllocation> allocation) override;

--- a/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.h
@@ -30,8 +30,7 @@ namespace gpgmm { namespace d3d12 {
                               ID3D12Device* device,
                               D3D12_HEAP_TYPE heapType,
                               D3D12_HEAP_FLAGS heapFlags,
-                              bool isUMA,
-                              bool isAlwaysInBudget);
+                              bool isUMA);
         ~ResourceHeapAllocator() override = default;
 
         // MemoryAllocator interface
@@ -47,7 +46,6 @@ namespace gpgmm { namespace d3d12 {
         const D3D12_HEAP_TYPE mHeapType;
         const D3D12_HEAP_FLAGS mHeapFlags;
         const bool mIsUMA;
-        const bool mIsAlwaysInBudget;
     };
 
 }}  // namespace gpgmm::d3d12

--- a/src/gpgmm/d3d12/d3d12_platform.h
+++ b/src/gpgmm/d3d12/d3d12_platform.h
@@ -20,6 +20,13 @@
 #include <dxgi1_4.h>
 #include <wrl.h>
 
+// Keep backwards compatibility when using D3D12 feature flags that are only defined in a newer
+// D3D12.h versions.
+// Only once ALL builds upgrade to newer D3D12.h, can these re-defines be safely removed.
+#ifndef D3D12_FEATURE_D3D12_OPTIONS7
+#    define D3D12_HEAP_FLAG_CREATE_NOT_RESIDENT static_cast<D3D12_HEAP_FLAGS>(0x800)
+#endif
+
 using Microsoft::WRL::ComPtr;
 
 #endif  // GPGMM_D3D12_D3D12PLATFORM_H_


### PR DESCRIPTION
Use D3D12_HEAP_FLAG_CREATE_NOT_RESIDENT to speed-up resource creation when residency is enabled.