### PR TITLE
Fix D3D12ProjectTemplate builds.

### DIFF
--- a/examples/D3D12ProjectTemplate/CMakeLists.txt
+++ b/examples/D3D12ProjectTemplate/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.14)
 
 project(D3D12ProjectTemplate LANGUAGES CXX)
 
+set(CMAKE_CXX_STANDARD 17)
+
 include(FetchContent)
 FetchContent_Declare(gpgmm
   GIT_REPOSITORY https://github.com/intel/gpgmm.git


### PR DESCRIPTION
CXX17 was not but required to be specified to build with GPGMM.