### PR TITLE
Use small slabs when over budget.

### DIFF
--- a/src/gpgmm/common/SlabMemoryAllocator.h
+++ b/src/gpgmm/common/SlabMemoryAllocator.h
@@ -64,7 +64,7 @@ namespace gpgmm {
         const char* GetTypename() const override;
 
       private:
-        uint64_t ComputeSlabSize(uint64_t requestSize, uint64_t slabSize) const;
+        uint64_t ComputeSlabSize(uint64_t requestSize, uint64_t minSlabSize) const;
 
         // Slab is a node in a doubly-linked list that contains a free-list of blocks
         // and a reference to underlying memory.

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -581,6 +581,8 @@ namespace gpgmm { namespace d3d12 {
         // MemoryAllocator interface
         void DeallocateMemory(std::unique_ptr<MemoryAllocation> allocation) override;
 
+        RESOURCE_ALLOCATOR_INFO GetInfoInternal() const;
+
         ComPtr<ID3D12Device> mDevice;
         ComPtr<ResidencyManager> mResidencyManager;
 

--- a/src/tests/end2end/D3D12ResidencyManagerTests.cpp
+++ b/src/tests/end2end/D3D12ResidencyManagerTests.cpp
@@ -108,7 +108,7 @@ TEST_F(D3D12ResidencyManagerTests, OverBudget) {
 
     ASSERT_GT(resourceHeaps.size(), 1u);
 
-    // When over-budget, the resource heap size should remain the same.
-    EXPECT_EQ(resourceHeaps.at(allocations.size() - 1)->GetSize(),
+    // When over-budget, the resource heap size should not increase.
+    EXPECT_LE(resourceHeaps.at(allocations.size() - 1)->GetSize(),
               resourceHeaps.at(allocations.size() - 2)->GetSize());
 }


### PR DESCRIPTION
Prevents larger slabs from being created when there is no available memory.