### PR TITLE
Specify slab block size based on request.

### DIFF
--- a/src/gpgmm/common/SlabMemoryAllocator.cpp
+++ b/src/gpgmm/common/SlabMemoryAllocator.cpp
@@ -311,8 +311,7 @@ namespace gpgmm {
 
     // SlabCacheAllocator
 
-    SlabCacheAllocator::SlabCacheAllocator(uint64_t minBlockSize,
-                                           uint64_t maxSlabSize,
+    SlabCacheAllocator::SlabCacheAllocator(uint64_t maxSlabSize,
                                            uint64_t minSlabSize,
                                            uint64_t slabAlignment,
                                            double slabFragmentationLimit,
@@ -320,7 +319,6 @@ namespace gpgmm {
                                            double slabGrowthFactor,
                                            std::unique_ptr<MemoryAllocator> memoryAllocator)
         : MemoryAllocator(std::move(memoryAllocator)),
-          mMinBlockSize(minBlockSize),
           mMaxSlabSize(maxSlabSize),
           mMinSlabSize(minSlabSize),
           mSlabAlignment(slabAlignment),
@@ -347,7 +345,7 @@ namespace gpgmm {
 
         GPGMM_CHECK_NONZERO(requestSize);
 
-        const uint64_t blockSize = AlignTo(requestSize, mMinBlockSize);
+        const uint64_t blockSize = AlignTo(requestSize, alignment);
 
         // Create a slab allocator for the new entry.
         auto entry = mSizeCache.GetOrCreate(SlabAllocatorCacheEntry(blockSize), cacheSize);

--- a/src/gpgmm/common/SlabMemoryAllocator.h
+++ b/src/gpgmm/common/SlabMemoryAllocator.h
@@ -134,8 +134,7 @@ namespace gpgmm {
     // fixed-sized slabs.
     class SlabCacheAllocator : public MemoryAllocator {
       public:
-        SlabCacheAllocator(uint64_t minBlockSize,
-                           uint64_t maxSlabSize,
+        SlabCacheAllocator(uint64_t maxSlabSize,
                            uint64_t minSlabSize,
                            uint64_t slabAlignment,
                            double slabFragmentationLimit,
@@ -177,7 +176,6 @@ namespace gpgmm {
             const uint64_t mBlockSize;
         };
 
-        const uint64_t mMinBlockSize;
         const uint64_t mMaxSlabSize;
         const uint64_t mMinSlabSize;
         const uint64_t mSlabAlignment;

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -459,7 +459,6 @@ namespace gpgmm { namespace d3d12 {
                 // TODO: Re-enable the buddy allocator?
                 mResourceAllocatorOfType[resourceHeapTypeIndex] = std::make_unique<
                     SlabCacheAllocator>(
-                    /*minBlockSize*/ D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT,
                     /*maxSlabSize*/ PrevPowerOfTwo(mMaxResourceHeapSize),
                     /*minSlabSize*/ std::max(heapAlignment, descriptor.PreferredResourceHeapSize),
                     /*slabAlignment*/ heapAlignment,
@@ -511,7 +510,6 @@ namespace gpgmm { namespace d3d12 {
                 // fragment by definition.
                 mBufferAllocatorOfType[resourceHeapTypeIndex] =
                     std::make_unique<SlabCacheAllocator>(
-                        /*minBlockSize*/ 1,
                         /*maxSlabSize*/ D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT,
                         /*slabSize*/ D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT,
                         /*slabAlignment*/ D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT,


### PR DESCRIPTION
Removes the min. block size from SlabCacheAllocator by using the requested size-aligned value instead. This allows backends to use smaller (or larger) page sizes as needed.