### PR TITLE
Fix non-standalone Windows CMake build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,12 +120,17 @@ endif()
 ################################################################################
 # GPGMM's public and common "configs"
 ################################################################################
+set(GPGMM_INCLUDE_DIRS
+  "${GPGMM_ROOT_DIR}/src"
+	"${GPGMM_INCLUDE_DIR}"
+)
+
+# Where GPGMM public .h files can be found.
+# Sets directory for header files to be searched.
+include_directories(${GPGMM_INCLUDE_DIRS})
 
 add_library(gpgmm_public_config INTERFACE)
-target_include_directories(gpgmm_public_config INTERFACE
-    "${GPGMM_ROOT_DIR}/src"
-    "${GPGMM_ROOT_DIR}/src/include"
-)
+target_include_directories(gpgmm_public_config INTERFACE "${GPGMM_INCLUDE_DIRS}")
 
 add_library(gpgmm_common_config INTERFACE)
 target_link_libraries(gpgmm_common_config INTERFACE gpgmm_public_config)

--- a/src/gpgmm/CMakeLists.txt
+++ b/src/gpgmm/CMakeLists.txt
@@ -21,9 +21,9 @@ if (BUILD_SHARED_LIBS)
 endif()
 
 target_link_libraries(gpgmm
-    PRIVATE gpgmm_utils
-            gpgmm_common
-            gpgmm_common_config
+    PUBLIC gpgmm_utils
+           gpgmm_common
+           gpgmm_common_config
 )
 
 # Only win32 app needs to link with user32.lib


### PR DESCRIPTION
Fixes: cannot open "gpgmm_d3d12.h" and min/max defintion errors when compiling with CMake.

#386