### PR TITLE
Re-use pre-fetching thread.

### DIFF
--- a/src/gpgmm/common/WorkerThread.cpp
+++ b/src/gpgmm/common/WorkerThread.cpp
@@ -15,9 +15,11 @@
 #include "gpgmm/common/WorkerThread.h"
 
 #include "gpgmm/common/TraceEvent.h"
+#include "gpgmm/utils/Assert.h"
 
 #include <condition_variable>
 #include <functional>
+#include <queue>
 #include <thread>
 
 namespace gpgmm {
@@ -27,7 +29,7 @@ namespace gpgmm {
         AsyncEventImpl() = default;
 
         void Wait() override {
-            TRACE_EVENT0(TraceEventCategory::Default, "AsyncEventImpl.Wait");
+            TRACE_EVENT0(TraceEventCategory::Default, "AsyncEvent.Wait");
 
             std::unique_lock<std::mutex> lock(mMutex);
             mCondition.wait(lock, [this] { return mIsSignaled; });
@@ -55,19 +57,74 @@ namespace gpgmm {
     class AsyncThreadPoolImpl final : public ThreadPool {
       public:
         AsyncThreadPoolImpl() = default;
-        ~AsyncThreadPoolImpl() override = default;
+
+        void checkAndRunPendingTasks() override {
+            if (mIsRunning) {
+                return;
+            }
+            mIsRunning = true;
+            mWorkerThread = std::thread([this]() { ProcessTasksInWorkerThread(); });
+        }
+
+        ~AsyncThreadPoolImpl() override {
+            if (!mIsRunning) {
+                return;
+            }
+
+            {
+                std::unique_lock<std::mutex> lock(mMutex);
+                mShouldTerminate = true;
+            }
+
+            mCondition.notify_all();
+            ASSERT(mWorkerThread.joinable());
+            mWorkerThread.join();
+        }
 
         std::shared_ptr<Event> postTaskImpl(std::shared_ptr<VoidCallback> callback) override {
             std::shared_ptr<Event> event = std::make_shared<AsyncEventImpl>();
-            std::thread thread([callback, event]() {
-                TRACE_EVENT_METADATA1(TraceEventCategory::Metadata, "thread_name", "name",
-                                      "GPGMM_ThreadPoolBackgroundWorker");
-                (*callback)();
-                event->Signal();
-            });
-            thread.detach();
+            {
+                std::unique_lock<std::mutex> lock(mMutex);
+                mTaskQueue.push(std::make_pair(event, callback));
+            }
+
+            mCondition.notify_all();
             return event;
         }
+
+        void ProcessTasksInWorkerThread() {
+            TRACE_EVENT_METADATA1(TraceEventCategory::Metadata, "thread_name", "name",
+                                  "GPGMM_ThreadPoolBackgroundWorker");
+            while (true) {
+                std::unique_lock<std::mutex> lock(mMutex);
+                mCondition.wait(lock, [this] { return !mTaskQueue.empty() || mShouldTerminate; });
+                if (mShouldTerminate) {
+                    break;
+                }
+
+                auto task = mTaskQueue.front();
+                mTaskQueue.pop();
+
+                auto event = task.first;
+                auto callback = task.second;
+
+                (*callback)();
+                event->Signal();
+
+                lock.unlock();
+                mCondition.notify_all();
+            }
+        }
+
+        bool mIsRunning = false;
+
+        // Protect access from the main and worker thread for shared class members.
+        std::mutex mMutex;
+
+        bool mShouldTerminate = false;
+        std::condition_variable mCondition;
+        std::thread mWorkerThread;
+        std::queue<std::pair<std::shared_ptr<Event>, std::shared_ptr<VoidCallback>>> mTaskQueue;
     };
 
     // Event
@@ -87,6 +144,7 @@ namespace gpgmm {
     std::shared_ptr<Event> ThreadPool::PostTask(std::shared_ptr<ThreadPool> pool,
                                                 std::shared_ptr<VoidCallback> callback) {
         std::shared_ptr<Event> event = pool->postTaskImpl(callback);
+        pool->checkAndRunPendingTasks();
         if (event != nullptr) {
             event->SetThreadPool(pool);
         }

--- a/src/gpgmm/common/WorkerThread.h
+++ b/src/gpgmm/common/WorkerThread.h
@@ -65,6 +65,9 @@ namespace gpgmm {
       private:
         // Return event to wait on until the callback runs.
         virtual std::shared_ptr<Event> postTaskImpl(std::shared_ptr<VoidCallback> callback) = 0;
+
+        // Check if the thread pool needs to start running a worker thread.
+        virtual void checkAndRunPendingTasks() = 0;
     };
 
 }  // namespace gpgmm

--- a/src/tests/BUILD.gn
+++ b/src/tests/BUILD.gn
@@ -120,6 +120,7 @@ test("gpgmm_unittests") {
     "unittests/SlabBlockAllocatorTests.cpp",
     "unittests/SlabMemoryAllocatorTests.cpp",
     "unittests/UtilsTest.cpp",
+    "unittests/WorkerThreadTests.cpp",
   ]
 
   # When building inside Chromium, use their gtest main function because it is

--- a/src/tests/unittests/WorkerThreadTests.cpp
+++ b/src/tests/unittests/WorkerThreadTests.cpp
@@ -1,0 +1,82 @@
+// Copyright 2021 The GPGMM Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "gpgmm/common/WorkerThread.h"
+
+using namespace gpgmm;
+
+#include <vector>
+
+class DummyTask : public VoidCallback {
+  public:
+    void operator()() override {
+        mIsTaskCompleted = true;
+    }
+
+    bool mIsTaskCompleted = false;
+};
+
+TEST(WorkerThreadTests, SingleAsyncTask) {
+    std::shared_ptr<ThreadPool> pool(ThreadPool::Create());
+    ASSERT_NE(pool, nullptr);
+
+    std::shared_ptr<DummyTask> task = std::make_shared<DummyTask>();
+    ASSERT_NE(task, nullptr);
+
+    std::shared_ptr<Event> event = ThreadPool::PostTask(pool, task);
+    ASSERT_NE(event, nullptr);
+
+    event->Wait();
+
+    ASSERT_TRUE(task->mIsTaskCompleted);
+}
+
+TEST(WorkerThreadTests, ManyTaskWait) {
+    std::shared_ptr<ThreadPool> pool(ThreadPool::Create());
+    ASSERT_NE(pool, nullptr);
+
+    constexpr uint32_t kTaskCount = 10000u;
+
+    std::vector<std::pair<std::shared_ptr<Event>, std::shared_ptr<DummyTask>>> tasks;
+    for (uint32_t i = 0; i < kTaskCount; i++) {
+        std::shared_ptr<DummyTask> task = std::make_shared<DummyTask>();
+        ASSERT_NE(task, nullptr);
+
+        tasks.push_back(std::make_pair(ThreadPool::PostTask(pool, task), task));
+    }
+
+    for (auto& task : tasks) {
+        task.first->Wait();
+        ASSERT_TRUE(task.second->mIsTaskCompleted);
+    }
+}
+
+TEST(WorkerThreadTests, ManyTaskExit) {
+    std::shared_ptr<ThreadPool> pool(ThreadPool::Create());
+    ASSERT_NE(pool, nullptr);
+
+    constexpr uint32_t kTaskCount = 10000u;
+
+    std::vector<std::pair<std::shared_ptr<Event>, std::shared_ptr<DummyTask>>> tasks;
+    for (uint32_t i = 0; i < kTaskCount; i++) {
+        std::shared_ptr<DummyTask> task = std::make_shared<DummyTask>();
+        ASSERT_NE(pool, nullptr);
+
+        tasks.push_back(std::make_pair(ThreadPool::PostTask(pool, task), task));
+    }
+
+    pool.reset();
+}


### PR DESCRIPTION
Avoids re-creating the thread between pre-fetches using the same thread pool.