### PR TITLE
Improve allocator error reporting.

### DIFF
--- a/build_overrides/gpgmm_features.gni
+++ b/build_overrides/gpgmm_features.gni
@@ -60,7 +60,7 @@ declare_args() {
 
   # Enables ASSERT on severity functionality.
   # Sets -dGPGMM_ENABLE_ASSERT_ON_WARNING
-  gpgmm_enable_assert_on_warning = is_debug
+  gpgmm_enable_assert_on_warning = false
 
   # Enables warming of caches with common sizes.
   # Sets -dGPGMM_ENABLE_SIZE_CACHE

--- a/src/gpgmm/common/BuddyBlockAllocator.cpp
+++ b/src/gpgmm/common/BuddyBlockAllocator.cpp
@@ -148,7 +148,7 @@ namespace gpgmm {
         GPGMM_CHECK_NONZERO(requestSize);
 
         if (requestSize > mMaxBlockSize) {
-            InfoEvent("BuddyBlockAllocator.TryAllocateBlock", ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED)
+            WarnEvent("BuddyBlockAllocator.TryAllocateBlock", ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED)
                 << "MemoryBlock size exceeded the max block size.";
             return nullptr;
         }
@@ -162,7 +162,7 @@ namespace gpgmm {
 
         // Error when no free blocks exist (allocator is full)
         if (currBlockLevel == kInvalidOffset) {
-            InfoEvent("BuddyBlockAllocator.TryAllocateBlock", ALLOCATOR_MESSAGE_ID_ALLOCATOR_FAILED)
+            WarnEvent("BuddyBlockAllocator.TryAllocateBlock", ALLOCATOR_MESSAGE_ID_ALLOCATOR_FAILED)
                 << "Allocator has reached capacity";
             return nullptr;
         }

--- a/src/gpgmm/common/Debug.cpp
+++ b/src/gpgmm/common/Debug.cpp
@@ -30,12 +30,8 @@ namespace gpgmm {
     }
 
     EventMessage::~EventMessage() {
-        const std::string description = mStream.str();
-
+        const std::string& description = mStream.str();
         gpgmm::Log(mSeverity) << mName << ": " << description;
-#if defined(GPGMM_ENABLE_ASSERT_ON_WARNING)
-        ASSERT(mSeverity < LogSeverity::Warning);
-#endif
         if (mSeverity >= gRecordEventLevel) {
             LOG_MESSAGE message{description, mMessageId};
             GPGMM_TRACE_EVENT_OBJECT_CALL(mName, message);

--- a/src/gpgmm/common/SlabMemoryAllocator.cpp
+++ b/src/gpgmm/common/SlabMemoryAllocator.cpp
@@ -100,7 +100,7 @@ namespace gpgmm {
         std::lock_guard<std::mutex> lock(mMutex);
 
         if (requestSize > mBlockSize) {
-            InfoEvent("SlabMemoryAllocator.TryAllocateMemory", ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED)
+            WarnEvent("SlabMemoryAllocator.TryAllocateMemory", ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED)
                 << "Allocation size exceeded the block size (" + std::to_string(requestSize) +
                        " vs " + std::to_string(mBlockSize) + " bytes).";
             return {};
@@ -108,7 +108,7 @@ namespace gpgmm {
 
         uint64_t slabSize = ComputeSlabSize(requestSize, std::max(mMinSlabSize, mLastUsedSlabSize));
         if (slabSize > mMaxSlabSize) {
-            InfoEvent("SlabMemoryAllocator.TryAllocateMemory", ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED)
+            WarnEvent("SlabMemoryAllocator.TryAllocateMemory", ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED)
                 << "Slab size exceeded the max slab size (" + std::to_string(slabSize) + " vs " +
                        std::to_string(mMaxSlabSize) + " bytes).";
             return {};

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -303,7 +303,7 @@ namespace gpgmm { namespace d3d12 {
             std::unique_ptr<MemoryAllocation> allocation = allocator->TryAllocateMemory(
                 size, alignment, neverAllocate, cacheSize, prefetchMemory);
             if (allocation == nullptr) {
-                InfoEvent("ResourceAllocator.TryAllocateResource",
+                WarnEvent("ResourceAllocator.TryAllocateResource",
                           ALLOCATOR_MESSAGE_ID_RESOURCE_ALLOCATION_FAILED)
                     << std::string(allocator->GetTypename()) +
                            " failed to allocate memory for resource.";
@@ -312,8 +312,8 @@ namespace gpgmm { namespace d3d12 {
             }
             HRESULT hr = createResourceFn(*allocation);
             if (FAILED(hr)) {
-                InfoEvent("ResourceAllocator.TryAllocateResource",
-                          ALLOCATOR_MESSAGE_ID_RESOURCE_ALLOCATION_FAILED)
+                ErrorEvent("ResourceAllocator.TryAllocateResource",
+                           ALLOCATOR_MESSAGE_ID_RESOURCE_ALLOCATION_FAILED)
                     << std::string(allocator->GetTypename()) +
                            " failed to create resource using allocated memory: " +
                            GetErrorMessage(hr);
@@ -820,12 +820,6 @@ namespace gpgmm { namespace d3d12 {
         // The time and space complexity of committed resource is driver-defined.
         if (neverAllocate) {
             return E_OUTOFMEMORY;
-        }
-
-        if (!mIsAlwaysCommitted) {
-            InfoEvent("ResourceAllocator.CreateResource",
-                      ALLOCATOR_MESSAGE_ID_RESOURCE_ALLOCATION_NON_POOLED)
-                << "Resource allocation could not be created from memory pool.";
         }
 
         ComPtr<ID3D12Resource> committedResource;

--- a/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.cpp
@@ -17,6 +17,7 @@
 
 #include "gpgmm/common/Debug.h"
 #include "gpgmm/d3d12/BackendD3D12.h"
+#include "gpgmm/d3d12/ErrorD3D12.h"
 #include "gpgmm/d3d12/HeapD3D12.h"
 #include "gpgmm/d3d12/ResidencyManagerD3D12.h"
 #include "gpgmm/d3d12/UtilsD3D12.h"
@@ -83,7 +84,10 @@ namespace gpgmm { namespace d3d12 {
         heapDesc.Flags = mHeapFlags;
 
         ComPtr<ID3D12Heap> heap;
-        if (FAILED(mDevice->CreateHeap(&heapDesc, IID_PPV_ARGS(&heap)))) {
+        HRESULT hr = mDevice->CreateHeap(&heapDesc, IID_PPV_ARGS(&heap));
+        if (FAILED(hr)) {
+            ErrorLog() << std::string(GetTypename())
+                       << " failed to create heap: " << GetErrorMessage(hr);
             return {};
         }
 

--- a/src/gpgmm/utils/Log.cpp
+++ b/src/gpgmm/utils/Log.cpp
@@ -136,6 +136,10 @@ namespace gpgmm {
                 ToString(std::this_thread::get_id()).c_str(), fullMessage.c_str());
         fflush(outputStream);
 #endif
+
+#if defined(GPGMM_ENABLE_ASSERT_ON_WARNING)
+        ASSERT(mSeverity < LogSeverity::Warning);
+#endif
     }
 
     LogMessage DebugLog() {

--- a/src/tests/capture_replay_tests/D3D12EventTraceReplay.cpp
+++ b/src/tests/capture_replay_tests/D3D12EventTraceReplay.cpp
@@ -16,6 +16,7 @@
 #include "tests/capture_replay_tests/GPGMMCaptureReplayTests.h"
 
 #include "gpgmm/common/TraceEventPhase.h"
+#include "gpgmm/d3d12/ErrorD3D12.h"
 #include "gpgmm/d3d12/UtilsD3D12.h"
 #include "gpgmm/utils/Log.h"
 #include "gpgmm/utils/PlatformTime.h"
@@ -182,7 +183,9 @@ class D3D12EventTraceReplay : public D3D12TestBase, public CaptureReplayTestWith
                         const double elapsedTime = mPlatformTime->EndElapsedTime();
 
                         if (!envParams.IsNeverAllocate && FAILED(hr)) {
-                            gpgmm::ErrorLog() << "CreateResource failed with :" << args << ".\n";
+                            gpgmm::ErrorLog()
+                                << "CreateResource failed. Reason: " << GetErrorMessage(hr)
+                                << ", CreationArgs:" << args << ".\n";
                         }
 
                         ASSERT_SUCCEEDED(hr);


### PR DESCRIPTION
* Displays HRESULT and message on replay failure.
* GPGMM_ENABLE_ASSERT_ON_WARNING now supports non-event logs.
* Raised severity where required.