### PR TITLE
Fix ASSERT in CreateBufferOversized.

### DIFF
--- a/src/gpgmm/common/MemoryAllocator.h
+++ b/src/gpgmm/common/MemoryAllocator.h
@@ -186,9 +186,9 @@ namespace gpgmm {
             ASSERT(memory != nullptr);
             memory->Ref();
 
-            // Calling memory allocator must be responsible in fully initializing the memory
-            // allocation. This is because we do not yet know how to map the sub-allocated block to
-            // memory.
+            // Caller is be responsible in fully initializing the memory allocation.
+            // This is because TrySubAllocateMemory() does not necessarily know how to map the
+            // final sub-allocated block to created memory.
             return std::make_unique<MemoryAllocation>(nullptr, memory, kInvalidOffset,
                                                       AllocationMethod::kUndefined, block);
         }

--- a/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.cpp
@@ -82,7 +82,7 @@ namespace gpgmm { namespace d3d12 {
         ComPtr<ID3D12Heap> heap;
         HRESULT hr = mDevice->CreateHeap(&heapDesc, IID_PPV_ARGS(&heap));
         if (FAILED(hr)) {
-            ErrorEvent(GetTypename()) << " failed to create heap: " << GetErrorMessage(hr);
+            InfoEvent(GetTypename()) << " failed to create heap: " << GetErrorMessage(hr);
             return {};
         }
 


### PR DESCRIPTION
Reduces the log severity so the test fails expectedly on non-WARP devices.