### PR TITLE
Rename namespaces to not be nested.

### DIFF
--- a/src/gpgmm/d3d12/BackendD3D12.h
+++ b/src/gpgmm/d3d12/BackendD3D12.h
@@ -17,7 +17,7 @@
 
 #include "gpgmm/common/Backend.h"
 
-namespace gpgmm { namespace d3d12 {
+namespace gpgmm::d3d12 {
 
     class Heap;
     class ResourceAllocation;
@@ -32,6 +32,6 @@ namespace gpgmm { namespace d3d12 {
         return gpgmm::ToBackend<BackendTrait>(common);
     }
 
-}}  // namespace gpgmm::d3d12
+}  // namespace gpgmm::d3d12
 
 #endif

--- a/src/gpgmm/d3d12/BufferAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/BufferAllocatorD3D12.cpp
@@ -20,7 +20,7 @@
 #include "gpgmm/d3d12/ResourceAllocationD3D12.h"
 #include "gpgmm/d3d12/ResourceAllocatorD3D12.h"
 
-namespace gpgmm { namespace d3d12 {
+namespace gpgmm::d3d12 {
 
     BufferAllocator::BufferAllocator(ResourceAllocator* resourceAllocator,
                                      D3D12_HEAP_TYPE heapType,
@@ -99,4 +99,4 @@ namespace gpgmm { namespace d3d12 {
         return mBufferAlignment;
     }
 
-}}  // namespace gpgmm::d3d12
+}  // namespace gpgmm::d3d12

--- a/src/gpgmm/d3d12/BufferAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/BufferAllocatorD3D12.h
@@ -19,7 +19,7 @@
 
 #include "gpgmm/d3d12/d3d12_platform.h"
 
-namespace gpgmm { namespace d3d12 {
+namespace gpgmm::d3d12 {
 
     class ResourceAllocator;
 
@@ -53,6 +53,6 @@ namespace gpgmm { namespace d3d12 {
         const uint64_t mBufferAlignment;
     };
 
-}}  // namespace gpgmm::d3d12
+}  // namespace gpgmm::d3d12
 
 #endif  // GPGMM_D3D12_BUFFERALLOCATORD3D12_H_

--- a/src/gpgmm/d3d12/CapsD3D12.cpp
+++ b/src/gpgmm/d3d12/CapsD3D12.cpp
@@ -19,7 +19,7 @@
 #include <cmath>
 #include <memory>
 
-namespace gpgmm { namespace d3d12 {
+namespace gpgmm::d3d12 {
 
     HRESULT SetMaxResourceSize(ID3D12Device* device, uint64_t* sizeOut) {
         D3D12_FEATURE_DATA_GPU_VIRTUAL_ADDRESS_SUPPORT feature = {};
@@ -92,4 +92,4 @@ namespace gpgmm { namespace d3d12 {
         return mIsResourceAccessAlwaysCoherent;
     }
 
-}}  // namespace gpgmm::d3d12
+}  // namespace gpgmm::d3d12

--- a/src/gpgmm/d3d12/CapsD3D12.h
+++ b/src/gpgmm/d3d12/CapsD3D12.h
@@ -20,7 +20,7 @@
 
 #include <cstdint>
 
-namespace gpgmm { namespace d3d12 {
+namespace gpgmm::d3d12 {
 
     class Caps {
       public:
@@ -47,6 +47,6 @@ namespace gpgmm { namespace d3d12 {
         bool mIsResourceAccessAlwaysCoherent = false;
     };
 
-}}  // namespace gpgmm::d3d12
+}  // namespace gpgmm::d3d12
 
 #endif  // GPGMM_D3D12_CAPSD3D12_H_

--- a/src/gpgmm/d3d12/DebugObjectD3D12.cpp
+++ b/src/gpgmm/d3d12/DebugObjectD3D12.cpp
@@ -14,7 +14,7 @@
 
 #include "gpgmm/d3d12/DebugObjectD3D12.h"
 
-namespace gpgmm { namespace d3d12 {
+namespace gpgmm::d3d12 {
 
     std::string DebugObject::GetDebugName() const {
         return mDebugName;
@@ -25,4 +25,4 @@ namespace gpgmm { namespace d3d12 {
         return SetDebugNameImpl(name);
     }
 
-}}  // namespace gpgmm::d3d12
+}  // namespace gpgmm::d3d12

--- a/src/gpgmm/d3d12/DebugObjectD3D12.h
+++ b/src/gpgmm/d3d12/DebugObjectD3D12.h
@@ -20,7 +20,7 @@
 
 #include <string>
 
-namespace gpgmm { namespace d3d12 {
+namespace gpgmm::d3d12 {
 
     /** \brief Debug object associates additional information for D3D objects using SetPrivateData.
 
@@ -55,6 +55,6 @@ namespace gpgmm { namespace d3d12 {
         std::string mDebugName;
     };
 
-}}  // namespace gpgmm::d3d12
+}  // namespace gpgmm::d3d12
 
 #endif  // GPGMM_D3D12_DEBUGOBJECTD3D12_H_

--- a/src/gpgmm/d3d12/DebugResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/DebugResourceAllocatorD3D12.cpp
@@ -20,7 +20,7 @@
 #include "gpgmm/d3d12/ResourceAllocationD3D12.h"
 #include "gpgmm/utils/Utils.h"
 
-namespace gpgmm { namespace d3d12 {
+namespace gpgmm::d3d12 {
 
     DebugResourceAllocator::ResourceAllocationEntry::ResourceAllocationEntry(
         ResourceAllocation* allocation)
@@ -91,4 +91,4 @@ namespace gpgmm { namespace d3d12 {
         return "DebugResourceAllocator";
     }
 
-}}  // namespace gpgmm::d3d12
+}  // namespace gpgmm::d3d12

--- a/src/gpgmm/d3d12/DebugResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/DebugResourceAllocatorD3D12.h
@@ -18,7 +18,7 @@
 #include "gpgmm/common/MemoryAllocator.h"
 #include "gpgmm/common/MemoryCache.h"
 
-namespace gpgmm { namespace d3d12 {
+namespace gpgmm::d3d12 {
 
     class ResourceAllocation;
 
@@ -67,6 +67,6 @@ namespace gpgmm { namespace d3d12 {
         MemoryCache<ResourceAllocationEntry> mLiveAllocations = {};
     };
 
-}}  // namespace gpgmm::d3d12
+}  // namespace gpgmm::d3d12
 
 #endif  // GPGMM_D3D12_DEBUGRESOURCEALLOCATORD3D12_H_

--- a/src/gpgmm/d3d12/ErrorD3D12.cpp
+++ b/src/gpgmm/d3d12/ErrorD3D12.cpp
@@ -20,7 +20,7 @@
 #include <iomanip>
 #include <sstream>
 
-namespace gpgmm { namespace d3d12 {
+namespace gpgmm::d3d12 {
 
     std::string GetErrorMessage(HRESULT error) {
         std::wstring wstring = TCharToWString(_com_error(error).ErrorMessage());
@@ -30,4 +30,4 @@ namespace gpgmm { namespace d3d12 {
         return ss.str();
     }
 
-}}  // namespace gpgmm::d3d12
+}  // namespace gpgmm::d3d12

--- a/src/gpgmm/d3d12/ErrorD3D12.h
+++ b/src/gpgmm/d3d12/ErrorD3D12.h
@@ -19,7 +19,7 @@
 
 #include <string>
 
-namespace gpgmm { namespace d3d12 {
+namespace gpgmm::d3d12 {
 
 #define ReturnIfFailed(expr)              \
     {                                     \
@@ -43,6 +43,6 @@ namespace gpgmm { namespace d3d12 {
 
     std::string GetErrorMessage(HRESULT error);
 
-}}  // namespace gpgmm::d3d12
+}  // namespace gpgmm::d3d12
 
 #endif  // GPGMM_D3D12_ERRORD3D12_H_

--- a/src/gpgmm/d3d12/FenceD3D12.cpp
+++ b/src/gpgmm/d3d12/FenceD3D12.cpp
@@ -17,7 +17,7 @@
 #include "gpgmm/d3d12/ErrorD3D12.h"
 #include "gpgmm/utils/Assert.h"
 
-namespace gpgmm { namespace d3d12 {
+namespace gpgmm::d3d12 {
 
     // static
     HRESULT Fence::CreateFence(ComPtr<ID3D12Device> device,
@@ -100,4 +100,4 @@ namespace gpgmm { namespace d3d12 {
         return mFence.Get();
     }
 
-}}  // namespace gpgmm::d3d12
+}  // namespace gpgmm::d3d12

--- a/src/gpgmm/d3d12/FenceD3D12.h
+++ b/src/gpgmm/d3d12/FenceD3D12.h
@@ -19,7 +19,7 @@
 
 #include <cstdint>
 
-namespace gpgmm { namespace d3d12 {
+namespace gpgmm::d3d12 {
 
     class Fence {
       public:
@@ -51,6 +51,6 @@ namespace gpgmm { namespace d3d12 {
         uint64_t mLastSignaledFence;
     };
 
-}}  // namespace gpgmm::d3d12
+}  // namespace gpgmm::d3d12
 
 #endif  // GPGMM_D3D12_FENCED3D12_H_

--- a/src/gpgmm/d3d12/HeapD3D12.cpp
+++ b/src/gpgmm/d3d12/HeapD3D12.cpp
@@ -21,7 +21,7 @@
 #include "gpgmm/d3d12/ResidencyManagerD3D12.h"
 #include "gpgmm/d3d12/UtilsD3D12.h"
 
-namespace gpgmm { namespace d3d12 {
+namespace gpgmm::d3d12 {
 
     // static
     HRESULT Heap::CreateHeap(const HEAP_DESC& descriptor,
@@ -126,4 +126,4 @@ namespace gpgmm { namespace d3d12 {
     HRESULT Heap::SetDebugNameImpl(const std::string& name) {
         return SetDebugObjectName(mPageable.Get(), name);
     }
-}}  // namespace gpgmm::d3d12
+}  // namespace gpgmm::d3d12

--- a/src/gpgmm/d3d12/HeapD3D12.h
+++ b/src/gpgmm/d3d12/HeapD3D12.h
@@ -25,7 +25,7 @@
 
 #include <memory>
 
-namespace gpgmm { namespace d3d12 {
+namespace gpgmm::d3d12 {
 
     class ResidencySet;
     class ResidencyManager;
@@ -182,6 +182,6 @@ namespace gpgmm { namespace d3d12 {
         RefCounted mResidencyLock;
         bool mIsExternal;
     };
-}}  // namespace gpgmm::d3d12
+}  // namespace gpgmm::d3d12
 
 #endif

--- a/src/gpgmm/d3d12/IUnknownImplD3D12.cpp
+++ b/src/gpgmm/d3d12/IUnknownImplD3D12.cpp
@@ -14,7 +14,7 @@
 
 #include "gpgmm/d3d12/IUnknownImplD3D12.h"
 
-namespace gpgmm { namespace d3d12 {
+namespace gpgmm::d3d12 {
     IUnknownImpl::IUnknownImpl() : RefCounted(1) {
     }
 
@@ -51,4 +51,4 @@ namespace gpgmm { namespace d3d12 {
     void IUnknownImpl::DeleteThis() {
         delete this;
     }
-}}  // namespace gpgmm::d3d12
+}  // namespace gpgmm::d3d12

--- a/src/gpgmm/d3d12/IUnknownImplD3D12.h
+++ b/src/gpgmm/d3d12/IUnknownImplD3D12.h
@@ -19,7 +19,7 @@
 #include "gpgmm/utils/RefCount.h"
 #include "include/gpgmm_export.h"
 
-namespace gpgmm { namespace d3d12 {
+namespace gpgmm::d3d12 {
 
     class GPGMM_EXPORT IUnknownImpl : public IUnknown, public RefCounted {
       public:
@@ -35,6 +35,6 @@ namespace gpgmm { namespace d3d12 {
         virtual void DeleteThis();
     };
 
-}}  // namespace gpgmm::d3d12
+}  // namespace gpgmm::d3d12
 
 #endif  // GPGMM_D3D12_IUNKNOWNIMPLD3D12_H_

--- a/src/gpgmm/d3d12/JSONSerializerD3D12.cpp
+++ b/src/gpgmm/d3d12/JSONSerializerD3D12.cpp
@@ -22,7 +22,7 @@
 #include "gpgmm/d3d12/ResourceAllocatorD3D12.h"
 #include "gpgmm/d3d12/UtilsD3D12.h"
 
-namespace gpgmm { namespace d3d12 {
+namespace gpgmm::d3d12 {
 
     // static
     JSONDict JSONSerializer::Serialize() {
@@ -250,4 +250,4 @@ namespace gpgmm { namespace d3d12 {
         return dict;
     }
 
-}}  // namespace gpgmm::d3d12
+}  // namespace gpgmm::d3d12

--- a/src/gpgmm/d3d12/JSONSerializerD3D12.h
+++ b/src/gpgmm/d3d12/JSONSerializerD3D12.h
@@ -18,7 +18,7 @@
 #include "gpgmm/common/JSONSerializer.h"
 #include "gpgmm/d3d12/d3d12_platform.h"
 
-namespace gpgmm { namespace d3d12 {
+namespace gpgmm::d3d12 {
 
     // Forward declare backend types.
     struct ALLOCATION_DESC;
@@ -69,6 +69,6 @@ namespace gpgmm { namespace d3d12 {
         static JSONDict Serialize(const ResidencySet& residencySet);
     };
 
-}}  // namespace gpgmm::d3d12
+}  // namespace gpgmm::d3d12
 
 #endif  // GPGMM_D3D12_JSONSERIALIZERD3D12_H_

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
@@ -27,7 +27,7 @@
 #include <algorithm>
 #include <vector>
 
-namespace gpgmm { namespace d3d12 {
+namespace gpgmm::d3d12 {
 
     static constexpr uint32_t kDefaultEvictBatchSize = 50ll * 1024ll * 1024ll;  // 50MB
     static constexpr float kDefaultVideoMemoryBudget = 0.95f;               // 95%
@@ -539,4 +539,4 @@ namespace gpgmm { namespace d3d12 {
         return info;
     }
 
-}}  // namespace gpgmm::d3d12
+}  // namespace gpgmm::d3d12

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.h
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.h
@@ -23,7 +23,7 @@
 #include <memory>
 #include <mutex>
 
-namespace gpgmm { namespace d3d12 {
+namespace gpgmm::d3d12 {
 
     class Fence;
     class Heap;
@@ -254,6 +254,6 @@ namespace gpgmm { namespace d3d12 {
         std::mutex mMutex;
     };
 
-}}  // namespace gpgmm::d3d12
+}  // namespace gpgmm::d3d12
 
 #endif  // GPGMM_D3D12_RESIDENCYMANAGERD3D12_H_

--- a/src/gpgmm/d3d12/ResidencySetD3D12.cpp
+++ b/src/gpgmm/d3d12/ResidencySetD3D12.cpp
@@ -16,7 +16,7 @@
 
 #include "gpgmm/common/TraceEvent.h"
 
-namespace gpgmm { namespace d3d12 {
+namespace gpgmm::d3d12 {
 
     ResidencySet::ResidencySet() {
         GPGMM_TRACE_EVENT_OBJECT_NEW(this);
@@ -53,4 +53,4 @@ namespace gpgmm { namespace d3d12 {
         return "ResidencySet";
     }
 
-}}  // namespace gpgmm::d3d12
+}  // namespace gpgmm::d3d12

--- a/src/gpgmm/d3d12/ResidencySetD3D12.h
+++ b/src/gpgmm/d3d12/ResidencySetD3D12.h
@@ -20,7 +20,7 @@
 
 #include <set>
 
-namespace gpgmm { namespace d3d12 {
+namespace gpgmm::d3d12 {
 
     class Heap;
 
@@ -71,6 +71,6 @@ namespace gpgmm { namespace d3d12 {
         UnderlyingType mSet;
     };
 
-}}  // namespace gpgmm::d3d12
+}  // namespace gpgmm::d3d12
 
 #endif

--- a/src/gpgmm/d3d12/ResourceAllocationD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocationD3D12.cpp
@@ -27,7 +27,7 @@
 
 #include <utility>
 
-namespace gpgmm { namespace d3d12 {
+namespace gpgmm::d3d12 {
 
     namespace {
 
@@ -169,4 +169,4 @@ namespace gpgmm { namespace d3d12 {
         return SetDebugObjectName(mResource.Get(), name);
     }
 
-}}  // namespace gpgmm::d3d12
+}  // namespace gpgmm::d3d12

--- a/src/gpgmm/d3d12/ResourceAllocationD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocationD3D12.h
@@ -23,7 +23,7 @@
 #include "gpgmm/utils/NonCopyable.h"
 #include "include/gpgmm_export.h"
 
-namespace gpgmm { namespace d3d12 {
+namespace gpgmm::d3d12 {
 
     class DebugResourceAllocator;
     class Heap;
@@ -209,6 +209,6 @@ namespace gpgmm { namespace d3d12 {
         const size_t mOffsetFromResource;
     };
 
-}}  // namespace gpgmm::d3d12
+}  // namespace gpgmm::d3d12
 
 #endif  // GPGMM_D3D12_RESOURCEALLOCATIOND3D12_H_

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -36,7 +36,7 @@
 #include "gpgmm/d3d12/ResourceHeapAllocatorD3D12.h"
 #include "gpgmm/d3d12/UtilsD3D12.h"
 
-namespace gpgmm { namespace d3d12 {
+namespace gpgmm::d3d12 {
     namespace {
 
         // Combines heap type and flags used to allocate memory for resources into a single type for
@@ -1229,4 +1229,4 @@ namespace gpgmm { namespace d3d12 {
         return E_INVALIDARG;
     }
 
-}}  // namespace gpgmm::d3d12
+}  // namespace gpgmm::d3d12

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -30,7 +30,7 @@ namespace gpgmm {
     class PlatformTime;
 }  // namespace gpgmm
 
-namespace gpgmm { namespace d3d12 {
+namespace gpgmm::d3d12 {
 
     class BufferAllocator;
     class Caps;
@@ -699,6 +699,6 @@ namespace gpgmm { namespace d3d12 {
         std::unique_ptr<DebugResourceAllocator> mDebugAllocator;
     };
 
-}}  // namespace gpgmm::d3d12
+}  // namespace gpgmm::d3d12
 
 #endif  // GPGMM_D3D12_RESOURCEALLOCATORD3D12_H_

--- a/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.cpp
@@ -24,7 +24,7 @@
 #include "gpgmm/utils/Limits.h"
 #include "gpgmm/utils/Math.h"
 
-namespace gpgmm { namespace d3d12 {
+namespace gpgmm::d3d12 {
 
     ResourceHeapAllocator::ResourceHeapAllocator(ResidencyManager* residencyManager,
                                                  ID3D12Device* device,
@@ -118,4 +118,4 @@ namespace gpgmm { namespace d3d12 {
         return "ResourceHeapAllocator";
     }
 
-}}  // namespace gpgmm::d3d12
+}  // namespace gpgmm::d3d12

--- a/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.h
@@ -19,7 +19,7 @@
 #include "gpgmm/common/MemoryAllocator.h"
 #include "gpgmm/d3d12/d3d12_platform.h"
 
-namespace gpgmm { namespace d3d12 {
+namespace gpgmm::d3d12 {
 
     class ResidencyManager;
 
@@ -48,6 +48,6 @@ namespace gpgmm { namespace d3d12 {
         const bool mIsUMA;
     };
 
-}}  // namespace gpgmm::d3d12
+}  // namespace gpgmm::d3d12
 
 #endif  // GPGMM_D3D12_RESOURCEHEAPALLOCATORD3D12_H_

--- a/src/gpgmm/d3d12/UtilsD3D12.cpp
+++ b/src/gpgmm/d3d12/UtilsD3D12.cpp
@@ -17,7 +17,7 @@
 #include "gpgmm/utils/Math.h"
 #include "gpgmm/utils/WindowsUtils.h"
 
-namespace gpgmm { namespace d3d12 {
+namespace gpgmm::d3d12 {
 
     DXGI_MEMORY_SEGMENT_GROUP GetPreferredMemorySegmentGroup(ID3D12Device* device,
                                                              bool isUMA,
@@ -436,4 +436,4 @@ namespace gpgmm { namespace d3d12 {
         return object->SetName(TCharToWString(name.c_str()).c_str());
     }
 
-}}  // namespace gpgmm::d3d12
+}  // namespace gpgmm::d3d12

--- a/src/gpgmm/d3d12/UtilsD3D12.h
+++ b/src/gpgmm/d3d12/UtilsD3D12.h
@@ -18,7 +18,7 @@
 
 #include <string>
 
-namespace gpgmm { namespace d3d12 {
+namespace gpgmm::d3d12 {
 
     DXGI_MEMORY_SEGMENT_GROUP GetPreferredMemorySegmentGroup(ID3D12Device* device,
                                                              bool isUMA,
@@ -27,6 +27,6 @@ namespace gpgmm { namespace d3d12 {
     bool IsAllowedToUseSmallAlignment(const D3D12_RESOURCE_DESC& Desc);
     HRESULT SetDebugObjectName(ID3D12Object* object, const std::string& name);
 
-}}  // namespace gpgmm::d3d12
+}  // namespace gpgmm::d3d12
 
 #endif  // GPGMM_D3D12_UTILSD3D12_H_

--- a/src/gpgmm/vk/BackendVk.h
+++ b/src/gpgmm/vk/BackendVk.h
@@ -17,7 +17,7 @@
 
 #include "gpgmm/common/Backend.h"
 
-namespace gpgmm { namespace vk {
+namespace gpgmm::vk {
 
     class DeviceMemory;
 
@@ -30,6 +30,6 @@ namespace gpgmm { namespace vk {
         return gpgmm::ToBackend<BackendTrait>(common);
     }
 
-}}  // namespace gpgmm::vk
+}  // namespace gpgmm::vk
 
 #endif  // GPGMM_VK_BACKENDVK_H_

--- a/src/gpgmm/vk/CapsVk.cpp
+++ b/src/gpgmm/vk/CapsVk.cpp
@@ -18,7 +18,7 @@
 #include <cstdint>
 #include <memory>
 
-namespace gpgmm { namespace vk {
+namespace gpgmm::vk {
 
     // static
     VkResult Caps::CreateCaps(VkPhysicalDevice physicalDevice,
@@ -49,4 +49,4 @@ namespace gpgmm { namespace vk {
         return mVulkanApiVersion;
     }
 
-}}  // namespace gpgmm::vk
+}  // namespace gpgmm::vk

--- a/src/gpgmm/vk/CapsVk.h
+++ b/src/gpgmm/vk/CapsVk.h
@@ -19,7 +19,7 @@
 
 #include <cstdint>
 
-namespace gpgmm { namespace vk {
+namespace gpgmm::vk {
 
     struct VulkanFunctions;
 
@@ -40,6 +40,6 @@ namespace gpgmm { namespace vk {
         uint32_t mVulkanApiVersion = 0;
     };
 
-}}  // namespace gpgmm::vk
+}  // namespace gpgmm::vk
 
 #endif  // GPGMM_VK_CAPSVK_H_

--- a/src/gpgmm/vk/DeviceMemoryAllocatorVk.cpp
+++ b/src/gpgmm/vk/DeviceMemoryAllocatorVk.cpp
@@ -21,7 +21,7 @@
 #include "gpgmm/vk/DeviceMemoryVk.h"
 #include "gpgmm/vk/ResourceAllocatorVk.h"
 
-namespace gpgmm { namespace vk {
+namespace gpgmm::vk {
 
     DeviceMemoryAllocator::DeviceMemoryAllocator(GpResourceAllocator resourceAllocator,
                                                  uint32_t memoryTypeIndex,
@@ -90,4 +90,4 @@ namespace gpgmm { namespace vk {
         SafeRelease(allocation);
     }
 
-}}  // namespace gpgmm::vk
+}  // namespace gpgmm::vk

--- a/src/gpgmm/vk/DeviceMemoryAllocatorVk.h
+++ b/src/gpgmm/vk/DeviceMemoryAllocatorVk.h
@@ -18,7 +18,7 @@
 #include "gpgmm/common/MemoryAllocator.h"
 #include "gpgmm/vk/vk_platform.h"
 
-namespace gpgmm { namespace vk {
+namespace gpgmm::vk {
 
     VK_DEFINE_HANDLE(GpResourceAllocator)
 
@@ -40,6 +40,6 @@ namespace gpgmm { namespace vk {
         VkDeviceSize mMemorySize;
     };
 
-}}  // namespace gpgmm::vk
+}  // namespace gpgmm::vk
 
 #endif  // GPGMM_VK_DEVICEMEMORYALLOCATORVK_H_

--- a/src/gpgmm/vk/DeviceMemoryVk.cpp
+++ b/src/gpgmm/vk/DeviceMemoryVk.cpp
@@ -14,7 +14,7 @@
 
 #include "gpgmm/vk/DeviceMemoryVk.h"
 
-namespace gpgmm { namespace vk {
+namespace gpgmm::vk {
 
     DeviceMemory::DeviceMemory(VkDeviceMemory memory,
                                uint32_t memoryTypeIndex,
@@ -31,4 +31,4 @@ namespace gpgmm { namespace vk {
         return mMemoryTypeIndex;
     }
 
-}}  // namespace gpgmm::vk
+}  // namespace gpgmm::vk

--- a/src/gpgmm/vk/DeviceMemoryVk.h
+++ b/src/gpgmm/vk/DeviceMemoryVk.h
@@ -19,7 +19,7 @@
 
 #include "gpgmm/vk/vk_platform.h"
 
-namespace gpgmm { namespace vk {
+namespace gpgmm::vk {
 
     class DeviceMemory final : public MemoryBase {
       public:
@@ -37,6 +37,6 @@ namespace gpgmm { namespace vk {
         uint32_t mMemoryTypeIndex = 0;
     };
 
-}}  // namespace gpgmm::vk
+}  // namespace gpgmm::vk
 
 #endif  // GPGMM_VK_DEVICEMEMORYVK_H_

--- a/src/gpgmm/vk/ErrorVk.h
+++ b/src/gpgmm/vk/ErrorVk.h
@@ -16,7 +16,7 @@
 
 #include "gpgmm/vk/vk_platform.h"
 
-namespace gpgmm { namespace vk {
+namespace gpgmm::vk {
 
 #define ReturnIfFailed(expr)        \
     {                               \
@@ -38,6 +38,6 @@ namespace gpgmm { namespace vk {
     for (;;)                        \
     break
 
-}}  // namespace gpgmm::vk
+}  // namespace gpgmm::vk
 
 #endif  // GPGMM_VK_ERRORVK_H_

--- a/src/gpgmm/vk/FunctionsVk.cpp
+++ b/src/gpgmm/vk/FunctionsVk.cpp
@@ -33,7 +33,7 @@
         functionName = reinterpret_cast<decltype(functionName)>(vk##functionName); \
     } while (0)
 
-namespace gpgmm { namespace vk {
+namespace gpgmm::vk {
     void VulkanFunctions::LoadInstanceFunctions(VkInstance instance) {
         GPGMM_DYNAMIC_GET_INSTANCE_FUNC(GetDeviceProcAddr);
         GPGMM_DYNAMIC_GET_INSTANCE_FUNC(GetPhysicalDeviceMemoryProperties);
@@ -97,4 +97,4 @@ namespace gpgmm { namespace vk {
         ASSERT(DestroyImage != nullptr);
     }
 
-}}  // namespace gpgmm::vk
+}  // namespace gpgmm::vk

--- a/src/gpgmm/vk/FunctionsVk.h
+++ b/src/gpgmm/vk/FunctionsVk.h
@@ -14,7 +14,7 @@
 
 #include "gpgmm/vk/vk_platform.h"
 
-namespace gpgmm { namespace vk {
+namespace gpgmm::vk {
 
     // Vulkan entrypoints used by GPGMM.
     struct VulkanFunctions {
@@ -50,4 +50,4 @@ namespace gpgmm { namespace vk {
         PFN_vkDestroyImage DestroyImage = nullptr;
     };
 
-}}  // namespace gpgmm::vk
+}  // namespace gpgmm::vk

--- a/src/gpgmm/vk/ResourceAllocatorVk.cpp
+++ b/src/gpgmm/vk/ResourceAllocatorVk.cpp
@@ -21,7 +21,7 @@
 #include "gpgmm/vk/DeviceMemoryVk.h"
 #include "gpgmm/vk/ErrorVk.h"
 
-namespace gpgmm { namespace vk {
+namespace gpgmm::vk {
 
     VkResult gpCreateResourceAllocator(const GpCreateAllocatorInfo& info,
                                        GpResourceAllocator* allocatorOut) {
@@ -261,4 +261,4 @@ namespace gpgmm { namespace vk {
     Caps* GpResourceAllocator_T::GetCaps() const {
         return mCaps.get();
     }
-}}  // namespace gpgmm::vk
+}  // namespace gpgmm::vk

--- a/src/gpgmm/vk/ResourceAllocatorVk.h
+++ b/src/gpgmm/vk/ResourceAllocatorVk.h
@@ -26,7 +26,7 @@ namespace gpgmm {
     class MemoryAllocation;
 }  // namespace gpgmm
 
-namespace gpgmm { namespace vk {
+namespace gpgmm::vk {
 
     /** \struct GpResourceAllocator
     \brief Opaque handle to a allocator object.
@@ -201,6 +201,6 @@ namespace gpgmm { namespace vk {
         std::vector<VkMemoryType> mMemoryTypes;
     };
 
-}}  // namespace gpgmm::vk
+}  // namespace gpgmm::vk
 
 #endif  // GPGMM_VK_RESOURCEALLOCATORVK_H_

--- a/src/tests/D3D12Test.cpp
+++ b/src/tests/D3D12Test.cpp
@@ -16,7 +16,7 @@
 
 #include <gpgmm_d3d12.h>
 
-namespace gpgmm { namespace d3d12 {
+namespace gpgmm::d3d12 {
 
     void D3D12TestBase::SetUp() {
         GPGMMTestBase::SetUp();
@@ -142,4 +142,4 @@ namespace gpgmm { namespace d3d12 {
 #endif
     }
 
-}}  // namespace gpgmm::d3d12
+}  // namespace gpgmm::d3d12

--- a/src/tests/D3D12Test.h
+++ b/src/tests/D3D12Test.h
@@ -27,7 +27,7 @@
 #define EXPECT_FAILED(expr) EXPECT_TRUE(FAILED(expr))
 #define EXPECT_SUCCEEDED(expr) EXPECT_TRUE(SUCCEEDED(expr))
 
-namespace gpgmm { namespace d3d12 {
+namespace gpgmm::d3d12 {
 
     struct ALLOCATOR_DESC;
     class ResourceAllocator;
@@ -60,6 +60,6 @@ namespace gpgmm { namespace d3d12 {
         D3D12_RESOURCE_HEAP_TIER mResourceHeapTier = D3D12_RESOURCE_HEAP_TIER_1;
     };
 
-}}  // namespace gpgmm::d3d12
+}  // namespace gpgmm::d3d12
 
 #endif  // TESTS_D3D12TEST_H_

--- a/src/tests/VKTest.cpp
+++ b/src/tests/VKTest.cpp
@@ -18,7 +18,7 @@
 
 #include <vector>
 
-namespace gpgmm { namespace vk {
+namespace gpgmm::vk {
 
     void VKTestBase::SetUp() {
         GPGMMTestBase::SetUp();
@@ -139,4 +139,4 @@ namespace gpgmm { namespace vk {
         return allocatorInfo;
     }
 
-}}  // namespace gpgmm::vk
+}  // namespace gpgmm::vk

--- a/src/tests/VKTest.h
+++ b/src/tests/VKTest.h
@@ -22,7 +22,7 @@
 #define ASSERT_FAILED(expr) ASSERT_TRUE((expr) != VK_SUCCESS)
 #define ASSERT_SUCCESS(expr) ASSERT_TRUE((expr) == VK_SUCCESS)
 
-namespace gpgmm { namespace vk {
+namespace gpgmm::vk {
 
     struct GpCreateAllocatorInfo;
 
@@ -39,6 +39,6 @@ namespace gpgmm { namespace vk {
         VkPhysicalDevice mPhysicalDevice = VK_NULL_HANDLE;
     };
 
-}}  // namespace gpgmm::vk
+}  // namespace gpgmm::vk
 
 #endif  // TESTS_VKTEST_H_


### PR DESCRIPTION
Changes "namespace gpgmm { namespace <backend>" to "namespace gpgmm:<backend>".