### PR TITLE
Add --capture-mask to CaptureReplayTest.

### DIFF
--- a/src/gpgmm/utils/Utils.cpp
+++ b/src/gpgmm/utils/Utils.cpp
@@ -17,9 +17,7 @@
 namespace gpgmm {
 
     std::string ToString(const void* object) {
-        std::stringstream output;
-        output << "0x" << std::hex << static_cast<uint64_t>(reinterpret_cast<uintptr_t>(object));
-        return output.str();
+        return ToHexStr(static_cast<uint64_t>(reinterpret_cast<uintptr_t>(object)));
     }
 
 }  // namespace gpgmm

--- a/src/gpgmm/utils/Utils.h
+++ b/src/gpgmm/utils/Utils.h
@@ -50,6 +50,14 @@ namespace gpgmm {
         return output.str();
     }
 
+    // Converts T to a hexadecimal string.
+    template <typename T>
+    std::string ToHexStr(T object) {
+        std::stringstream stream;
+        stream << "0x" << std::hex << object;
+        return stream.str();
+    }
+
     // Used to combine multiple ToString calls for concatenation.
     // Eg. ToString("a", "b", "c") == "abc".
     template <typename T, typename... Args>

--- a/src/tests/capture_replay_tests/D3D12EventTraceReplay.cpp
+++ b/src/tests/capture_replay_tests/D3D12EventTraceReplay.cpp
@@ -342,6 +342,9 @@ class D3D12EventTraceReplay : public D3D12TestBase, public CaptureReplayTestWith
                         }
 
                         if (envParams.IsCaptureEnabled) {
+                            allocatorDesc.RecordOptions.Flags |=
+                                static_cast<ALLOCATOR_RECORD_FLAGS_TYPE>(
+                                    envParams.CaptureEventMask);
                             allocatorDesc.RecordOptions.Flags |= ALLOCATOR_RECORD_FLAG_CAPTURE;
                             allocatorDesc.RecordOptions.TraceFile = traceFile.path;
                             allocatorDesc.RecordOptions.MinMessageLevel =

--- a/src/tests/capture_replay_tests/GPGMMCaptureReplayTests.cpp
+++ b/src/tests/capture_replay_tests/GPGMMCaptureReplayTests.cpp
@@ -98,8 +98,21 @@ GPGMMCaptureReplayTestEnvironment::GPGMMCaptureReplayTestEnvironment(int argc, c
             continue;
         }
 
+        constexpr const char kCaptureMask[] = "--capture-mask=";
+        arglen = sizeof(kCaptureMask) - 1;
+        if (strncmp(argv[i], kCaptureMask, arglen) == 0) {
+            const char* mask = argv[i] + arglen;
+            mParams.CaptureEventMask = strtoul(mask, nullptr, 0);
+            continue;
+        }
+
         if (strcmp("--same-caps", argv[i]) == 0) {
             mParams.IsSameCapsRequired = true;
+            continue;
+        }
+
+        if (strcmp("--disable-suballocation", argv[i]) == 0) {
+            mParams.IsSuballocationDisabled = true;
             continue;
         }
 
@@ -160,9 +173,10 @@ GPGMMCaptureReplayTestEnvironment::GPGMMCaptureReplayTestEnvironment(int argc, c
                 << " --log-level=[DEBUG|INFO|WARN|ERROR]: Log severity "
                    "level for log messages.\n"
                 << " --capture: Capture upon playback.\n"
+                << " --capture-mask: Event mask to record during capture.\n"
                 << " --playback-file: Path to captured file to playback.\n"
                 << " --same-caps: Captured device must be compatible with playback device.\n"
-                << " --profile=[MAXPERF|LOWMEM|CAPTURED|DEFAULT]: Allocator profile.\n";
+                << " --profile=[MAXPERF|LOWMEM|CAPTURED|DEFAULT]: Allocation profile.\n";
             continue;
         }
     }
@@ -186,7 +200,10 @@ void GPGMMCaptureReplayTestEnvironment::PrintCaptureReplaySettings() const {
     gpgmm::InfoLog() << "Playback settings\n"
                         "-----------------\n"
                      << "Iterations per test: " << mParams.Iterations << "\n"
-                     << "Capture on playback: " << (mParams.IsCaptureEnabled ? "true" : "false")
+                     << "Capture on playback: "
+                     << (mParams.IsCaptureEnabled
+                             ? "true (" + gpgmm::ToHexStr(mParams.CaptureEventMask) + ")"
+                             : "false")
                      << "\n"
                      << "Log level: " << LogSeverityToString(mParams.LogLevel) << "\n"
                      << "Require same caps: " << (mParams.IsSameCapsRequired ? "true" : "false")
@@ -196,7 +213,6 @@ void GPGMMCaptureReplayTestEnvironment::PrintCaptureReplaySettings() const {
                         "-------------------\n"
                      << "Disable sub-allocation: "
                      << (mParams.IsSuballocationDisabled ? "true" : "false") << "\n"
-                     << "Never allocate: " << (mParams.IsNeverAllocate ? "true" : "false") << "\n"
                      << "Profile: " << AllocatorProfileToString(mParams.AllocatorProfile) << "\n";
 }
 

--- a/src/tests/capture_replay_tests/GPGMMCaptureReplayTests.h
+++ b/src/tests/capture_replay_tests/GPGMMCaptureReplayTests.h
@@ -52,6 +52,7 @@ enum class AllocatorProfile {
 struct TestEnviromentParams {
     uint64_t Iterations = 1;                                 // Number of test iterations to run.
     gpgmm::LogSeverity LogLevel = gpgmm::LogSeverity::Info;  // Level of logging.
+    uint64_t CaptureEventMask = 0;
 
     bool IsCaptureEnabled = false;    // Should the allocator record.
     bool IsSameCapsRequired = false;  // Caps of test device must match capture caps.


### PR DESCRIPTION
Allows playback to expand recorded events for more detailed analysis.