### PR TITLE
Add and use SafeDivison on input.

### DIFF
--- a/src/gpgmm/common/BuddyMemoryAllocator.cpp
+++ b/src/gpgmm/common/BuddyMemoryAllocator.cpp
@@ -37,7 +37,7 @@ namespace gpgmm {
 
     uint64_t BuddyMemoryAllocator::GetMemoryIndex(uint64_t offset) const {
         ASSERT(offset != kInvalidOffset);
-        return offset / mMemorySize;
+        return SafeDivison(offset, mMemorySize);
     }
 
     std::unique_ptr<MemoryAllocation> BuddyMemoryAllocator::TryAllocateMemory(uint64_t requestSize,

--- a/src/gpgmm/common/SlabMemoryAllocator.cpp
+++ b/src/gpgmm/common/SlabMemoryAllocator.cpp
@@ -17,7 +17,6 @@
 #include "gpgmm/common/Debug.h"
 #include "gpgmm/common/Memory.h"
 #include "gpgmm/utils/Assert.h"
-#include "gpgmm/utils/Math.h"
 #include "gpgmm/utils/Utils.h"
 
 #include <algorithm>  // std::max
@@ -142,7 +141,7 @@ namespace gpgmm {
                 }
             }
 
-            Slab* pNewFreeSlab = new Slab(slabSize / mBlockSize, mBlockSize);
+            Slab* pNewFreeSlab = new Slab(SafeDivison(slabSize, mBlockSize), mBlockSize);
             pNewFreeSlab->InsertBefore(cache->FreeList.head());
             pFreeSlab = pNewFreeSlab;
         }
@@ -351,9 +350,9 @@ namespace gpgmm {
                        (GetFirstChild()->GetInfo().UsedMemoryUsage) / 1e6);
 
         TRACE_COUNTER1(TraceEventCategory::Default, "GPU slab cache miss-rate (%)",
-                       (mSizeCache.GetStats().NumOfMisses /
-                        static_cast<double>((mSizeCache.GetStats().NumOfHits +
-                                             mSizeCache.GetStats().NumOfMisses))) *
+                       SafeDivison(mSizeCache.GetStats().NumOfMisses,
+                                   static_cast<double>((mSizeCache.GetStats().NumOfHits +
+                                                        mSizeCache.GetStats().NumOfMisses))) *
                            100);
 
         return std::make_unique<MemoryAllocation>(

--- a/src/gpgmm/common/SlabMemoryAllocator.h
+++ b/src/gpgmm/common/SlabMemoryAllocator.h
@@ -19,6 +19,7 @@
 #include "gpgmm/common/MemoryCache.h"
 #include "gpgmm/common/SlabBlockAllocator.h"
 #include "gpgmm/utils/LinkedList.h"
+#include "gpgmm/utils/Math.h"
 
 #include <vector>
 
@@ -86,7 +87,8 @@ namespace gpgmm {
             }
 
             double GetUsedPercent() const {
-                return static_cast<uint32_t>(GetRefCount()) / static_cast<double>(BlockCount);
+                return SafeDivison(static_cast<uint32_t>(GetRefCount()),
+                                   static_cast<double>(BlockCount));
             }
 
             uint64_t BlockCount = 0;

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
@@ -21,6 +21,7 @@
 #include "gpgmm/d3d12/HeapD3D12.h"
 #include "gpgmm/d3d12/JSONSerializerD3D12.h"
 #include "gpgmm/d3d12/ResidencySetD3D12.h"
+#include "gpgmm/utils/Math.h"
 
 #include <algorithm>
 #include <vector>

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -632,9 +632,11 @@ namespace gpgmm { namespace d3d12 {
         TRACE_COUNTER1(TraceEventCategory::Default, "GPU memory fragmentation (MB)",
                        (info.UsedMemoryUsage - info.UsedBlockUsage) / 1e6);
 
-        TRACE_COUNTER1(TraceEventCategory::Default, "GPU memory utilization (%)",
-                       (info.UsedMemoryUsage /
-                        static_cast<double>(info.UsedMemoryUsage + info.FreeMemoryUsage) * 100));
+        TRACE_COUNTER1(
+            TraceEventCategory::Default, "GPU memory utilization (%)",
+            SafeDivison(info.UsedMemoryUsage,
+                        static_cast<double>(info.UsedMemoryUsage + info.FreeMemoryUsage)) *
+                100);
 
         TRACE_COUNTER1(TraceEventCategory::Default, "GPU memory free (MB)",
                        info.FreeMemoryUsage / 1e6);

--- a/src/gpgmm/utils/Math.cpp
+++ b/src/gpgmm/utils/Math.cpp
@@ -108,4 +108,12 @@ namespace gpgmm {
         return ((n + m - 1) / m) * m;
     }
 
+    double SafeDivison(double a, double b) {
+        if (b == 0) {
+            return 0.;
+        } else {
+            return a / b;
+        }
+    }
+
 }  // namespace gpgmm

--- a/src/gpgmm/utils/Math.h
+++ b/src/gpgmm/utils/Math.h
@@ -57,6 +57,9 @@ namespace gpgmm {
 
     uint64_t RoundUp(uint64_t n, uint64_t m);
 
+    // Evaluates a/b, avoiding division by zero.
+    double SafeDivison(double a, double b);
+
 }  // namespace gpgmm
 
 #endif  // GPGMM_UTILS_MATH_H_

--- a/src/gpgmm/utils/WindowsTime.cpp
+++ b/src/gpgmm/utils/WindowsTime.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "Assert.h"
+#include "Math.h"
 #include "PlatformTime.h"
 
 #include <windows.h>
@@ -28,7 +29,7 @@ namespace gpgmm {
             LARGE_INTEGER curTime;
             const bool success = QueryPerformanceCounter(&curTime);
             ASSERT(success);
-            return static_cast<double>(curTime.QuadPart) / GetFrequency();
+            return SafeDivison(static_cast<double>(curTime.QuadPart), GetFrequency());
         }
 
         void StartElapsedTime() override {
@@ -42,7 +43,8 @@ namespace gpgmm {
             LARGE_INTEGER endCount;
             const bool success = QueryPerformanceCounter(&endCount);
             ASSERT(success);
-            return static_cast<double>(endCount.QuadPart - mCounterStart) / GetFrequency();
+            return SafeDivison(static_cast<double>(endCount.QuadPart - mCounterStart),
+                               GetFrequency());
         }
 
       private:


### PR DESCRIPTION
Prevents division by zero from crashing GPGMM.