### PR TITLE
Generate end2end test patterns for buffers.

### DIFF
--- a/src/tests/D3D12Test.cpp
+++ b/src/tests/D3D12Test.cpp
@@ -79,10 +79,10 @@ namespace gpgmm { namespace d3d12 {
     }
 
     // static
-    D3D12_RESOURCE_DESC D3D12TestBase::CreateBasicBufferDesc(uint64_t width) {
+    D3D12_RESOURCE_DESC D3D12TestBase::CreateBasicBufferDesc(uint64_t width, uint64_t alignment) {
         D3D12_RESOURCE_DESC resourceDesc;
         resourceDesc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
-        resourceDesc.Alignment = 0;
+        resourceDesc.Alignment = alignment;
         resourceDesc.Width = width;
         resourceDesc.Height = 1;
         resourceDesc.DepthOrArraySize = 1;
@@ -118,6 +118,11 @@ namespace gpgmm { namespace d3d12 {
             (sampleCount > 1) ? D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET : D3D12_RESOURCE_FLAG_NONE;
 
         return resourceDesc;
+    }
+
+    // static
+    std::vector<MEMORY_ALLOCATION_EXPECT> D3D12TestBase::GenerateBufferAllocations() {
+        return GPGMMTestBase::GenerateTestAllocations(D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT);
     }
 
 }}  // namespace gpgmm::d3d12

--- a/src/tests/D3D12Test.h
+++ b/src/tests/D3D12Test.h
@@ -17,6 +17,8 @@
 
 #include "tests/GPGMMTest.h"
 
+#include <vector>
+
 #include "gpgmm/d3d12/d3d12_platform.h"
 
 #define ASSERT_FAILED(expr) ASSERT_TRUE(FAILED(expr))
@@ -38,12 +40,14 @@ namespace gpgmm { namespace d3d12 {
 
         ALLOCATOR_DESC CreateBasicAllocatorDesc(bool isPrefetchAllowed = false) const;
 
-        static D3D12_RESOURCE_DESC CreateBasicBufferDesc(uint64_t width);
+        static D3D12_RESOURCE_DESC CreateBasicBufferDesc(uint64_t width, uint64_t alignment = 0);
 
         static D3D12_RESOURCE_DESC CreateBasicTextureDesc(DXGI_FORMAT format,
                                                           uint64_t width,
                                                           uint64_t height,
                                                           uint32_t sampleCount = 1);
+
+        static std::vector<MEMORY_ALLOCATION_EXPECT> GenerateBufferAllocations();
 
       protected:
         ComPtr<IDXGIAdapter3> mAdapter;

--- a/src/tests/GPGMMTest.cpp
+++ b/src/tests/GPGMMTest.cpp
@@ -36,6 +36,53 @@ gpgmm::DebugPlatform* GPGMMTestBase::GetDebugPlatform() {
     return mDebugPlatform.get();
 }
 
+// static
+std::vector<MEMORY_ALLOCATION_EXPECT> GPGMMTestBase::GenerateTestAllocations(uint64_t alignment) {
+    return {
+        // Edge-case fails.
+        {0, 0, false},
+        {0, 1, false},
+        {gpgmm::kInvalidSize, 1, false},
+
+        // Edge-case pass.
+        {1, gpgmm::kInvalidSize, true},
+        {alignment - 1, 1, true},
+        {alignment + 1, 1, true},
+        {1, alignment - 1, true},
+        {1, alignment + 1, true},
+
+        // Common small sizes, likely sub-allocated.
+        {256, alignment, true},
+        {1 * 1024, alignment, true},
+        {4 * 1024, alignment, true},
+
+        // Common large sizes, likely standalone.
+        {16 * 1024 * 1024, 0, true},
+        {64 * 1024 * 1024, 0, true},
+
+        // Mixed sizes, any method.
+        {1 * 1024, 1, true},
+        {64 * 1024 * 1024, 0, true},
+        {1 * 1024, 1, true},
+        {64 * 1024 * 1024, 0, true},
+        {1 * 1024, 1, true},
+        {64 * 1024 * 1024, 0, true},
+
+        // Increasing sizes, any method.
+        {alignment * 1, 0, true},
+        {alignment * 2, 0, true},
+        {alignment * 4, 0, true},
+        {alignment * 8, 0, true},
+        {alignment * 16, 0, true},
+        {alignment * 32, 0, true},
+        {alignment * 64, 0, true},
+        {alignment * 128, 0, true},
+        {alignment * 256, 0, true},
+        {alignment * 512, 0, true},
+        {alignment * 1024, 0, true},
+    };
+}
+
 // GPGMMTestEnvironment
 
 void InitGPGMMEnd2EndTestEnvironment(int argc, char** argv) {

--- a/src/tests/GPGMMTest.h
+++ b/src/tests/GPGMMTest.h
@@ -17,8 +17,11 @@
 
 #include <gtest/gtest.h>
 
+#include "gpgmm/common/MemoryAllocator.h"
 #include "gpgmm/utils/Log.h"
 #include "gpgmm/utils/PlatformDebug.h"
+
+#include <vector>
 
 #define GPGMM_SKIP_TEST_IF(expr)                            \
     do {                                                    \
@@ -43,6 +46,12 @@ namespace gpgmm {
     class DebugPlatform;
 }  // namespace gpgmm
 
+struct MEMORY_ALLOCATION_EXPECT {
+    uint64_t size;
+    uint64_t alignment;
+    bool succeeds;
+};
+
 class GPGMMTestBase {
   protected:
     virtual ~GPGMMTestBase();
@@ -51,6 +60,8 @@ class GPGMMTestBase {
     void TearDown();
 
     gpgmm::DebugPlatform* GetDebugPlatform();
+
+    static std::vector<MEMORY_ALLOCATION_EXPECT> GenerateTestAllocations(uint64_t alignment);
 };
 
 void InitGPGMMEnd2EndTestEnvironment(int argc, char** argv);


### PR DESCRIPTION
Also, fixes edge-case when buffer alignment would ASSERT upon overflow.