### PR TITLE
Re-use free slabs when over budget.

### DIFF
--- a/src/gpgmm/common/SlabMemoryAllocator.h
+++ b/src/gpgmm/common/SlabMemoryAllocator.h
@@ -64,7 +64,11 @@ namespace gpgmm {
         const char* GetTypename() const override;
 
       private:
-        uint64_t ComputeSlabSize(uint64_t requestSize, uint64_t minSlabSize) const;
+        uint64_t ComputeSlabSize(uint64_t requestSize,
+                                 uint64_t baseSlabSize,
+                                 uint64_t availableForAllocation) const;
+
+        uint64_t FindNextFreeSlabOfSize(uint64_t requestSize) const;
 
         // Slab is a node in a doubly-linked list that contains a free-list of blocks
         // and a reference to underlying memory.


### PR DESCRIPTION
Restricts slab sizes to those already free in the cache instead of allowing new larger ones to be created.