### PR TITLE
Move TryAllocateMemory args into MEMORY_ALLOCATION_REQUEST struct.

### DIFF
--- a/src/gpgmm/common/BuddyMemoryAllocator.h
+++ b/src/gpgmm/common/BuddyMemoryAllocator.h
@@ -43,11 +43,8 @@ namespace gpgmm {
                              std::unique_ptr<MemoryAllocator> memoryAllocator);
 
         // MemoryAllocator interface
-        std::unique_ptr<MemoryAllocation> TryAllocateMemory(uint64_t requestSize,
-                                                            uint64_t alignment,
-                                                            bool neverAllocate,
-                                                            bool cacheSize,
-                                                            bool prefetchMemory) override;
+        std::unique_ptr<MemoryAllocation> TryAllocateMemory(
+            const MEMORY_ALLOCATION_REQUEST& request) override;
         void DeallocateMemory(std::unique_ptr<MemoryAllocation> subAllocation) override;
 
         uint64_t GetMemorySize() const override;

--- a/src/gpgmm/common/ConditionalMemoryAllocator.cpp
+++ b/src/gpgmm/common/ConditionalMemoryAllocator.cpp
@@ -29,19 +29,13 @@ namespace gpgmm {
     }
 
     std::unique_ptr<MemoryAllocation> ConditionalMemoryAllocator::TryAllocateMemory(
-        uint64_t requestSize,
-        uint64_t alignment,
-        bool neverAllocate,
-        bool cacheSize,
-        bool prefetchMemory) {
+        const MEMORY_ALLOCATION_REQUEST& request) {
         TRACE_EVENT0(TraceEventCategory::Default, "ConditionalMemoryAllocator.TryAllocateMemory");
 
-        if (requestSize <= mConditionalSize) {
-            return mFirstAllocator->TryAllocateMemory(requestSize, alignment, neverAllocate,
-                                                      cacheSize, prefetchMemory);
+        if (request.SizeInBytes <= mConditionalSize) {
+            return mFirstAllocator->TryAllocateMemory(request);
         } else {
-            return mSecondAllocator->TryAllocateMemory(requestSize, alignment, neverAllocate,
-                                                       cacheSize, prefetchMemory);
+            return mSecondAllocator->TryAllocateMemory(request);
         }
     }
 

--- a/src/gpgmm/common/ConditionalMemoryAllocator.h
+++ b/src/gpgmm/common/ConditionalMemoryAllocator.h
@@ -30,11 +30,8 @@ namespace gpgmm {
         ~ConditionalMemoryAllocator() override = default;
 
         // MemoryAllocator interface
-        std::unique_ptr<MemoryAllocation> TryAllocateMemory(uint64_t requestSize,
-                                                            uint64_t alignment,
-                                                            bool neverAllocate,
-                                                            bool cacheSize,
-                                                            bool prefetchMemory) override;
+        std::unique_ptr<MemoryAllocation> TryAllocateMemory(
+            const MEMORY_ALLOCATION_REQUEST& request) override;
         void DeallocateMemory(std::unique_ptr<MemoryAllocation> allocation) override;
 
         MEMORY_ALLOCATOR_INFO GetInfo() const override;

--- a/src/gpgmm/common/MemoryAllocator.cpp
+++ b/src/gpgmm/common/MemoryAllocator.cpp
@@ -18,13 +18,12 @@ namespace gpgmm {
 
     class AllocateMemoryTask : public VoidCallback {
       public:
-        AllocateMemoryTask(MemoryAllocator* allocator, uint64_t requestSize, uint64_t alignment)
-            : mAllocator(allocator), mRequestSize(requestSize), mAlignment(alignment) {
+        AllocateMemoryTask(MemoryAllocator* allocator, const MEMORY_ALLOCATION_REQUEST& request)
+            : mAllocator(allocator), mRequest(request) {
         }
 
         void operator()() override {
-            mAllocation = mAllocator->TryAllocateMemory(mRequestSize, mAlignment, /*neverAllocate*/
-                                                        false, true, false);
+            mAllocation = mAllocator->TryAllocateMemory(mRequest);
         }
 
         std::unique_ptr<MemoryAllocation> AcquireAllocation() {
@@ -33,8 +32,7 @@ namespace gpgmm {
 
       private:
         MemoryAllocator* const mAllocator;
-        const uint64_t mRequestSize;
-        const uint64_t mAlignment;
+        const MEMORY_ALLOCATION_REQUEST mRequest;
 
         std::unique_ptr<MemoryAllocation> mAllocation;
     };
@@ -81,20 +79,16 @@ namespace gpgmm {
         }
     }
 
-    std::unique_ptr<MemoryAllocation> MemoryAllocator::TryAllocateMemory(uint64_t requestSize,
-                                                                         uint64_t alignment,
-                                                                         bool neverAllocate,
-                                                                         bool cacheSize,
-                                                                         bool prefetchMemory) {
+    std::unique_ptr<MemoryAllocation> MemoryAllocator::TryAllocateMemory(
+        const MEMORY_ALLOCATION_REQUEST& request) {
         ASSERT(false);
         return {};
     }
 
     std::shared_ptr<MemoryAllocationEvent> MemoryAllocator::TryAllocateMemoryAsync(
-        uint64_t size,
-        uint64_t alignment) {
+        const MEMORY_ALLOCATION_REQUEST& request) {
         std::shared_ptr<AllocateMemoryTask> task =
-            std::make_shared<AllocateMemoryTask>(this, size, alignment);
+            std::make_shared<AllocateMemoryTask>(this, request);
         return std::make_shared<MemoryAllocationEvent>(ThreadPool::PostTask(mThreadPool, task),
                                                        task);
     }

--- a/src/gpgmm/common/PooledMemoryAllocator.cpp
+++ b/src/gpgmm/common/PooledMemoryAllocator.cpp
@@ -27,20 +27,14 @@ namespace gpgmm {
     }
 
     std::unique_ptr<MemoryAllocation> PooledMemoryAllocator::TryAllocateMemory(
-        uint64_t requestSize,
-        uint64_t alignment,
-        bool neverAllocate,
-        bool cacheSize,
-        bool prefetchMemory) {
+        const MEMORY_ALLOCATION_REQUEST& request) {
         TRACE_EVENT0(TraceEventCategory::Default, "PooledMemoryAllocator.TryAllocateMemory");
 
         std::lock_guard<std::mutex> lock(mMutex);
 
         std::unique_ptr<MemoryAllocation> allocation = mPool->AcquireFromPool();
         if (allocation == nullptr) {
-            GPGMM_TRY_ASSIGN(GetNextInChain()->TryAllocateMemory(
-                                 requestSize, alignment, neverAllocate, cacheSize, prefetchMemory),
-                             allocation);
+            GPGMM_TRY_ASSIGN(GetNextInChain()->TryAllocateMemory(request), allocation);
         } else {
             mInfo.FreeMemoryUsage -= allocation->GetSize();
         }

--- a/src/gpgmm/common/PooledMemoryAllocator.h
+++ b/src/gpgmm/common/PooledMemoryAllocator.h
@@ -28,11 +28,8 @@ namespace gpgmm {
         ~PooledMemoryAllocator() override = default;
 
         // MemoryAllocator interface
-        std::unique_ptr<MemoryAllocation> TryAllocateMemory(uint64_t requestSize,
-                                                            uint64_t alignment,
-                                                            bool neverAllocate,
-                                                            bool cacheSize,
-                                                            bool prefetchMemory) override;
+        std::unique_ptr<MemoryAllocation> TryAllocateMemory(
+            const MEMORY_ALLOCATION_REQUEST& request) override;
         void DeallocateMemory(std::unique_ptr<MemoryAllocation> allocation) override;
         uint64_t GetMemorySize() const override;
         const char* GetTypename() const override;

--- a/src/gpgmm/common/SegmentedMemoryAllocator.h
+++ b/src/gpgmm/common/SegmentedMemoryAllocator.h
@@ -39,11 +39,8 @@ namespace gpgmm {
         ~SegmentedMemoryAllocator() override;
 
         // MemoryAllocator interface
-        std::unique_ptr<MemoryAllocation> TryAllocateMemory(uint64_t requestSize,
-                                                            uint64_t alignment,
-                                                            bool neverAllocate,
-                                                            bool cacheSize,
-                                                            bool prefetchMemory) override;
+        std::unique_ptr<MemoryAllocation> TryAllocateMemory(
+            const MEMORY_ALLOCATION_REQUEST& request) override;
         void DeallocateMemory(std::unique_ptr<MemoryAllocation> allocation) override;
         void ReleaseMemory() override;
         uint64_t GetMemoryAlignment() const override;

--- a/src/gpgmm/common/SlabMemoryAllocator.h
+++ b/src/gpgmm/common/SlabMemoryAllocator.h
@@ -55,11 +55,8 @@ namespace gpgmm {
         ~SlabMemoryAllocator() override;
 
         // MemoryAllocator interface
-        std::unique_ptr<MemoryAllocation> TryAllocateMemory(uint64_t requestSize,
-                                                            uint64_t alignment,
-                                                            bool neverAllocate,
-                                                            bool cacheSize,
-                                                            bool prefetchMemory) override;
+        std::unique_ptr<MemoryAllocation> TryAllocateMemory(
+            const MEMORY_ALLOCATION_REQUEST& request) override;
         void DeallocateMemory(std::unique_ptr<MemoryAllocation> allocation) override;
 
         MEMORY_ALLOCATOR_INFO GetInfo() const override;
@@ -121,7 +118,7 @@ namespace gpgmm {
         const uint64_t mMinSlabSize;  // Optional size when non-zero.
 
         const double mSlabFragmentationLimit;
-        const bool mPrefetchSlab;
+        const bool mAlwaysPrefetchSlab;
         const double mSlabGrowthFactor;
 
         MemoryAllocator* mMemoryAllocator = nullptr;
@@ -136,18 +133,15 @@ namespace gpgmm {
                            uint64_t minSlabSize,
                            uint64_t slabAlignment,
                            double slabFragmentationLimit,
-                           bool prefetchSlab,
+                           bool alwaysPrefetchSlab,
                            double slabGrowthFactor,
                            std::unique_ptr<MemoryAllocator> memoryAllocator);
 
         ~SlabCacheAllocator() override;
 
         // MemoryAllocator interface
-        std::unique_ptr<MemoryAllocation> TryAllocateMemory(uint64_t requestSize,
-                                                            uint64_t alignment,
-                                                            bool neverAllocate,
-                                                            bool cacheSize,
-                                                            bool prefetchMemory) override;
+        std::unique_ptr<MemoryAllocation> TryAllocateMemory(
+            const MEMORY_ALLOCATION_REQUEST& request) override;
         void DeallocateMemory(std::unique_ptr<MemoryAllocation> allocation) override;
 
         MEMORY_ALLOCATOR_INFO GetInfo() const override;
@@ -177,7 +171,7 @@ namespace gpgmm {
         const uint64_t mSlabAlignment;
 
         const double mSlabFragmentationLimit;
-        const bool mPrefetchSlab;
+        const bool mAlwaysPrefetchSlab;
         const double mSlabGrowthFactor;
 
         LinkedList<MemoryAllocator> mSlabAllocators;

--- a/src/gpgmm/common/StandaloneMemoryAllocator.h
+++ b/src/gpgmm/common/StandaloneMemoryAllocator.h
@@ -27,11 +27,8 @@ namespace gpgmm {
         StandaloneMemoryAllocator(std::unique_ptr<MemoryAllocator> memoryAllocator);
 
         // MemoryAllocator interface
-        std::unique_ptr<MemoryAllocation> TryAllocateMemory(uint64_t requestSize,
-                                                            uint64_t alignment,
-                                                            bool neverAllocate,
-                                                            bool cacheSize,
-                                                            bool prefetchMemory) override;
+        std::unique_ptr<MemoryAllocation> TryAllocateMemory(
+            const MEMORY_ALLOCATION_REQUEST& request) override;
         void DeallocateMemory(std::unique_ptr<MemoryAllocation> subAllocation) override;
 
         MEMORY_ALLOCATOR_INFO GetInfo() const override;

--- a/src/gpgmm/d3d12/BufferAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/BufferAllocatorD3D12.h
@@ -34,11 +34,8 @@ namespace gpgmm { namespace d3d12 {
         ~BufferAllocator() override = default;
 
         // MemoryAllocator interface
-        std::unique_ptr<MemoryAllocation> TryAllocateMemory(uint64_t requestSize,
-                                                            uint64_t alignment,
-                                                            bool neverAllocate,
-                                                            bool cacheSize,
-                                                            bool prefetchMemory) override;
+        std::unique_ptr<MemoryAllocation> TryAllocateMemory(
+            const MEMORY_ALLOCATION_REQUEST& request) override;
         void DeallocateMemory(std::unique_ptr<MemoryAllocation> allocation) override;
 
         uint64_t GetMemorySize() const override;

--- a/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.h
@@ -35,11 +35,8 @@ namespace gpgmm { namespace d3d12 {
         ~ResourceHeapAllocator() override = default;
 
         // MemoryAllocator interface
-        std::unique_ptr<MemoryAllocation> TryAllocateMemory(uint64_t requestSize,
-                                                            uint64_t alignment,
-                                                            bool neverAllocate,
-                                                            bool cacheSize,
-                                                            bool prefetchMemory) override;
+        std::unique_ptr<MemoryAllocation> TryAllocateMemory(
+            const MEMORY_ALLOCATION_REQUEST& request) override;
         void DeallocateMemory(std::unique_ptr<MemoryAllocation> allocation) override;
 
         const char* GetTypename() const override;

--- a/src/gpgmm/vk/DeviceMemoryAllocatorVk.h
+++ b/src/gpgmm/vk/DeviceMemoryAllocatorVk.h
@@ -30,11 +30,8 @@ namespace gpgmm { namespace vk {
         ~DeviceMemoryAllocator() override = default;
 
         // MemoryAllocator interface
-        std::unique_ptr<MemoryAllocation> TryAllocateMemory(uint64_t requestSize,
-                                                            uint64_t alignment,
-                                                            bool neverAllocate,
-                                                            bool cacheSize,
-                                                            bool prefetchMemory) override;
+        std::unique_ptr<MemoryAllocation> TryAllocateMemory(
+            const MEMORY_ALLOCATION_REQUEST& request) override;
         void DeallocateMemory(std::unique_ptr<MemoryAllocation> allocation) override;
 
       private:

--- a/src/gpgmm/vk/ResourceAllocatorVk.cpp
+++ b/src/gpgmm/vk/ResourceAllocatorVk.cpp
@@ -222,10 +222,15 @@ namespace gpgmm { namespace vk {
             FindMemoryTypeIndex(requirements.memoryTypeBits, allocationInfo, &memoryTypeIndex));
 
         MemoryAllocator* allocator = mDeviceAllocatorsPerType[memoryTypeIndex].get();
-        std::unique_ptr<MemoryAllocation> memoryAllocation = allocator->TryAllocateMemory(
-            requirements.size, requirements.alignment,
-            (allocationInfo.flags & GP_ALLOCATION_FLAG_NEVER_ALLOCATE_MEMORY), /*cacheSize*/ false,
-            (allocationInfo.flags & GP_ALLOCATION_FLAG_ALWAYS_PREFETCH_MEMORY));
+
+        MEMORY_ALLOCATION_REQUEST request = {};
+        request.SizeInBytes = requirements.size;
+        request.Alignment = requirements.alignment;
+        request.NeverAllocate = (allocationInfo.flags & GP_ALLOCATION_FLAG_NEVER_ALLOCATE_MEMORY);
+        request.CacheSize = false;
+        request.AlwaysPrefetch = (allocationInfo.flags & GP_ALLOCATION_FLAG_ALWAYS_PREFETCH_MEMORY);
+
+        std::unique_ptr<MemoryAllocation> memoryAllocation = allocator->TryAllocateMemory(request);
         if (memoryAllocation == nullptr) {
             InfoEvent("GpResourceAllocator.TryAllocateResource",
                       ALLOCATOR_MESSAGE_ID_ALLOCATOR_FAILED)

--- a/src/tests/DummyMemoryAllocator.h
+++ b/src/tests/DummyMemoryAllocator.h
@@ -29,22 +29,19 @@ namespace gpgmm {
             : MemoryAllocator(std::move(next)) {
         }
 
-        std::unique_ptr<MemoryAllocation> TryAllocateMemory(uint64_t requestSize,
-                                                            uint64_t alignment,
-                                                            bool neverAllocate,
-                                                            bool cacheSize,
-                                                            bool prefetchMemory) override {
+        std::unique_ptr<MemoryAllocation> TryAllocateMemory(
+            const MEMORY_ALLOCATION_REQUEST& request) override {
             TRACE_EVENT0(TraceEventCategory::Default, "DummyMemoryAllocator.TryAllocateMemory");
 
             std::lock_guard<std::mutex> lock(mMutex);
 
-            if (neverAllocate) {
+            if (request.NeverAllocate) {
                 return {};
             }
 
             mInfo.UsedMemoryCount++;
-            mInfo.UsedMemoryUsage += requestSize;
-            return std::make_unique<MemoryAllocation>(this, new MemoryBase(requestSize));
+            mInfo.UsedMemoryUsage += request.SizeInBytes;
+            return std::make_unique<MemoryAllocation>(this, new MemoryBase(request.SizeInBytes));
         }
 
         void DeallocateMemory(std::unique_ptr<MemoryAllocation> allocation) override {


### PR DESCRIPTION
Allows for easier adding/removing of new args with documentation.