### PR TITLE
Allow extra D3D12_HEAP_FLAGS to be specified.

### DIFF
--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -451,6 +451,19 @@ namespace gpgmm::d3d12 {
         */
         D3D12_HEAP_TYPE HeapType = D3D12_HEAP_TYPE_DEFAULT;
 
+        /** \brief Additional heap flags that the resource requires.
+
+        By default, GPGMM infers the required heap flags based on the required
+        fields in the D3D12_RESOURCE_DESC, ALLOCATOR_DESC and ALLOCATION_DESC.
+        But if additional heap flags are required, they can also be specified.
+
+        It is recommended to only specify D3D12_HEAP_FLAG_NONE since not all
+        allocation methods are guarenteed to be supported.
+
+        Optional parameter.
+        */
+        D3D12_HEAP_FLAGS ExtraRequiredHeapFlags = D3D12_HEAP_FLAG_NONE;
+
         /** \brief Associates a name with the given allocation.
 
         Optional parameter. By default, no name is associated.

--- a/src/gpgmm/utils/Flags.h
+++ b/src/gpgmm/utils/Flags.h
@@ -120,6 +120,11 @@ namespace gpgmm {
             return mValue;
         }
 
+        // Returns true if |this| has all |flags|.
+        bool HasFlags(const Flags& flags) const {
+            return (mValue & flags) == flags;
+        }
+
       private:
         ValueT mValue;
     };

--- a/src/tests/unittests/FlagsTests.cpp
+++ b/src/tests/unittests/FlagsTests.cpp
@@ -59,6 +59,7 @@ namespace gpgmm {
             kFirst = 1,
             kSecond = 2,
             kThird = 3,
+            kFourth = 4,
         };
 
         using OptionFlags = Flags<Option>;
@@ -85,6 +86,15 @@ namespace gpgmm {
             ss << a;
             EXPECT_EQ(ss.str(), "3");
         }
+    }
+
+    TEST(FlagsTests, HasFlags) {
+        constexpr Desc::OptionFlags firstAndSecond = Desc::kFirst | Desc::kSecond;
+
+        EXPECT_TRUE(firstAndSecond.HasFlags(Desc::kSecond));
+        EXPECT_TRUE(firstAndSecond.HasFlags(Desc::kFirst));
+
+        EXPECT_FALSE(firstAndSecond.HasFlags(Desc::kFourth));
     }
 
 }  // namespace gpgmm


### PR DESCRIPTION
Support ExtraRequiredHeapFlags to ALLOCATION_DESC. If the heap flags are unsupported, the resource is always a committed one.