### PR TITLE
Restrict D3D12EventTraceReplay.AllocationPerf to a single iteration.

### DIFF
--- a/src/tests/capture_replay_tests/D3D12EventTraceReplay.cpp
+++ b/src/tests/capture_replay_tests/D3D12EventTraceReplay.cpp
@@ -442,7 +442,6 @@ class D3D12EventTraceReplay : public D3D12TestBase, public CaptureReplayTestWith
 
 TEST_P(D3D12EventTraceReplay, AllocationPerf) {
     TestEnviromentParams forceParams = {};
-    forceParams.Iterations = 100;
     forceParams.PrefetchMemory = true;
     RunTestLoop(forceParams);
 


### PR DESCRIPTION
Runtime becomes too long with longer traces.