### PR TITLE
Restrict recording trace events per allocation.

### DIFF
--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -418,7 +418,8 @@ namespace gpgmm { namespace d3d12 {
           mIsAlwaysInBudget(descriptor.Flags & ALLOCATOR_FLAG_ALWAYS_IN_BUDGET),
           mMaxResourceHeapSize(descriptor.MaxResourceHeapSize),
           mShutdownEventTrace(descriptor.RecordOptions.EventScope &
-                              ALLOCATOR_RECORD_SCOPE_PER_INSTANCE) {
+                              ALLOCATOR_RECORD_SCOPE_PER_INSTANCE),
+          mUseDetailedTimingEvents(descriptor.RecordOptions.UseDetailedTimingEvents) {
         GPGMM_TRACE_EVENT_OBJECT_NEW(this);
 
 #if defined(GPGMM_ENABLE_ALLOCATOR_CHECKS)
@@ -654,6 +655,9 @@ namespace gpgmm { namespace d3d12 {
             mResourceHeapAllocatorOfType[resourceHeapTypeIndex]->ReleaseMemory();
             mResourceAllocatorOfType[resourceHeapTypeIndex]->ReleaseMemory();
         }
+
+        // TODO: Check when nothing trims.
+        GetInfoInternal();
     }
 
     HRESULT ResourceAllocator::CreateResource(const ALLOCATION_DESC& allocationDescriptor,
@@ -676,7 +680,7 @@ namespace gpgmm { namespace d3d12 {
                                               initialResourceState, clearValue,
                                               resourceAllocationOut));
 
-        if (IsEventTraceEnabled()) {
+        if (mUseDetailedTimingEvents) {
             GetInfo();
         }
 

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -163,6 +163,16 @@ namespace gpgmm { namespace d3d12 {
         */
         ALLOCATOR_RECORD_SCOPE EventScope = ALLOCATOR_RECORD_SCOPE_PER_PROCESS;
 
+        /** \brief Record detailed timing events.
+
+        Records detailed trace events when a resource allocation is created. Details include the
+        current usage by the allocator.
+
+        Optional parameter. By default, detailed timing events will only be recorded when the App
+        calls GetInfo() directly.
+        */
+        bool UseDetailedTimingEvents = false;
+
         /** \brief Path to trace file.
 
         Optional parameter. By default, a trace file is created for you.
@@ -600,6 +610,7 @@ namespace gpgmm { namespace d3d12 {
         const bool mIsAlwaysInBudget;
         const uint64_t mMaxResourceHeapSize;
         const bool mShutdownEventTrace;
+        const bool mUseDetailedTimingEvents;
 
         static constexpr uint64_t kNumOfResourceHeapTypes = 8u;
 

--- a/src/tests/D3D12Test.cpp
+++ b/src/tests/D3D12Test.cpp
@@ -58,6 +58,8 @@ namespace gpgmm { namespace d3d12 {
 
     ALLOCATOR_DESC D3D12TestBase::CreateBasicAllocatorDesc(bool isPrefetchAllowed) const {
         ALLOCATOR_DESC desc = {};
+
+        // Required parameters.
         desc.Adapter = mAdapter;
         desc.Device = mDevice;
         desc.IsUMA = mIsUMA;
@@ -73,6 +75,7 @@ namespace gpgmm { namespace d3d12 {
         desc.MinLogLevel = D3D12_MESSAGE_SEVERITY_WARNING;
 #else
         desc.MinLogLevel = D3D12_MESSAGE_SEVERITY_MESSAGE;
+        desc.RecordOptions.UseDetailedTimingEvents = true;
 #endif
 
         return desc;


### PR DESCRIPTION
Adds UseDetailedTimingEvents to optionally record usage per allocation (default is ON for debug 
tests).