### PR TITLE
Move ASSERT handler into GPGMM namespace.

### DIFF
--- a/src/gpgmm/utils/Assert.cpp
+++ b/src/gpgmm/utils/Assert.cpp
@@ -18,15 +18,19 @@
 
 #include <cstdlib>
 
-void HandleAssertionFailure(const char* file,
-                            const char* function,
-                            int line,
-                            const char* condition) {
-    gpgmm::ErrorLog() << "Assertion failure at " << file << ":" << line << " (" << function
-                      << "): " << condition;
+namespace gpgmm {
+
+    void HandleAssertionFailure(const char* file,
+                                const char* function,
+                                int line,
+                                const char* condition) {
+        gpgmm::ErrorLog() << "Assertion failure at " << file << ":" << line << " (" << function
+                          << "): " << condition;
 #if defined(GPGMM_ABORT_ON_ASSERT)
-    abort();
+        abort();
 #else
-    GPGMM_BREAKPOINT();
+        GPGMM_BREAKPOINT();
 #endif
-}
+    }
+
+}  // namespace gpgmm

--- a/src/gpgmm/utils/Assert.h
+++ b/src/gpgmm/utils/Assert.h
@@ -40,11 +40,11 @@
 // expect of an assert and in release it tries to give hints to make the compiler generate better
 // code.
 #if defined(GPGMM_ENABLE_ASSERTS)
-#    define GPGMM_ASSERT_CALLSITE_HELPER(file, func, line, condition) \
-        do {                                                          \
-            if (!(condition)) {                                       \
-                HandleAssertionFailure(file, func, line, #condition); \
-            }                                                         \
+#    define GPGMM_ASSERT_CALLSITE_HELPER(file, func, line, condition)        \
+        do {                                                                 \
+            if (!(condition)) {                                              \
+                gpgmm::HandleAssertionFailure(file, func, line, #condition); \
+            }                                                                \
         } while (GPGMM_ASSERT_LOOP_CONDITION)
 #else
 #    if defined(GPGMM_COMPILER_MSVC)
@@ -78,9 +78,13 @@
 #    define UNREACHABLE GPGMM_UNREACHABLE
 #endif
 
-void HandleAssertionFailure(const char* file,
-                            const char* function,
-                            int line,
-                            const char* condition);
+namespace gpgmm {
+
+    void HandleAssertionFailure(const char* file,
+                                const char* function,
+                                int line,
+                                const char* condition);
+
+}
 
 #endif  // GPGMM_UTILS_ASSERT_H_


### PR DESCRIPTION
Fixes bug where building GPGMM under third_party may clobber over another ASSERT by moving the handler into the GPGMM specific namespace.