### PR TITLE
Replace unsafe GetHeap() with As().

### DIFF
--- a/src/gpgmm/d3d12/HeapD3D12.cpp
+++ b/src/gpgmm/d3d12/HeapD3D12.cpp
@@ -75,16 +75,6 @@ namespace gpgmm { namespace d3d12 {
         return "Heap";
     }
 
-    ComPtr<ID3D12Pageable> Heap::GetPageable() const {
-        return mPageable;
-    }
-
-    ID3D12Heap* Heap::GetHeap() const {
-        ComPtr<ID3D12Heap> heap;
-        mPageable.As(&heap);
-        return heap.Get();
-    }
-
     uint64_t Heap::GetLastUsedFenceValue() const {
         return mLastUsedFenceValue;
     }
@@ -118,6 +108,7 @@ namespace gpgmm { namespace d3d12 {
     }
 
     HEAP_INFO Heap::GetInfo() const {
-        return {GetSize(), IsResident(), mMemorySegmentGroup, GetRefCount(), GetPool(), GetHeap()};
+        return {GetSize(),     IsResident(), mMemorySegmentGroup,
+                GetRefCount(), GetPool(),    mPageable.Get()};
     }
 }}  // namespace gpgmm::d3d12

--- a/src/gpgmm/d3d12/HeapD3D12.h
+++ b/src/gpgmm/d3d12/HeapD3D12.h
@@ -59,9 +59,9 @@ namespace gpgmm { namespace d3d12 {
         */
         MemoryPool* MemoryPool;
 
-        /** \brief Pointer to ID3D12Heap or NULL, if this heap has none.
+        /** \brief Pointer to ID3D12Pageable, the underlying heap created by D3D12.
          */
-        ID3D12Heap* Heap;
+        ID3D12Pageable* Pageable;
     };
 
     /** \struct HEAP_DESC
@@ -104,6 +104,7 @@ namespace gpgmm { namespace d3d12 {
         implicit D3D12 heap OR 2) an explicit D3D12 heap used with placed resources.
 
         @param descriptor A reference to HEAP_DESC structure that describes the heap.
+        @param residencyManager A pointer to the ResidencyManager used to manage this heap.
         @param[out] heapOut Pointer to a memory block that recieves a pointer to the
         heap.
         */
@@ -119,11 +120,22 @@ namespace gpgmm { namespace d3d12 {
 
         ~Heap();
 
-        /** \brief Get the ID3D12Heap.
+        /** \brief Returns a ComPtr object that represents the interface specified.
 
-        \return Return a pointer to ID3D12Heap or NULL, if this heap has none.
+        For example, to get a ID3D12Heap:
+
+        \code
+        ComPtr<ID3D12Heap> heap;
+        HRESULT hr = resourceHeap->As(&heap);
+        \endcode
+
+        \return Error HRESULT if the specified interface was not represented by the
+        heap.
         */
-        ID3D12Heap* GetHeap() const;
+        template <typename T>
+        HRESULT As(Microsoft::WRL::Details::ComPtrRef<ComPtr<T>> ptr) const {
+            return mPageable.As(ptr);
+        }
 
         /** \brief Determine if the heap is resident or not.
 
@@ -146,7 +158,6 @@ namespace gpgmm { namespace d3d12 {
         friend ResourceAllocator;
 
         const char* GetTypename() const;
-        ComPtr<ID3D12Pageable> GetPageable() const;
         DXGI_MEMORY_SEGMENT_GROUP GetMemorySegmentGroup() const;
 
         // The residency manager must know the last fence value that any portion of the pageable was

--- a/src/gpgmm/d3d12/JSONSerializerD3D12.cpp
+++ b/src/gpgmm/d3d12/JSONSerializerD3D12.cpp
@@ -144,8 +144,9 @@ namespace gpgmm { namespace d3d12 {
         if (desc.MemoryPool != nullptr) {
             dict.AddItem("MemoryPool", gpgmm::JSONSerializer::Serialize(desc.MemoryPool));
         }
-        if (desc.Heap != nullptr) {
-            dict.AddItem("Heap", Serialize(desc.Heap->GetDesc()));
+        ComPtr<ID3D12Heap> heap;
+        if (SUCCEEDED(desc.Pageable->QueryInterface(IID_PPV_ARGS(&heap)))) {
+            dict.AddItem("Heap", Serialize(heap->GetDesc()));
         }
         return dict;
     }

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -773,7 +773,7 @@ namespace gpgmm { namespace d3d12 {
                     // used for sub-allocation.
                     ComPtr<ID3D12Resource> committedResource;
                     Heap* resourceHeap = ToBackend(subAllocation.GetMemory());
-                    ReturnIfFailed(resourceHeap->GetPageable().As(&committedResource));
+                    ReturnIfFailed(resourceHeap->As(&committedResource));
 
                     *resourceAllocationOut = new ResourceAllocation{
                         mResidencyManager.Get(),      subAllocation.GetAllocator(),
@@ -989,10 +989,13 @@ namespace gpgmm { namespace d3d12 {
         // CreatePlacedResource will fail.
         ComPtr<ID3D12Resource> placedResource;
         {
+            ComPtr<ID3D12Heap> heap;
+            ReturnIfFailed(resourceHeap->As(&heap));
+
             ScopedResidencyLock residencyLock(mResidencyManager.Get(), resourceHeap);
             ReturnIfFailed(mDevice->CreatePlacedResource(
-                resourceHeap->GetHeap(), resourceOffset, resourceDescriptor, initialResourceState,
-                clearValue, IID_PPV_ARGS(&placedResource)));
+                heap.Get(), resourceOffset, resourceDescriptor, initialResourceState, clearValue,
+                IID_PPV_ARGS(&placedResource)));
         }
 
         *placedResourceOut = placedResource.Detach();

--- a/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
+++ b/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
@@ -303,7 +303,9 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferAlwaysCommitted) {
     // Commmitted resources cannot be backed by a D3D12 heap.
     Heap* resourceHeap = allocation->GetMemory();
     ASSERT_NE(resourceHeap, nullptr);
-    ASSERT_EQ(resourceHeap->GetHeap(), nullptr);
+
+    ComPtr<ID3D12Heap> heap;
+    ASSERT_FAILED(resourceHeap->As(&heap));
 
     // Commited resources must use all the memory allocated.
     EXPECT_EQ(resourceAllocator->GetInfo().UsedMemoryUsage, kDefaultBufferSize);


### PR DESCRIPTION
Avoids QI'ing a managed heap that isn't represented by the memory type, ID3D12Heap, then using nullptr. Instead, Heap::As() mimics ComPtr::As() and returns error code if cast fails.