### PR TITLE
Fix bug during trace shutdown.

### DIFF
--- a/src/gpgmm/common/EventTraceWriter.cpp
+++ b/src/gpgmm/common/EventTraceWriter.cpp
@@ -33,13 +33,17 @@ namespace gpgmm {
     }
 
     void EventTraceWriter::SetConfiguration(const std::string& traceFile,
-                                            const TraceEventPhase& ignoreMask) {
+                                            const TraceEventPhase& ignoreMask,
+                                            bool flushOnDestruct) {
         mTraceFile = (traceFile.empty()) ? mTraceFile : traceFile;
         mIgnoreMask = ignoreMask;
+        mFlushOnDestruct = flushOnDestruct;
     }
 
     EventTraceWriter::~EventTraceWriter() {
-        FlushQueuedEventsToDisk();
+        if (mFlushOnDestruct) {
+            FlushQueuedEventsToDisk();
+        }
     }
 
     void EventTraceWriter::EnqueueTraceEvent(char phase,

--- a/src/gpgmm/common/EventTraceWriter.h
+++ b/src/gpgmm/common/EventTraceWriter.h
@@ -30,7 +30,9 @@ namespace gpgmm {
       public:
         EventTraceWriter();
 
-        void SetConfiguration(const std::string& traceFile, const TraceEventPhase& ignoreMask);
+        void SetConfiguration(const std::string& traceFile,
+                              const TraceEventPhase& ignoreMask,
+                              bool flushOnDestruct);
 
         ~EventTraceWriter();
 
@@ -54,6 +56,7 @@ namespace gpgmm {
             mBufferPerThread;
 
         TraceEventPhase mIgnoreMask;
+        bool mFlushOnDestruct = true;
     };
 
 }  // namespace gpgmm

--- a/src/gpgmm/common/TraceEvent.cpp
+++ b/src/gpgmm/common/TraceEvent.cpp
@@ -33,12 +33,14 @@ namespace gpgmm {
         return gEventTrace.get();
     }
 
-    void StartupEventTrace(const std::string& traceFile, const TraceEventPhase& ignoreMask) {
+    void StartupEventTrace(const std::string& traceFile,
+                           const TraceEventPhase& ignoreMask,
+                           bool flushOnDestruct) {
 #if defined(GPGMM_DISABLE_TRACING)
         gpgmm::WarningLog() << "Event tracing enabled but unable to record due to GPGMM_DISABLE_TRACING.";
 #endif
 
-        GetInstance()->SetConfiguration(traceFile, ignoreMask);
+        GetInstance()->SetConfiguration(traceFile, ignoreMask, flushOnDestruct);
         TRACE_EVENT_METADATA1(TraceEventCategory::Metadata, "thread_name", "name",
                               "GPGMM_MainThread");
     }

--- a/src/gpgmm/common/TraceEvent.h
+++ b/src/gpgmm/common/TraceEvent.h
@@ -172,7 +172,8 @@ namespace gpgmm {
     class PlatformTime;
 
     void StartupEventTrace(const std::string& traceFile,
-                           const TraceEventPhase& ignoreMask);
+                           const TraceEventPhase& ignoreMask,
+                           bool flushOnDestruct);
 
     void ShutdownEventTrace();
 

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -343,8 +343,10 @@ namespace gpgmm::d3d12 {
         }
 
         if (newDescriptor.RecordOptions.Flags != ALLOCATOR_RECORD_FLAG_NONE) {
-            StartupEventTrace(descriptor.RecordOptions.TraceFile,
-                              static_cast<TraceEventPhase>(~newDescriptor.RecordOptions.Flags | 0));
+            StartupEventTrace(
+                descriptor.RecordOptions.TraceFile,
+                static_cast<TraceEventPhase>(~newDescriptor.RecordOptions.Flags | 0),
+                descriptor.RecordOptions.EventScope & ALLOCATOR_RECORD_SCOPE_PER_PROCESS);
 
             SetEventMessageLevel(GetLogSeverity(newDescriptor.RecordOptions.MinMessageLevel));
         }


### PR DESCRIPTION
Events could be still recorded after shutdown which caused the existing trace file to get overwritten with only those events. This fix destroys the instance, which requires StartupEventTrace to be called again to restart.