### PR TITLE
Another SafeDivide cast warning fix for MSVC.

### DIFF
--- a/src/gpgmm/common/SlabMemoryAllocator.cpp
+++ b/src/gpgmm/common/SlabMemoryAllocator.cpp
@@ -270,9 +270,9 @@ namespace gpgmm {
         bool allowSlabPrefetch = mAllowSlabPrefetch;
         if (allowSlabPrefetch &&
             mInfo.PrefetchedMemoryMissesEliminated < mInfo.PrefetchedMemoryMisses) {
-            const double currentCoverage =
+            const double currentCoverage = static_cast<double>(
                 SafeDivide(mInfo.PrefetchedMemoryMissesEliminated,
-                           mInfo.PrefetchedMemoryMissesEliminated + mInfo.PrefetchedMemoryMisses);
+                           mInfo.PrefetchedMemoryMissesEliminated + mInfo.PrefetchedMemoryMisses));
             if (currentCoverage < kPrefetchCoverageWarnMinThreshold) {
                 WarnEvent(GetTypename(), EventMessageId::PrefetchFailed)
                     << "Allow prefetch disabled, coverage went below threshold: ("

--- a/src/gpgmm/utils/Math.h
+++ b/src/gpgmm/utils/Math.h
@@ -59,9 +59,9 @@ namespace gpgmm {
 
     // Evaluates a/b, avoiding division by zero.
     template <typename T>
-    double SafeDivide(T dividend, T divisor) {
+    T SafeDivide(T dividend, T divisor) {
         if (divisor == 0) {
-            return 0.0;
+            return divisor;
         } else {
             return dividend / divisor;
         }

--- a/src/gpgmm/utils/WindowsTime.cpp
+++ b/src/gpgmm/utils/WindowsTime.cpp
@@ -29,7 +29,7 @@ namespace gpgmm {
             LARGE_INTEGER curTime;
             const bool success = QueryPerformanceCounter(&curTime);
             ASSERT(success);
-            return SafeDivide(curTime.QuadPart, GetFrequency());
+            return static_cast<double>(SafeDivide(curTime.QuadPart, GetFrequency()));
         }
 
         void StartElapsedTime() override {


### PR DESCRIPTION
Eliminates MSVC warnings related to SafeDivide by using the same type for both return/input and requires an explicit cast where needed.