### PR TITLE
Move per allocator trace counters into GetInfo().

### DIFF
--- a/src/gpgmm/common/SlabMemoryAllocator.cpp
+++ b/src/gpgmm/common/SlabMemoryAllocator.cpp
@@ -346,15 +346,6 @@ namespace gpgmm {
         // Hold onto the cached allocator until the last allocation gets deallocated.
         entry->Ref();
 
-        TRACE_COUNTER1(TraceEventCategory::Default, "GPU slab memory used (MB)",
-                       (GetFirstChild()->GetInfo().UsedMemoryUsage) / 1e6);
-
-        TRACE_COUNTER1(TraceEventCategory::Default, "GPU slab cache miss-rate (%)",
-                       SafeDivison(mSizeCache.GetStats().NumOfMisses,
-                                   static_cast<double>((mSizeCache.GetStats().NumOfHits +
-                                                        mSizeCache.GetStats().NumOfMisses))) *
-                           100);
-
         return std::make_unique<MemoryAllocation>(
             this, subAllocation->GetMemory(), subAllocation->GetOffset(),
             subAllocation->GetMethod(), subAllocation->GetBlock());
@@ -395,6 +386,15 @@ namespace gpgmm {
         result.FreeMemoryUsage = info.FreeMemoryUsage;
         result.UsedMemoryCount = info.UsedMemoryCount;
         result.UsedMemoryUsage = info.UsedMemoryUsage;
+
+        TRACE_COUNTER1(TraceEventCategory::Default, "GPU slab memory used (MB)",
+                       (info.UsedMemoryUsage) / 1e6);
+
+        TRACE_COUNTER1(TraceEventCategory::Default, "GPU slab cache miss-rate (%)",
+                       SafeDivison(mSizeCache.GetStats().NumOfMisses,
+                                   static_cast<double>((mSizeCache.GetStats().NumOfHits +
+                                                        mSizeCache.GetStats().NumOfMisses))) *
+                           100);
 
         return result;
     }

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -627,20 +627,9 @@ namespace gpgmm { namespace d3d12 {
         TRACE_COUNTER1(TraceEventCategory::Default, "GPU allocation latency (us)",
                        allocationLatency);
 
-        const RESOURCE_ALLOCATOR_INFO info = GetInfo();
-        GPGMM_UNUSED(info);
-
-        TRACE_COUNTER1(TraceEventCategory::Default, "GPU memory unused (MB)",
-                       (info.UsedMemoryUsage - info.UsedBlockUsage) / 1e6);
-
-        TRACE_COUNTER1(
-            TraceEventCategory::Default, "GPU memory utilization (%)",
-            SafeDivison(info.UsedMemoryUsage,
-                        static_cast<double>(info.UsedMemoryUsage + info.FreeMemoryUsage)) *
-                100);
-
-        TRACE_COUNTER1(TraceEventCategory::Default, "GPU memory free (MB)",
-                       info.FreeMemoryUsage / 1e6);
+        if (IsEventTraceEnabled()) {
+            GetInfo();
+        }
 
         // Insert a new (debug) allocator layer into the allocation so it can report details used
         // during leak checks. Since we don't want to use it unless we are debugging, we hide it
@@ -985,6 +974,18 @@ namespace gpgmm { namespace d3d12 {
         for (const auto& allocator : mResourceHeapAllocatorOfType) {
             result += allocator->GetInfo();
         }
+
+        TRACE_COUNTER1(TraceEventCategory::Default, "GPU memory unused (MB)",
+                       (result.UsedMemoryUsage - result.UsedBlockUsage) / 1e6);
+
+        TRACE_COUNTER1(
+            TraceEventCategory::Default, "GPU memory utilization (%)",
+            SafeDivison(result.UsedMemoryUsage,
+                        static_cast<double>(result.UsedMemoryUsage + result.FreeMemoryUsage)) *
+                100);
+
+        TRACE_COUNTER1(TraceEventCategory::Default, "GPU memory free (MB)",
+                       result.FreeMemoryUsage / 1e6);
 
         return result;
     }


### PR DESCRIPTION
Ensure the parent updates the child allocator counters before reporting them itself.