### PR TITLE
Limit memory growth by checking prior size usage.

### DIFF
--- a/src/gpgmm/common/Allocator.h
+++ b/src/gpgmm/common/Allocator.h
@@ -26,6 +26,7 @@ namespace gpgmm {
         ALLOCATOR_MESSAGE_ID_SIZE_EXCEEDED,
         ALLOCATOR_MESSAGE_ID_ALIGNMENT_MISMATCH,
         ALLOCATOR_MESSAGE_ID_ALLOCATOR_FAILED,
+        ALLOCATOR_MESSAGE_ID_SIZE_MISMATCH,
     };
 
     class AllocatorBase : public NonCopyable {

--- a/src/gpgmm/common/AllocatorNode.cpp
+++ b/src/gpgmm/common/AllocatorNode.cpp
@@ -26,7 +26,7 @@ namespace gpgmm {
     template <typename T>
     AllocatorNode<T>::~AllocatorNode() {
         // Deletes adjacent node recursively (post-order).
-        mNext.RemoveAndDeleteAll();
+        mNext.clear();
         if (LinkNode<T>::IsInList()) {
             LinkNode<T>::RemoveFromList();
         }
@@ -52,7 +52,7 @@ namespace gpgmm {
         ASSERT(mNext.empty());
         ASSERT(next != nullptr);
         next->mParent = this->value();
-        mNext.Append(next.release());
+        mNext.push_back(next.release());
         return mNext.tail()->value();
     }
 

--- a/src/gpgmm/common/MemoryCache.h
+++ b/src/gpgmm/common/MemoryCache.h
@@ -136,7 +136,7 @@ namespace gpgmm {
         MemoryCache() = default;
 
         ~MemoryCache() {
-            RemoveAndDeleteAll();
+            clear();
             ASSERT(GetSize() == 0);
         }
 
@@ -181,7 +181,7 @@ namespace gpgmm {
             return mCache.cend();
         }
 
-        void RemoveAndDeleteAll() {
+        void clear() {
             for (auto it = mCache.begin(); it != mCache.end();) {
                 if ((*it)->Unref()) {
                     CacheEntryT* item = (*it);

--- a/src/gpgmm/common/SegmentedMemoryAllocator.cpp
+++ b/src/gpgmm/common/SegmentedMemoryAllocator.cpp
@@ -104,7 +104,7 @@ namespace gpgmm {
         if (existingFreeSegment == mFreeSegments.end()) {
             ASSERT(mFreeSegments.empty());
             MemorySegment* newFreeSegment = new MemorySegment{memorySize};
-            mFreeSegments.Append(newFreeSegment);
+            mFreeSegments.push_back(newFreeSegment);
             return newFreeSegment;
         }
 

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
@@ -178,7 +178,7 @@ namespace gpgmm { namespace d3d12 {
         LRUCache* cache = GetVideoMemorySegmentCache(heap->GetMemorySegmentGroup());
         ASSERT(cache != nullptr);
 
-        cache->Append(heap);
+        cache->push_back(heap);
 
         ASSERT(heap->IsInList());
 

--- a/src/gpgmm/utils/LinkedList.h
+++ b/src/gpgmm/utils/LinkedList.h
@@ -184,8 +184,26 @@ namespace gpgmm {
         }
 
         // Appends |e| to the end of the linked list.
-        void Append(LinkNode<T>* e) {
+        void push_back(LinkNode<T>* e) {
             e->InsertBefore(&root_);
+            size_++;
+        }
+
+        // Prepend |e| to the start of the linked list.
+        void push_front(LinkNode<T>* e) {
+            e->InsertBefore(head());
+            size_++;
+        }
+
+        // Removes the first node in the linked list.
+        void pop_front() {
+            remove(head());
+        }
+
+        // Removes |e| from the linked list, decreasing the size by 1.
+        void remove(LinkNode<T>* e) {
+            e->RemoveFromList();
+            size_--;
         }
 
         LinkNode<T>* head() const {
@@ -205,9 +223,9 @@ namespace gpgmm {
         }
 
         // Empty the list by deleting all nodes.
-        // ~T must check if IsInList and call RemoveFromList to unlink itself or RemoveAndDeleteAll
+        // ~T must check if IsInList and call RemoveFromList to unlink itself or clear
         // will ASSERT to indicate programmer error.
-        void RemoveAndDeleteAll() const {
+        void clear() {
             auto curr = head();
             while (curr != end()) {
                 auto next = curr->next();
@@ -215,10 +233,16 @@ namespace gpgmm {
                 curr = next;
             }
             ASSERT(empty());
+            size_ = 0;
+        }
+
+        size_t size() const {
+            return size_;
         }
 
       private:
         LinkNode<T> root_;
+        size_t size_ = 0;
     };
 
 }  // namespace gpgmm

--- a/src/tests/unittests/LinkedListTests.cpp
+++ b/src/tests/unittests/LinkedListTests.cpp
@@ -29,16 +29,55 @@ class FakeObject final : public LinkNode<FakeObject> {
     }
 };
 
-TEST(LinkedListTests, RemoveAndDeleteAll) {
+TEST(LinkedListTests, Insert) {
+    LinkNode<FakeObject>* start = new FakeObject();
+    LinkNode<FakeObject>* middle = new FakeObject();
+    LinkNode<FakeObject>* end = new FakeObject();
+
+    LinkedList<FakeObject> list;
+    list.push_front(middle);
+    list.push_front(start);
+    list.push_back(end);
+
+    EXPECT_EQ(list.head(), start);
+    EXPECT_EQ(list.tail(), end);
+
+    EXPECT_FALSE(list.empty());
+    EXPECT_EQ(list.size(), 3u);
+}
+
+TEST(LinkedListTests, Remove) {
+    LinkNode<FakeObject>* start = new FakeObject();
+    LinkNode<FakeObject>* middle = new FakeObject();
+    LinkNode<FakeObject>* end = new FakeObject();
+
+    LinkedList<FakeObject> list;
+    list.push_back(start);
+    list.push_back(middle);
+    list.push_back(end);
+
+    list.remove(middle);
+    list.remove(start);
+    list.remove(end);
+
+    EXPECT_TRUE(list.empty());
+    EXPECT_EQ(list.size(), 0u);
+}
+
+TEST(LinkedListTests, Clear) {
     LinkNode<FakeObject>* first = new FakeObject();
     LinkNode<FakeObject>* second = new FakeObject();
     LinkNode<FakeObject>* third = new FakeObject();
 
     LinkedList<FakeObject> list;
-    list.Append(first);
-    list.Append(second);
-    list.Append(third);
+    list.push_back(first);
+    list.push_back(second);
+    list.push_back(third);
 
-    list.RemoveAndDeleteAll();
+    EXPECT_EQ(list.size(), 3u);
+
+    list.clear();
+
     EXPECT_TRUE(list.empty());
+    EXPECT_EQ(list.size(), 0u);
 }


### PR DESCRIPTION
Growing heaps too quickly increases the chance of larger 
heaps being under-utilized and forcing previous, better-utilized, ones to be paged-out. This change helps addresses such problem by checking if the current size had used the same amount of memory the next size requires.