### PR TITLE
Fix StartupEventTrace mask.

### DIFF
--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -354,7 +354,7 @@ namespace gpgmm { namespace d3d12 {
 
         if (newDescriptor.RecordOptions.Flags != ALLOCATOR_RECORD_FLAG_NONE) {
             StartupEventTrace(descriptor.RecordOptions.TraceFile,
-                              static_cast<TraceEventPhase>(newDescriptor.RecordOptions.Flags | 0));
+                              static_cast<TraceEventPhase>(~newDescriptor.RecordOptions.Flags | 0));
 
             SetEventMessageLevel(GetLogSeverity(newDescriptor.RecordOptions.MinMessageLevel));
         }


### PR DESCRIPTION
StartupEventTrace is an excludeMask while ALLOCATOR_RECORD_FLAGS is a includeMask. This fix flips the bits before StartupEventTrace() is called.