### PR TITLE
Fix MSVC conversion warning by GetOffsetFromResource().

### DIFF
--- a/src/gpgmm/d3d12/ResourceAllocationD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocationD3D12.cpp
@@ -31,7 +31,7 @@ namespace gpgmm { namespace d3d12 {
     namespace {
 
         // Returns a resource range from the start of the allocation.
-        D3D12_RANGE GetResourceRange(const D3D12_RANGE* range, uint64_t offset) {
+        D3D12_RANGE GetResourceRange(const D3D12_RANGE* range, size_t offset) {
             if (range == nullptr) {
                 return {};
             }
@@ -154,7 +154,7 @@ namespace gpgmm { namespace d3d12 {
         return mResource->GetGPUVirtualAddress() + mOffsetFromResource;
     }
 
-    uint64_t ResourceAllocation::GetOffsetFromResource() const {
+    size_t ResourceAllocation::GetOffsetFromResource() const {
         return mOffsetFromResource;
     }
 

--- a/src/gpgmm/d3d12/ResourceAllocationD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocationD3D12.h
@@ -183,7 +183,7 @@ namespace gpgmm { namespace d3d12 {
 
         \return A offset, in bytes, of the start of this allocation in the resource.
         */
-        uint64_t GetOffsetFromResource() const;
+        size_t GetOffsetFromResource() const;
 
         /** \brief Returns information about this resource allocation.
 
@@ -213,7 +213,7 @@ namespace gpgmm { namespace d3d12 {
         ResidencyManager* const mResidencyManager;
         ComPtr<ID3D12Resource> mResource;
 
-        const uint64_t mOffsetFromResource;
+        const size_t mOffsetFromResource;
     };
 
 }}  // namespace gpgmm::d3d12


### PR DESCRIPTION
Replaces uint64_t with size_t since D3D12_RANGE is always size_t.