### PR TITLE
Filter out zero counts from metrics.

### DIFF
--- a/src/gpgmm/common/TraceEvent.h
+++ b/src/gpgmm/common/TraceEvent.h
@@ -47,6 +47,7 @@
 #define GPGMM_TRACE_EVENT_OBJECT_DESTROY(objPtr) TRACE_EMPTY
 #define GPGMM_TRACE_EVENT_OBJECT_SNAPSHOT(objPtr, desc) TRACE_EMPTY
 #define GPGMM_TRACE_EVENT_OBJECT_CALL(name, desc) TRACE_EMPTY
+#define GPGMM_TRACE_EVENT_METRIC(name, value) TRACE_EMPTY
 
 #else // !GPGMM_DISABLE_TRACING
 
@@ -142,6 +143,13 @@ const uint64_t kNoId = 0;
 // Helper macro to avoid evaluating the arguments when the condition doesn't hold.
 #define GPGMM_LAZY_SERIALIZE(object, condition) \
         !(condition) ? JSONSerializer::Serialize() : JSONSerializer::Serialize(object)
+
+// Works like TRACE_COUNTER1 but filters out zero'd samples.
+#define GPGMM_TRACE_EVENT_METRIC(name, value)                     \
+    do {                                                          \
+        if (value == 0) break;                                    \
+        TRACE_COUNTER1(TraceEventCategory::Default, name, value); \
+    } while (false)
 
 #endif
 

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
@@ -271,28 +271,22 @@ namespace gpgmm { namespace d3d12 {
         }
 
         // Not all segments could be used.
-        if (pVideoMemoryInfo->CurrentUsage > 0) {
-            TRACE_COUNTER1(
-                TraceEventCategory::Default,
-                ToString((memorySegmentGroup == DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL) ? "Dedicated"
-                                                                                     : "Shared",
-                         " GPU memory utilization (%)")
-                    .c_str(),
-                (pVideoMemoryInfo->CurrentUsage > pVideoMemoryInfo->Budget)
-                    ? 100
-                    : SafeDivison(pVideoMemoryInfo->CurrentUsage, pVideoMemoryInfo->Budget) * 100);
-        }
+        GPGMM_TRACE_EVENT_METRIC(
+            ToString((memorySegmentGroup == DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL) ? "Dedicated"
+                                                                                 : "Shared",
+                     " GPU memory utilization (%)")
+                .c_str(),
+            (pVideoMemoryInfo->CurrentUsage > pVideoMemoryInfo->Budget)
+                ? 100
+                : SafeDivison(pVideoMemoryInfo->CurrentUsage, pVideoMemoryInfo->Budget) * 100);
 
         // Reservations are optional.
-        if (pVideoMemoryInfo->CurrentReservation > 0) {
-            TRACE_COUNTER1(
-                TraceEventCategory::Default,
-                ToString((memorySegmentGroup == DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL) ? "Dedicated"
-                                                                                     : "Shared",
-                         " GPU memory reserved (MB)")
-                    .c_str(),
-                pVideoMemoryInfo->CurrentReservation / 1e6);
-        }
+        GPGMM_TRACE_EVENT_METRIC(
+            ToString((memorySegmentGroup == DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL) ? "Dedicated"
+                                                                                 : "Shared",
+                     " GPU memory reserved (MB)")
+                .c_str(),
+            pVideoMemoryInfo->CurrentReservation / 1e6);
 
         return S_OK;
     }
@@ -380,8 +374,7 @@ namespace gpgmm { namespace d3d12 {
         }
 
         if (objectsToEvict.size() > 0) {
-            TRACE_COUNTER1(TraceEventCategory::Default, "GPU memory page-out (MB)",
-                           evictedSizeInBytes / 1e6);
+            GPGMM_TRACE_EVENT_METRIC("GPU memory page-out (MB)", evictedSizeInBytes / 1e6);
 
             const uint32_t objectEvictCount = static_cast<uint32_t>(objectsToEvict.size());
             ReturnIfFailed(mDevice->Evict(objectEvictCount, objectsToEvict.data()));
@@ -475,10 +468,8 @@ namespace gpgmm { namespace d3d12 {
                                         nonLocalHeapsToMakeResident.data()));
         }
 
-        if (localSizeToMakeResident > 0 || nonLocalSizeToMakeResident > 0) {
-            TRACE_COUNTER1(TraceEventCategory::Default, "GPU memory page-in (MB)",
-                           (localSizeToMakeResident + nonLocalSizeToMakeResident) / 1e6);
-        }
+        GPGMM_TRACE_EVENT_METRIC("GPU memory page-in (MB)",
+                                 (localSizeToMakeResident + nonLocalSizeToMakeResident) / 1e6);
 
         // Queue and command-lists may not be specified since they are not capturable for playback.
         if (commandLists != nullptr && queue != nullptr) {

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -1103,24 +1103,24 @@ namespace gpgmm { namespace d3d12 {
             result += mResourceHeapAllocatorOfType[resourceHeapTypeIndex]->GetInfo();
         }
 
-        TRACE_COUNTER1(
-            TraceEventCategory::Default, "GPU allocation utilization (%)",
+        GPGMM_TRACE_EVENT_METRIC(
+            "GPU allocation utilization (%)",
             SafeDivison(result.UsedBlockUsage,
                         static_cast<double>(result.UsedMemoryUsage + result.FreeMemoryUsage)) *
                 100);
 
-        TRACE_COUNTER1(TraceEventCategory::Default, "GPU allocation free (MB)",
-                       result.FreeMemoryUsage / 1e6);
+        GPGMM_TRACE_EVENT_METRIC("GPU allocation free (MB)", result.FreeMemoryUsage / 1e6);
 
-        TRACE_COUNTER1(TraceEventCategory::Default, "GPU prefetch memory miss (%)",
-                       SafeDivison(result.PrefetchedMemoryMissesEliminated,
-                                   static_cast<double>(result.PrefetchedMemoryMisses +
-                                                       result.PrefetchedMemoryMissesEliminated)) *
-                           100);
+        GPGMM_TRACE_EVENT_METRIC(
+            "GPU prefetch memory cache (%)",
+            SafeDivison(result.PrefetchedMemoryMissesEliminated,
+                        static_cast<double>(result.PrefetchedMemoryMisses +
+                                            result.PrefetchedMemoryMissesEliminated)) *
+                100);
 
-        TRACE_COUNTER1(
-            TraceEventCategory::Default, "GPU size cache miss (%)",
-            SafeDivison(result.CacheSizeMisses,
+        GPGMM_TRACE_EVENT_METRIC(
+            "GPU request cache (%)",
+            SafeDivison(result.CacheSizeHits,
                         static_cast<double>(result.CacheSizeMisses + result.CacheSizeHits)) *
                 100);
 


### PR DESCRIPTION
Prevents sampling metrics with zero counts. Adds GPGMM_TRACE_EVENT_METRIC to replace using TRACE_COUNTER1 directly.