### PR TITLE
Fix crash in ~Log when using GPGMM_ENABLE_ASSERT_ON_WARNING.

### DIFF
--- a/src/gpgmm/common/Debug.cpp
+++ b/src/gpgmm/common/Debug.cpp
@@ -32,6 +32,9 @@ namespace gpgmm {
     EventMessage::~EventMessage() {
         const std::string description = mStream.str();
 
+#if defined(GPGMM_ENABLE_ASSERT_ON_WARNING)
+        ASSERT(mSeverity < LogSeverity::Warning);
+#endif
         gpgmm::Log(mSeverity) << mName << ": " << description;
         if (mSeverity >= gRecordEventLevel) {
             LOG_MESSAGE message{description, mMessageId};

--- a/src/gpgmm/d3d12/DebugResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/DebugResourceAllocatorD3D12.cpp
@@ -51,11 +51,11 @@ namespace gpgmm { namespace d3d12 {
 
         for (auto allocationEntry : mLiveAllocations) {
             const ResourceAllocation* allocation = allocationEntry->GetValue().GetAllocation();
-            gpgmm::WarningLog() << "Live ResourceAllocation: "
-                                << "Addr=" << ToString(allocation) << ", "
-                                << "ExtRef=" << allocation->GetRefCount() << ", "
-                                << "Info="
-                                << JSONSerializer::Serialize(allocation->GetInfo()).ToString();
+            gpgmm::WarnEvent(allocation->GetAllocator()->GetTypename())
+                << "Live ResourceAllocation: "
+                << "Addr=" << ToString(allocation) << ", "
+                << "ExtRef=" << allocation->GetRefCount() << ", "
+                << "Info=" << JSONSerializer::Serialize(allocation->GetInfo()).ToString();
         }
     }
 

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -1017,8 +1017,8 @@ namespace gpgmm { namespace d3d12 {
             switch (message->ID) {
                 case D3D12_MESSAGE_ID_LIVE_HEAP:
                 case D3D12_MESSAGE_ID_LIVE_RESOURCE: {
-                    gpgmm::WarningLog()
-                        << "Device leak detected: " + std::string(message->pDescription);
+                    gpgmm::WarnEvent("Device")
+                        << "Leak detected: " + std::string(message->pDescription);
                 } break;
                 default:
                     break;

--- a/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.cpp
@@ -86,7 +86,7 @@ namespace gpgmm { namespace d3d12 {
         ComPtr<ID3D12Heap> heap;
         HRESULT hr = mDevice->CreateHeap(&heapDesc, IID_PPV_ARGS(&heap));
         if (FAILED(hr)) {
-            ErrorLog() << GetTypename() << " failed to create heap: " << GetErrorMessage(hr);
+            ErrorEvent(GetTypename()) << " failed to create heap: " << GetErrorMessage(hr);
             return {};
         }
 

--- a/src/gpgmm/utils/Log.cpp
+++ b/src/gpgmm/utils/Log.cpp
@@ -136,10 +136,6 @@ namespace gpgmm {
                 ToString(std::this_thread::get_id()).c_str(), fullMessage.c_str());
         fflush(outputStream);
 #endif
-
-#if defined(GPGMM_ENABLE_ASSERT_ON_WARNING)
-        ASSERT(mSeverity < LogSeverity::Warning);
-#endif
     }
 
     LogMessage DebugLog() {


### PR DESCRIPTION
* Move check outside of Log into Debug.cpp.
* Replaces use of Log with EventMessage where ASSERT is not desired.