### PR TITLE
Replace ALLOCATOR_MESSAGE_SEVERITY with D3D12_MESSAGE_SEVERITY.

### DIFF
--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -178,6 +178,23 @@ namespace gpgmm { namespace d3d12 {
             }
         }
 
+        LogSeverity GetLogSeverity(D3D12_MESSAGE_SEVERITY messageSeverity) {
+            switch (messageSeverity) {
+                case D3D12_MESSAGE_SEVERITY_CORRUPTION:
+                case D3D12_MESSAGE_SEVERITY_ERROR:
+                    return LogSeverity::Error;
+                case D3D12_MESSAGE_SEVERITY_WARNING:
+                    return LogSeverity::Warning;
+                case D3D12_MESSAGE_SEVERITY_INFO:
+                    return LogSeverity::Info;
+                case D3D12_MESSAGE_SEVERITY_MESSAGE:
+                    return LogSeverity::Debug;
+                default:
+                    UNREACHABLE();
+                    return LogSeverity::Debug;
+            }
+        }
+
         // https://docs.microsoft.com/en-us/windows/win32/api/d3d12/ne-d3d12-d3d12_heap_flags
         uint64_t GetHeapAlignment(D3D12_HEAP_FLAGS heapFlags) {
             const D3D12_HEAP_FLAGS denyAllTexturesFlags =
@@ -366,14 +383,10 @@ namespace gpgmm { namespace d3d12 {
                 !(newDescriptor.RecordOptions.Flags & ALLOCATOR_RECORD_FLAG_API_CALLS),
                 !(newDescriptor.RecordOptions.Flags & ALLOCATOR_RECORD_FLAG_COUNTERS));
 
-            const LogSeverity& recordMessageMinLevel =
-                static_cast<LogSeverity>(newDescriptor.RecordOptions.MinMessageLevel);
-
-            SetEventMessageLevel(recordMessageMinLevel);
+            SetEventMessageLevel(GetLogSeverity(newDescriptor.RecordOptions.MinMessageLevel));
         }
 
-        const LogSeverity& logLevel = static_cast<LogSeverity>(newDescriptor.MinLogLevel);
-        SetLogMessageLevel(logLevel);
+        SetLogMessageLevel(GetLogSeverity(newDescriptor.MinLogLevel));
 
 #if defined(GPGMM_ENABLE_DEVICE_CHECKS)
         ComPtr<ID3D12InfoQueue> leakMessageQueue;

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -75,35 +75,6 @@ namespace gpgmm { namespace d3d12 {
     using ALLOCATOR_FLAGS_TYPE = Flags<ALLOCATOR_FLAGS>;
     DEFINE_OPERATORS_FOR_FLAGS(ALLOCATOR_FLAGS_TYPE)
 
-    /** \enum ALLOCATOR_MESSAGE_SEVERITY
-    Represents different severity levels used for logging.
-    */
-    enum ALLOCATOR_MESSAGE_SEVERITY {
-        /** \brief Message (or debug) severity.
-
-        Message is for debugging purposes only.
-        */
-        ALLOCATOR_MESSAGE_SEVERITY_MESSAGE = 0x0,
-
-        /** \brief Info severity.
-
-        Message is for informational purposes only.
-        */
-        ALLOCATOR_MESSAGE_SEVERITY_INFO = 0x1,
-
-        /** \brief Warning severity.
-
-        A non-fatal message that does not abort execution.
-        */
-        ALLOCATOR_MESSAGE_SEVERITY_WARNING = 0x2,
-
-        /** \brief Error severity.
-
-        A fatal message will abort execution.
-        */
-        ALLOCATOR_MESSAGE_SEVERITY_ERROR = 0x3,
-    };
-
     /** \enum ALLOCATOR_RECORD_FLAGS
     Represents different event categories to record.
     */
@@ -177,7 +148,7 @@ namespace gpgmm { namespace d3d12 {
 
         Optional parameter. By default, the minimum severity level is WARN.
         */
-        ALLOCATOR_MESSAGE_SEVERITY MinMessageLevel = ALLOCATOR_MESSAGE_SEVERITY_WARNING;
+        D3D12_MESSAGE_SEVERITY MinMessageLevel = D3D12_MESSAGE_SEVERITY_WARNING;
 
         /** \brief Specifies the scope of the events.
 
@@ -219,7 +190,7 @@ namespace gpgmm { namespace d3d12 {
 
         Messages with lower severity will be ignored.
         */
-        ALLOCATOR_MESSAGE_SEVERITY MinLogLevel = ALLOCATOR_MESSAGE_SEVERITY_WARNING;
+        D3D12_MESSAGE_SEVERITY MinLogLevel = D3D12_MESSAGE_SEVERITY_WARNING;
 
         /** \brief Specifies recording options.
 

--- a/src/tests/D3D12Test.cpp
+++ b/src/tests/D3D12Test.cpp
@@ -70,9 +70,9 @@ namespace gpgmm { namespace d3d12 {
         }
 
 #if defined(NDEBUG)
-        desc.MinLogLevel = ALLOCATOR_MESSAGE_SEVERITY_WARNING;
+        desc.MinLogLevel = D3D12_MESSAGE_SEVERITY_WARNING;
 #else
-        desc.MinLogLevel = ALLOCATOR_MESSAGE_SEVERITY_MESSAGE;
+        desc.MinLogLevel = D3D12_MESSAGE_SEVERITY_MESSAGE;
 #endif
 
         return desc;

--- a/src/tests/capture_replay_tests/D3D12EventTraceReplay.cpp
+++ b/src/tests/capture_replay_tests/D3D12EventTraceReplay.cpp
@@ -326,8 +326,7 @@ class D3D12EventTraceReplay : public D3D12TestBase, public CaptureReplayTestWith
                             allocatorDesc.RecordOptions.Flags |= ALLOCATOR_RECORD_FLAG_CAPTURE;
                             allocatorDesc.RecordOptions.TraceFile = traceFile.path;
                             allocatorDesc.RecordOptions.MinMessageLevel =
-                                static_cast<ALLOCATOR_MESSAGE_SEVERITY>(
-                                    envParams.EventMessageLevel);
+                                static_cast<D3D12_MESSAGE_SEVERITY>(envParams.EventMessageLevel);
 
                             // Keep recording across multiple playback iterations to ensure all
                             // events will be captured instead of overwritten per iteration.
@@ -338,7 +337,7 @@ class D3D12EventTraceReplay : public D3D12TestBase, public CaptureReplayTestWith
                         }
 
                         allocatorDesc.MinLogLevel =
-                            static_cast<ALLOCATOR_MESSAGE_SEVERITY>(envParams.LogLevel);
+                            static_cast<D3D12_MESSAGE_SEVERITY>(envParams.LogLevel);
 
                         if (envParams.LogLevel <= gpgmm::LogSeverity::Warning &&
                             allocatorDesc.IsUMA != snapshot["IsUMA"].asBool() &&


### PR DESCRIPTION
Reuse the built-in D3D12 message type instead of re-defining one for GPGMM.