### PR TITLE
Align UBOs within resources when unspecified.

### DIFF
--- a/src/tests/D3D12Test.cpp
+++ b/src/tests/D3D12Test.cpp
@@ -102,10 +102,11 @@ namespace gpgmm { namespace d3d12 {
     D3D12_RESOURCE_DESC D3D12TestBase::CreateBasicTextureDesc(DXGI_FORMAT format,
                                                               uint64_t width,
                                                               uint64_t height,
-                                                              uint32_t sampleCount) {
+                                                              uint32_t sampleCount,
+                                                              uint64_t alignment) {
         D3D12_RESOURCE_DESC resourceDesc;
         resourceDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
-        resourceDesc.Alignment = 0;
+        resourceDesc.Alignment = alignment;
         resourceDesc.Width = width;
         resourceDesc.Height = height;
         resourceDesc.DepthOrArraySize = 1;

--- a/src/tests/D3D12Test.h
+++ b/src/tests/D3D12Test.h
@@ -45,7 +45,8 @@ namespace gpgmm { namespace d3d12 {
         static D3D12_RESOURCE_DESC CreateBasicTextureDesc(DXGI_FORMAT format,
                                                           uint64_t width,
                                                           uint64_t height,
-                                                          uint32_t sampleCount = 1);
+                                                          uint32_t sampleCount = 1,
+                                                          uint64_t alignment = 0);
 
         static std::vector<MEMORY_ALLOCATION_EXPECT> GenerateBufferAllocations();
 


### PR DESCRIPTION
Specifies the smaller UBO required alignment when the requested alignment is unspecified.