### PR TITLE
Add descriptor usage warnings.

### DIFF
--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
@@ -44,6 +44,11 @@ namespace gpgmm { namespace d3d12 {
             residencyFence.reset(ptr);
         }
 
+        if (descriptor.VideoMemoryBudget != 0 && descriptor.Budget != 0) {
+            gpgmm::WarningLog()
+                << "Video memory budget was ignored since a budget was already specified.";
+        }
+
         std::unique_ptr<ResidencyManager> residencyManager = std::unique_ptr<ResidencyManager>(
             new ResidencyManager(descriptor, std::move(residencyFence)));
 

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -375,7 +375,7 @@ namespace gpgmm { namespace d3d12 {
             ReturnIfFailed(leakMessageQueue->PushRetrievalFilter(&emptyFilter));
         } else {
             gpgmm::WarningLog()
-                << "Debug layer must be installed and enabled to use GPGMM_ENABLE_DEVICE_CHECKS.\n";
+                << "Debug layer must be installed and enabled to use GPGMM_ENABLE_DEVICE_CHECKS.";
         }
 #endif
 
@@ -391,6 +391,11 @@ namespace gpgmm { namespace d3d12 {
 
             ReturnIfFailed(
                 ResidencyManager::CreateResidencyManager(residencyDesc, &residencyManager));
+        }
+
+        if (newDescriptor.Flags & ALLOCATOR_FLAG_ALWAYS_IN_BUDGET && !residencyManager) {
+            gpgmm::WarningLog() << "Residency must be specified and enabled to use "
+                                   "ALLOCATOR_FLAG_ALWAYS_IN_BUDGET.";
         }
 
         if (resourceAllocatorOut != nullptr) {


### PR DESCRIPTION
Outputs non-fatal error messages when the descriptor usage may lead to possible setup mistakes.