### PR TITLE
Add front-end support to partially release memory pools.

### DIFF
--- a/src/gpgmm/common/IndexedMemoryPool.cpp
+++ b/src/gpgmm/common/IndexedMemoryPool.cpp
@@ -33,17 +33,13 @@ namespace gpgmm {
                                          uint64_t memoryIndex) {
         ASSERT(allocation != nullptr);
         ASSERT(memoryIndex < mPool.size());
+        ASSERT(allocation->GetSize() == GetMemorySize());
+
         mPool[memoryIndex] = std::move(allocation);
     }
 
-    void IndexedMemoryPool::ReleasePool() {
-        for (auto& allocation : mPool) {
-            if (allocation != nullptr) {
-                allocation->GetAllocator()->DeallocateMemory(std::move(allocation));
-            }
-        }
-
-        mPool.clear();
+    uint64_t IndexedMemoryPool::ReleasePool(uint64_t bytesToRelease) {
+        return TrimPoolUntil(mPool, bytesToRelease);
     }
 
     uint64_t IndexedMemoryPool::GetPoolSize() const {

--- a/src/gpgmm/common/IndexedMemoryPool.h
+++ b/src/gpgmm/common/IndexedMemoryPool.h
@@ -30,7 +30,7 @@ namespace gpgmm {
         std::unique_ptr<MemoryAllocation> AcquireFromPool(uint64_t memoryIndex) override;
         void ReturnToPool(std::unique_ptr<MemoryAllocation> allocation,
                           uint64_t memoryIndex) override;
-        void ReleasePool() override;
+        uint64_t ReleasePool(uint64_t bytesToRelease) override;
 
         uint64_t GetPoolSize() const override;
 

--- a/src/gpgmm/common/JSONSerializer.cpp
+++ b/src/gpgmm/common/JSONSerializer.cpp
@@ -28,9 +28,9 @@ namespace gpgmm {
     }
 
     // static
-    JSONDict JSONSerializer::Serialize(const POOL_INFO& info) {
+    JSONDict JSONSerializer::Serialize(const MEMORY_POOL_INFO& info) {
         JSONDict dict;
-        dict.AddItem("PoolSizeInBytes", info.PoolSizeInBytes);
+        dict.AddItem("SizeInBytes", info.SizeInBytes);
         return dict;
     }
 

--- a/src/gpgmm/common/JSONSerializer.h
+++ b/src/gpgmm/common/JSONSerializer.h
@@ -20,7 +20,7 @@
 namespace gpgmm {
 
     // Forward declare common types.
-    struct POOL_INFO;
+    struct MEMORY_POOL_INFO;
     struct MEMORY_ALLOCATOR_INFO;
     struct MEMORY_ALLOCATION_INFO;
     struct MEMORY_ALLOCATION_REQUEST;
@@ -33,7 +33,7 @@ namespace gpgmm {
         static JSONDict Serialize(const MEMORY_ALLOCATOR_INFO& info);
         static JSONDict Serialize(const MEMORY_ALLOCATION_REQUEST& desc);
         static JSONDict Serialize(const MEMORY_ALLOCATION_INFO& info);
-        static JSONDict Serialize(const POOL_INFO& desc);
+        static JSONDict Serialize(const MEMORY_POOL_INFO& desc);
         static JSONDict Serialize(const void* objectPtr);
     };
 

--- a/src/gpgmm/common/LIFOMemoryPool.cpp
+++ b/src/gpgmm/common/LIFOMemoryPool.cpp
@@ -37,18 +37,15 @@ namespace gpgmm {
 
     void LIFOMemoryPool::ReturnToPool(std::unique_ptr<MemoryAllocation> allocation,
                                       uint64_t memoryIndex) {
-        ASSERT(memoryIndex == kInvalidIndex);
         ASSERT(allocation != nullptr);
+        ASSERT(memoryIndex == kInvalidIndex);
+        ASSERT(allocation->GetSize() == GetMemorySize());
+
         mPool.push_front(std::move(allocation));
     }
 
-    void LIFOMemoryPool::ReleasePool() {
-        for (auto& allocation : mPool) {
-            ASSERT(allocation != nullptr);
-            allocation->GetAllocator()->DeallocateMemory(std::move(allocation));
-        }
-
-        mPool.clear();
+    uint64_t LIFOMemoryPool::ReleasePool(uint64_t bytesToRelease) {
+        return TrimPoolUntil(mPool, bytesToRelease);
     }
 
     uint64_t LIFOMemoryPool::GetPoolSize() const {

--- a/src/gpgmm/common/LIFOMemoryPool.h
+++ b/src/gpgmm/common/LIFOMemoryPool.h
@@ -32,7 +32,7 @@ namespace gpgmm {
             uint64_t memoryIndex = kInvalidIndex) override;
         void ReturnToPool(std::unique_ptr<MemoryAllocation> allocation,
                           uint64_t memoryIndex = kInvalidIndex) override;
-        void ReleasePool() override;
+        uint64_t ReleasePool(uint64_t bytesToFree = kInvalidSize) override;
 
         uint64_t GetPoolSize() const override;
 

--- a/src/gpgmm/common/MemoryPool.cpp
+++ b/src/gpgmm/common/MemoryPool.cpp
@@ -30,7 +30,7 @@ namespace gpgmm {
         return mMemorySize;
     }
 
-    POOL_INFO MemoryPool::GetInfo() const {
+    MEMORY_POOL_INFO MemoryPool::GetInfo() const {
         return {GetPoolSize() * mMemorySize};
     }
 

--- a/src/gpgmm/common/MemoryPool.h
+++ b/src/gpgmm/common/MemoryPool.h
@@ -23,36 +23,102 @@ namespace gpgmm {
 
     class MemoryAllocation;
 
-    struct POOL_INFO {
-        uint64_t PoolSizeInBytes;
+    /** \struct MEMORY_POOL_INFO
+    Additional information about the memory pool.
+    */
+    struct MEMORY_POOL_INFO {
+        /** \brief Total size of the pool, in bytes.
+         */
+        uint64_t SizeInBytes;
     };
 
-    // Stores a collection of fixed-size memory allocations.
+    /** \brief Stores a collection of memory allocations.
+
+    Memory allocations stored in the pool must ALL be in the same state (ex. "free pool").
+
+    To grow the pool, created memory allocations are inserted into the pool by ReturnToPool().
+
+    To shrink the pool, existing allocations can removed out by AcquireFromPool() or de-allocated
+    together by ReleasePool().
+    */
     class MemoryPool {
       public:
+        /** \brief Constructs a pool for memory of the specified size.
+
+        @param memorySize Size, in bytes, of the memory object stored in the pool.
+        */
         explicit MemoryPool(uint64_t memorySize);
         virtual ~MemoryPool();
 
-        // Retrieves a memory allocation from the pool using an optional index.
+        /** \brief Retrieves a memory allocation from the pool using an optional index.
+
+        @param memoryIndex Optional index of the memory object to retrieve.
+        */
         virtual std::unique_ptr<MemoryAllocation> AcquireFromPool(
             uint64_t memoryIndex = kInvalidIndex) = 0;
 
-        // Returns a memory allocation back to the pool using an optional index.
+        /** \brief Returns a memory allocation back to the pool using an optional index.
+
+        @param memoryIndex Optional index of the memory object to return.
+        */
         virtual void ReturnToPool(std::unique_ptr<MemoryAllocation> allocation,
                                   uint64_t memoryIndex = kInvalidIndex) = 0;
 
-        // Deallocates memory allocations owned by the pool.
-        virtual void ReleasePool() = 0;
+        /** \brief Deallocate or shrink the pool.
 
-        // Returns number of memory allocations in the pool.
+        @param bytesToRelease Optional size, in bytes, to release from the pool. If no size is
+        specified or kInvalidSize, the entire pool will be released.
+
+        \return Total amount, in bytes, released by the pool.
+        */
+        virtual uint64_t ReleasePool(uint64_t bytesToRelease = kInvalidSize) = 0;
+
+        /** \brief Get the size of the pool.
+
+        \return Number of memory allocations in the pool.
+        */
         virtual uint64_t GetPoolSize() const = 0;
 
-        // Returns the size of the memory allocations being pooled.
+        /** \brief Returns the size of the memory allocations being pooled.
+
+        \return Size, in bytes, of the memory allocation being pooled.
+        */
         virtual uint64_t GetMemorySize() const;
 
-        POOL_INFO GetInfo() const;
+        /** \brief Returns information about this memory pool.
 
+        \return A MEMORY_POOL_INFO struct containing the information.
+        */
+        MEMORY_POOL_INFO GetInfo() const;
+
+        /** \brief Returns the class name of this allocation.
+
+        \return A pointer to a C character string with data, "MemoryPool".
+        */
         const char* GetTypename() const;
+
+      protected:
+        // Shrinks the size of the pool in |mMemorySize| sizes until |bytesToRelease| is reached.
+        template <typename T>
+        uint64_t TrimPoolUntil(T& pool, uint64_t bytesToRelease) {
+            uint64_t totalBytesReleased = 0;
+            uint64_t lastIndex = 0;
+            for (auto& allocation : pool) {
+                totalBytesReleased += allocation->GetSize();
+                allocation->GetAllocator()->DeallocateMemory(std::move(allocation));
+                lastIndex++;
+                if (totalBytesReleased >= bytesToRelease) {
+                    break;
+                }
+            }
+
+            // Last is non-inclusive or [first, last).
+            if (lastIndex > 0) {
+                pool.erase(pool.begin(), pool.begin() + lastIndex);
+            }
+
+            return totalBytesReleased;
+        }
 
       private:
         uint64_t mMemorySize;

--- a/src/gpgmm/common/PooledMemoryAllocator.cpp
+++ b/src/gpgmm/common/PooledMemoryAllocator.cpp
@@ -27,7 +27,7 @@ namespace gpgmm {
     }
 
     PooledMemoryAllocator::~PooledMemoryAllocator() {
-        mPool->ReleasePool();
+        mPool->ReleasePool(kInvalidSize);
     }
 
     std::unique_ptr<MemoryAllocation> PooledMemoryAllocator::TryAllocateMemory(
@@ -71,8 +71,7 @@ namespace gpgmm {
     }
 
     void PooledMemoryAllocator::ReleaseMemory() {
-        mInfo.FreeMemoryUsage -= mPool->GetInfo().PoolSizeInBytes;
-        mPool->ReleasePool();
+        mInfo.FreeMemoryUsage -= mPool->ReleasePool();
     }
 
     uint64_t PooledMemoryAllocator::GetMemorySize() const {

--- a/src/gpgmm/common/SegmentedMemoryAllocator.cpp
+++ b/src/gpgmm/common/SegmentedMemoryAllocator.cpp
@@ -16,6 +16,7 @@
 
 #include "gpgmm/common/Debug.h"
 #include "gpgmm/utils/Assert.h"
+#include "gpgmm/utils/Math.h"
 #include "gpgmm/utils/Utils.h"
 
 namespace gpgmm {
@@ -140,7 +141,8 @@ namespace gpgmm {
                              std::to_string(request.Alignment) + " vs " +
                              std::to_string(mMemoryAlignment) + " bytes).");
 
-        MemorySegment* segment = GetOrCreateFreeSegment(request.SizeInBytes);
+        const uint64_t memorySize = AlignTo(request.SizeInBytes, mMemoryAlignment);
+        MemorySegment* segment = GetOrCreateFreeSegment(memorySize);
         ASSERT(segment != nullptr);
 
         std::unique_ptr<MemoryAllocation> allocation = segment->AcquireFromPool();
@@ -187,8 +189,7 @@ namespace gpgmm {
         for (auto node = mFreeSegments.head(); node != mFreeSegments.end(); node = node->next()) {
             MemorySegment* segment = node->value();
             ASSERT(segment != nullptr);
-            mInfo.FreeMemoryUsage -= segment->GetInfo().PoolSizeInBytes;
-            segment->ReleasePool();
+            mInfo.FreeMemoryUsage -= segment->ReleasePool();
         }
     }
 

--- a/src/tests/BUILD.gn
+++ b/src/tests/BUILD.gn
@@ -113,6 +113,7 @@ test("gpgmm_unittests") {
     "unittests/MathTests.cpp",
     "unittests/MemoryAllocatorTests.cpp",
     "unittests/MemoryCacheTests.cpp",
+    "unittests/MemoryPoolTests.cpp",
     "unittests/PooledMemoryAllocatorTests.cpp",
     "unittests/RefCountTests.cpp",
     "unittests/SegmentedMemoryAllocatorTests.cpp",

--- a/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
+++ b/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
@@ -855,16 +855,6 @@ TEST_F(D3D12ResourceAllocatorTests, CreateTexturePooled) {
         ASSERT_NE(secondAllocation, nullptr);
         EXPECT_EQ(secondAllocation->GetMethod(), gpgmm::AllocationMethod::kStandalone);
     }
-
-    // Check the first small texture of size A cannot be reused when creating a larger texture of
-    // size B.
-    {
-        ComPtr<ResourceAllocation> thirdAllocation;
-        ASSERT_FAILED(poolAllocator->CreateResource(
-            reusePoolOnlyDesc, CreateBasicTextureDesc(DXGI_FORMAT_R8G8B8A8_UNORM, 128, 128),
-            D3D12_RESOURCE_STATE_GENERIC_READ, nullptr, &thirdAllocation));
-        ASSERT_EQ(thirdAllocation, nullptr);
-    }
 }
 
 // Verify a 1 byte buffer will be defragmented by creating a heaps large enough to stay under the

--- a/src/tests/unittests/MemoryPoolTests.cpp
+++ b/src/tests/unittests/MemoryPoolTests.cpp
@@ -1,0 +1,84 @@
+// Copyright 2021 The GPGMM Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "gpgmm/common/LIFOMemoryPool.h"
+#include "tests/DummyMemoryAllocator.h"
+
+using namespace gpgmm;
+
+static uint64_t kDefaultMemorySize = 128u;
+
+class MemoryPoolTests : public testing::Test {
+  public:
+    MEMORY_ALLOCATION_REQUEST CreateBasicRequest(uint64_t size) {
+        MEMORY_ALLOCATION_REQUEST request = {};
+        request.SizeInBytes = size;
+        request.Alignment = 1;
+        return request;
+    }
+};
+
+class LIFOMemoryPoolTests : public MemoryPoolTests {};
+
+TEST_F(LIFOMemoryPoolTests, SingleAllocation) {
+    DummyMemoryAllocator allocator;
+    LIFOMemoryPool pool(kDefaultMemorySize);
+    EXPECT_EQ(pool.GetInfo().SizeInBytes, 0u);
+
+    EXPECT_EQ(pool.ReleasePool(), 0u);
+    EXPECT_EQ(pool.GetInfo().SizeInBytes, 0u);
+
+    pool.ReturnToPool(allocator.TryAllocateMemory(CreateBasicRequest(kDefaultMemorySize)));
+    EXPECT_EQ(pool.GetInfo().SizeInBytes, kDefaultMemorySize);
+    EXPECT_EQ(pool.GetPoolSize(), 1u);
+
+    pool.ReturnToPool(pool.AcquireFromPool());
+    EXPECT_EQ(pool.GetInfo().SizeInBytes, kDefaultMemorySize);
+    EXPECT_EQ(pool.GetPoolSize(), 1u);
+
+    EXPECT_EQ(pool.ReleasePool(kDefaultMemorySize), kDefaultMemorySize);
+    EXPECT_EQ(pool.GetInfo().SizeInBytes, 0u);
+    EXPECT_EQ(pool.GetPoolSize(), 0u);
+
+    EXPECT_EQ(pool.ReleasePool(), 0u);
+    EXPECT_EQ(pool.GetInfo().SizeInBytes, 0u);
+    EXPECT_EQ(pool.GetPoolSize(), 0u);
+}
+
+TEST_F(LIFOMemoryPoolTests, MultipleAllocations) {
+    DummyMemoryAllocator allocator;
+    LIFOMemoryPool pool(kDefaultMemorySize);
+    EXPECT_EQ(pool.GetInfo().SizeInBytes, 0u);
+    EXPECT_EQ(pool.GetPoolSize(), 0u);
+
+    constexpr uint64_t kPoolSize = 64;
+    while (pool.GetPoolSize() < kPoolSize) {
+        pool.ReturnToPool(allocator.TryAllocateMemory(CreateBasicRequest(kDefaultMemorySize)));
+    }
+
+    EXPECT_EQ(pool.GetInfo().SizeInBytes, kDefaultMemorySize * kPoolSize);
+    EXPECT_EQ(pool.GetPoolSize(), kPoolSize);
+
+    // Release half of the pool.
+    EXPECT_EQ(pool.ReleasePool(kDefaultMemorySize * kPoolSize / 2),
+              kDefaultMemorySize * kPoolSize / 2);
+    EXPECT_EQ(pool.GetPoolSize(), kPoolSize / 2);
+
+    // Release the other half.
+    EXPECT_EQ(pool.ReleasePool(), kDefaultMemorySize * kPoolSize / 2);
+    EXPECT_EQ(pool.GetInfo().SizeInBytes, 0u);
+    EXPECT_EQ(pool.GetPoolSize(), 0u);
+}


### PR DESCRIPTION
In a future change, backend allocators will partially release these pools to stay within the budget.