### PR TITLE
Represent multiple allocator nodes without lists.

### DIFF
--- a/src/gpgmm/common/AllocatorNode.cpp
+++ b/src/gpgmm/common/AllocatorNode.cpp
@@ -25,21 +25,19 @@ namespace gpgmm {
 
     template <typename T>
     AllocatorNode<T>::~AllocatorNode() {
-        // Deletes adjacent node recursively (post-order).
-        mNext.RemoveAndDeleteAll();
-        if (LinkNode<T>::IsInList()) {
-            LinkNode<T>::RemoveFromList();
+        LinkNode<T>* pNext = LinkNode<T>::next();
+        if (pNext != nullptr) {
+            SafeDelete(pNext->value());
         }
-
-        ASSERT(mNext.empty());
     }
 
     template <typename T>
     T* AllocatorNode<T>::GetNextInChain() const {
-        if (mNext.head() == mNext.end()) {
+        LinkNode<T>* pNext = LinkNode<T>::next();
+        if (pNext == nullptr) {
             return nullptr;
         }
-        return mNext.head()->value();
+        return pNext->value();
     }
 
     template <typename T>
@@ -49,11 +47,11 @@ namespace gpgmm {
 
     template <typename T>
     T* AllocatorNode<T>::InsertIntoChain(std::unique_ptr<T> next) {
-        ASSERT(mNext.empty());
         ASSERT(next != nullptr);
-        next->mParent = this->value();
-        mNext.Append(next.release());
-        return mNext.tail()->value();
+        T* nextPtr = next.release();
+        nextPtr->mParent = this->value();
+        LinkNode<T>::InsertBefore(nextPtr);
+        return nextPtr->value();
     }
 
     // Explictly instantiate the template to ensure the compiler has the

--- a/src/gpgmm/common/AllocatorNode.h
+++ b/src/gpgmm/common/AllocatorNode.h
@@ -21,24 +21,43 @@
 
 namespace gpgmm {
 
-    // Stores allocators as a doubly-linked list.
-    // A allocator becomes a linked node where allocations made between the parent and the next
-    // allocator form a one-way edge (ie. child sub-allocates parent's allocation). This results in
-    // trivial lifetime management and traversals.
+    /** \brief  Chain together allocators as a doubly linked list.
+
+    A allocator becomes a node in a linked-list where allocations made between the parent and the
+    child allocator form a one-way edge (child sub-allocates parent's allocation).
+
+    This scheme results in trivial lifetime management and traversals between multiple allocators
+    that depend on each other.
+    */
     template <typename T>
     class AllocatorNode : public LinkNode<T> {
       public:
+        /** \brief Construct the node without a child.
+         */
         AllocatorNode() = default;
+
+        /** \brief Construct the node as a parent or with a child.
+
+        @param next Pointer to the next or child node.
+        */
         explicit AllocatorNode(std::unique_ptr<T> next);
+
         virtual ~AllocatorNode();
 
+        /** \brief Returns the next node in the chain.
+
+        \return Pointer to the child or next node. NULL if none exists.
+        */
         T* GetNextInChain() const;
+
+        /** \brief Returns the next node in the chain.
+
+        \return Pointer to the parent or previous node. NULL if none exists
+        */
         T* GetParent() const;
 
       private:
         T* InsertIntoChain(std::unique_ptr<T> next);
-
-        LinkedList<T> mNext;
         T* mParent = nullptr;
     };
 

--- a/src/gpgmm/utils/LinkedList.h
+++ b/src/gpgmm/utils/LinkedList.h
@@ -112,8 +112,13 @@ namespace gpgmm {
         void InsertBefore(LinkNode<T>* e) {
             this->next_ = e;
             this->previous_ = e->previous_;
-            e->previous_->next_ = this;
-            e->previous_ = this;
+
+            // If |e| belongs to a list, e->previous_ is non-null.
+            // Otherwise, null.
+            if (e->previous_) {
+                e->previous_->next_ = this;
+                e->previous_ = this;
+            }
         }
 
         // Insert |this| into the linked list, after |e|.


### PR DESCRIPTION
Eliminates the need to store a LinkedList per node and instead, allows each LinkNode to connect to another without them being used in a LinkedList.