### PR TITLE
Move backend build options from declare_args() to build_overrides.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,18 @@ BUILD.gn
 
 ```gn
 source_set("proj") {
-  deps = [ "${gpgmm_dir}:gpgmm" ]
+  deps = [ "${gpgmm_dir}:src/gpgmm" ]
 }
 ```
+
 Create `build_overrides/gpgmm.gni` file in root directory.
+
+To build with a backend, add the corresponding argument from following table in ``build_overrides/gpgmm.gni`:
+
+| Backend | Build override argument |
+|---------|--------------|
+| DirectX 12 | `gpgmm_enable_d3d12=true` |
+| Vulkan | `gpgmm_enable_vk=true` |
 
 ### CMake
 
@@ -211,13 +219,6 @@ Get the source code as follows:
 Generate build files using `gn args out/Debug` or `gn args out/Release`.
 
 A text editor will appear asking build arguments, the most common argument is `is_debug=true/false`; otherwise `gn args out/Release --list` shows all the possible options.
-
-To build with a backend, please set the corresponding argument from following table.
-
-| Backend | Build argument |
-|---------|--------------|
-| DirectX 12 | `gpgmm_enable_d3d12=true` |
-| Vulkan | `gpgmm_enable_vk=true` |
 
 ### Build
 

--- a/build_overrides/gpgmm_features.gni
+++ b/build_overrides/gpgmm_features.gni
@@ -14,9 +14,6 @@
 
 import("//build/config/gclient_args.gni")
 
-# Enable the compilation for UWP
-gpgmm_is_winuwp = is_win && target_os == "winuwp"
-
 # Non-standalone builds should not checkout integrations used for testing.
 # Rather then require GN clients to modify DEPS to disable,
 # always disable them here by default or when undefined.
@@ -36,13 +33,6 @@ declare_args() {
   # Enables event tracing even in release builds.
   # Sets -dGPGMM_FORCE_TRACING
   gpgmm_force_tracing = false
-
-  # Enables the compilation of the DirectX 12 backend.
-  gpgmm_enable_d3d12 = is_win
-
-  # Enables the compilation of the Vulkan backend
-  gpgmm_enable_vk = is_linux || is_chromeos || (is_win && !gpgmm_is_winuwp) ||
-                    is_fuchsia || is_android
 
   # Enables compilation of Dawn's end2end tests.
   gpgmm_enable_dawn = checkout_dawn
@@ -69,19 +59,6 @@ declare_args() {
   # Enables checking of device leaks.
   # Sets -dGPGMM_ENABLE_DEVICE_CHECKS
   gpgmm_enable_device_checks = false
-}
-
-# Declare separately since both depend on |gpgmm_enable_vk| and GN does not allow
-# args to depend on another args in the same declare_args().
-declare_args() {
-  # Uses our built version of the Vulkan validation layers
-  gpgmm_enable_vk_validation_layers =
-      gpgmm_enable_vk && ((is_linux && !is_chromeos) || is_win || is_mac)
-
-  # Uses our built version of the Vulkan loader on platforms where we can't
-  # assume to have one present at the system level.
-  gpgmm_enable_vk_loader =
-      gpgmm_enable_vk && (is_mac || (is_linux && !is_android))
 
   # Configures Vulkan functions by statically importing them (ie. importing the Vulkan loader symbols).
   gpgmm_vk_static_functions = true

--- a/build_overrides/gpgmm_overrides_with_defaults.gni
+++ b/build_overrides/gpgmm_overrides_with_defaults.gni
@@ -13,6 +13,9 @@
 # limitations under the License.
 import("//build_overrides/gpgmm.gni")
 
+# Enable the compilation for UWP
+gpgmm_is_winuwp = is_win && target_os == "winuwp"
+
 if (!defined(gpgmm_standalone)) {
   gpgmm_standalone = false
 }
@@ -53,4 +56,26 @@ if (!defined(gpgmm_vk_tools_dir)) {
 
 if (!defined(gpgmm_vk_validation_layers_dir)) {
   gpgmm_vk_validation_layers_dir = ""
+}
+
+if (!defined(gpgmm_enable_d3d12)) {
+  gpgmm_enable_d3d12 = is_win
+}
+
+if (!defined(gpgmm_enable_vk)) {
+  gpgmm_enable_vk = is_linux || is_chromeos || (is_win && !gpgmm_is_winuwp) ||
+                    is_fuchsia || is_android
+}
+
+# Use our built version of the Vulkan validation layers
+if (!defined(gpgmm_enable_vk_validation_layers)) {
+  gpgmm_enable_vk_validation_layers =
+      gpgmm_enable_vk && ((is_linux && !is_chromeos) || is_win || is_mac)
+}
+
+# Use our built version of the Vulkan loader on platforms where we can't
+# assume to have one present at the system level.
+if (!defined(gpgmm_enable_vk_loader)) {
+  gpgmm_enable_vk_loader =
+      gpgmm_enable_vk && (is_mac || (is_linux && !is_android))
 }


### PR DESCRIPTION
Avoids requiring every GN user to explicitly change the default parameters in gpgmm_features.gni or specify them in ARGS.gn, in order to disable a backend from being built.