### PR TITLE
 Fix ALLOCATION_FLAG_ALWAYS_CACHE_SIZE from disabling sub-allocation.

### DIFF
--- a/src/gpgmm/common/MemoryAllocator.h
+++ b/src/gpgmm/common/MemoryAllocator.h
@@ -63,14 +63,27 @@ namespace gpgmm {
          */
         uint64_t PrefetchedMemoryMissesEliminated;
 
+        /** \brief Requested size was NOT cached.
+         */
+        uint64_t CacheSizeMisses;
+
+        /** \brief Requested size was cached.
+         */
+        uint64_t CacheSizeHits;
+
         MEMORY_ALLOCATOR_INFO& operator+=(const MEMORY_ALLOCATOR_INFO& rhs) {
             UsedBlockCount += rhs.UsedBlockCount;
             UsedBlockUsage += rhs.UsedBlockUsage;
             FreeMemoryUsage += rhs.FreeMemoryUsage;
             UsedMemoryUsage += rhs.UsedMemoryUsage;
             UsedMemoryCount += rhs.UsedMemoryCount;
+
             PrefetchedMemoryMisses += rhs.PrefetchedMemoryMisses;
             PrefetchedMemoryMissesEliminated += rhs.PrefetchedMemoryMissesEliminated;
+
+            CacheSizeMisses += rhs.CacheSizeMisses;
+            CacheSizeHits += rhs.CacheSizeHits;
+
             return *this;
         }
     };

--- a/src/gpgmm/common/SlabMemoryAllocator.cpp
+++ b/src/gpgmm/common/SlabMemoryAllocator.cpp
@@ -487,6 +487,11 @@ namespace gpgmm {
         result.UsedMemoryCount = info.UsedMemoryCount;
         result.UsedMemoryUsage = info.UsedMemoryUsage;
 
+        // Size cache is common across slab allocators.
+        const CacheStats& sizeCacheStats = mSizeCache.GetStats();
+        result.CacheSizeHits = sizeCacheStats.NumOfHits;
+        result.CacheSizeMisses = sizeCacheStats.NumOfMisses;
+
         return result;
     }
 

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -429,7 +429,7 @@ namespace gpgmm { namespace d3d12 {
 
         Allow internal data structures used for resource allocation to be cached in-memory.
         */
-        ALLOCATION_FLAG_ALWAYS_CACHE_SIZE = 0x16,
+        ALLOCATION_FLAG_ALWAYS_CACHE_SIZE = 0x10,
     };
 
     using ALLOCATION_FLAGS_TYPE = Flags<ALLOCATION_FLAGS>;

--- a/src/tests/D3D12Test.cpp
+++ b/src/tests/D3D12Test.cpp
@@ -134,4 +134,12 @@ namespace gpgmm { namespace d3d12 {
         return GPGMMTestBase::GenerateTestAllocations(D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT);
     }
 
+    bool D3D12TestBase::IsSizeCacheEnabled() const {
+#if defined(GPGMM_ENABLE_SIZE_CACHE)
+        return true;
+#else
+        return false;
+#endif
+    }
+
 }}  // namespace gpgmm::d3d12

--- a/src/tests/D3D12Test.h
+++ b/src/tests/D3D12Test.h
@@ -50,6 +50,8 @@ namespace gpgmm { namespace d3d12 {
 
         static std::vector<MEMORY_ALLOCATION_EXPECT> GenerateBufferAllocations();
 
+        bool IsSizeCacheEnabled() const;
+
       protected:
         ComPtr<IDXGIAdapter3> mAdapter;
         ComPtr<ID3D12Device> mDevice;


### PR DESCRIPTION
Flag specified by GPGMM was wrong, which resulted in sub-allocation being disabled. Also, cached sizes did not apply to sub-allocating within a resource which may be unexpected.

This change fixes the incorrectly specified flag value, re-enables the size cache for small textures, and adds tests.