### PR TITLE
Update residency budget after UpdateVideoMemorySegments.

### DIFF
--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.h
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.h
@@ -199,7 +199,7 @@ namespace gpgmm { namespace d3d12 {
         std::unique_ptr<Fence> mFence;
 
         const float mVideoMemoryBudget;
-        const uint64_t mBudget;
+        const bool mIsBudgetRestricted;
         const uint64_t mEvictBatchSize;
         const bool mIsUMA;
 


### PR DESCRIPTION
If a budget was specified to the residency manager, the actual budget didn't include the current usage since the video memory usage was updated after this was set.