### PR TITLE
Avoid leaking event buffers in TLS.

### DIFF
--- a/src/gpgmm/common/EventTraceWriter.cpp
+++ b/src/gpgmm/common/EventTraceWriter.cpp
@@ -182,16 +182,15 @@ namespace gpgmm {
     }
 
     std::vector<TraceEvent>* EventTraceWriter::GetOrCreateBufferFromTLS() {
-        thread_local std::vector<TraceEvent>* pBufferInTLS = nullptr;
-        if (pBufferInTLS == nullptr) {
-            auto buffer = std::make_unique<std::vector<TraceEvent>>();
-            pBufferInTLS = buffer.get();
+        thread_local std::unique_ptr<std::vector<TraceEvent>> bufferInTLS;
+        if (bufferInTLS == nullptr) {
+            bufferInTLS.reset(new std::vector<TraceEvent>());
 
             std::lock_guard<std::mutex> mutex(mMutex);
-            mBufferPerThread[std::this_thread::get_id()] = std::move(buffer);
+            mBufferPerThread[std::this_thread::get_id()] = bufferInTLS.get();
         }
-        ASSERT(pBufferInTLS != nullptr);
-        return pBufferInTLS;
+        ASSERT(bufferInTLS != nullptr);
+        return bufferInTLS.get();
     }
 
     std::vector<TraceEvent> EventTraceWriter::MergeAndClearBuffers() const {

--- a/src/gpgmm/common/EventTraceWriter.h
+++ b/src/gpgmm/common/EventTraceWriter.h
@@ -52,8 +52,7 @@ namespace gpgmm {
         std::unique_ptr<PlatformTime> mPlatformTime;
         mutable std::mutex mMutex;
 
-        std::unordered_map<std::thread::id, std::unique_ptr<std::vector<TraceEvent>>>
-            mBufferPerThread;
+        std::unordered_map<std::thread::id, std::vector<TraceEvent>*> mBufferPerThread;
 
         TraceEventPhase mIgnoreMask;
         bool mFlushOnDestruct = true;


### PR DESCRIPTION
Stores event buffers in TLS using unique_ptr instead of raw pointer. Using a raw pointer is not safe because EventTraceWriter could be destructed where TLS has dangling references.