### PR TITLE
Disable slab growth when over budget.

### DIFF
--- a/src/gpgmm/common/MemoryAllocator.h
+++ b/src/gpgmm/common/MemoryAllocator.h
@@ -109,6 +109,12 @@ namespace gpgmm {
         on the requested size.
         */
         bool AlwaysPrefetch;
+
+        /** \brief Memory available for the allocation.
+
+        A value of 0 means there is no memory available left to allocate from.
+        */
+        uint64_t AvailableForAllocation;
     };
 
     class MemoryAllocator : public AllocatorBase, public AllocatorNode<MemoryAllocator> {

--- a/src/gpgmm/common/SlabMemoryAllocator.h
+++ b/src/gpgmm/common/SlabMemoryAllocator.h
@@ -61,6 +61,8 @@ namespace gpgmm {
 
         MEMORY_ALLOCATOR_INFO GetInfo() const override;
 
+        const char* GetTypename() const override;
+
       private:
         uint64_t ComputeSlabSize(uint64_t requestSize, uint64_t slabSize) const;
 
@@ -152,9 +154,9 @@ namespace gpgmm {
 
         uint64_t GetMemorySize() const override;
 
+      private:
         const char* GetTypename() const override;
 
-      private:
         class SlabAllocatorCacheEntry : public NonCopyable {
           public:
             explicit SlabAllocatorCacheEntry(uint64_t blockSize) : mBlockSize(blockSize) {

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.h
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.h
@@ -158,6 +158,15 @@ namespace gpgmm { namespace d3d12 {
                                           uint64_t reservation,
                                           uint64_t* reservationOut = nullptr);
 
+        /** \brief  Get the current budget and memory usage.
+
+        @param memorySegmentGroup Memory segment to retrieve info from.
+
+        \return A pointer to DXGI_QUERY_VIDEO_MEMORY_INFO struct of the video memory segment info.
+        */
+        DXGI_QUERY_VIDEO_MEMORY_INFO* GetVideoMemoryInfo(
+            const DXGI_MEMORY_SEGMENT_GROUP& memorySegmentGroup);
+
       private:
         ResidencyManager(const RESIDENCY_DESC& descriptor, std::unique_ptr<Fence> fence);
 
@@ -180,9 +189,6 @@ namespace gpgmm { namespace d3d12 {
                              uint64_t sizeToMakeResident,
                              uint32_t numberOfObjectsToMakeResident,
                              ID3D12Pageable** allocations);
-
-        DXGI_QUERY_VIDEO_MEMORY_INFO* GetVideoMemorySegmentInfo(
-            const DXGI_MEMORY_SEGMENT_GROUP& memorySegmentGroup);
 
         LRUCache* GetVideoMemorySegmentCache(const DXGI_MEMORY_SEGMENT_GROUP& memorySegmentGroup);
 

--- a/src/tests/unittests/SlabMemoryAllocatorTests.cpp
+++ b/src/tests/unittests/SlabMemoryAllocatorTests.cpp
@@ -43,6 +43,7 @@ class SlabMemoryAllocatorTests : public testing::Test {
         request.NeverAllocate = neverAllocate;
         request.CacheSize = false;
         request.AlwaysPrefetch = false;
+        request.AvailableForAllocation = kInvalidSize;
         return request;
     }
 };


### PR DESCRIPTION
Using larger slabs when over budget is counter productive since it also increases the number of previous slabs to be paged-out before the new largest one can be allocated.