### PR TITLE
Fix ASSERT when using slab + fixed pool.

### DIFF
--- a/src/gpgmm/common/PooledMemoryAllocator.cpp
+++ b/src/gpgmm/common/PooledMemoryAllocator.cpp
@@ -41,6 +41,10 @@ namespace gpgmm {
 
         GPGMM_ASSERT_NONZERO(request);
 
+        if (request.SizeInBytes != GetMemorySize()) {
+            return {};
+        }
+
         std::unique_ptr<MemoryAllocation> allocation = mPool->AcquireFromPool();
         if (allocation == nullptr) {
             GPGMM_TRY_ASSIGN(GetNextInChain()->TryAllocateMemory(request), allocation);


### PR DESCRIPTION
Fixes ASSERT when using slab + fixed sized pools. The fix adds a size-check to PooledMemoryAllocator::TryAllocateMemory.