### PR TITLE
Add workaround for automerge.

### DIFF
--- a/.github/workflows/linux_auto_merge.yaml
+++ b/.github/workflows/linux_auto_merge.yaml
@@ -1,26 +1,10 @@
 name: "Auto merge pull requests"
 
 on:
-  pull_request:
-    types:
-      - labeled
-      - unlabeled
-      - synchronize
-      - opened
-      - edited
-      - ready_for_review
-      - reopened
-      - unlocked
-
-  pull_request_review:
-    types:
-      - submitted
-
-  check_suite:
-    types:
-      - completed
-
-  status: {}
+  # Trigger when checks complete.
+  # This is manually triggered as final step of CI workflow.
+  repository_dispatch:
+    types: [checks-complete]
 
 jobs:
   automerge:

--- a/.github/workflows/win_dawn_dbg.yaml
+++ b/.github/workflows/win_dawn_dbg.yaml
@@ -110,3 +110,15 @@ jobs:
     - name: Regression check end2end tests
       run: |
         python test\scripts\regression_check.py ${{ github.workspace }}\..\baseline_end2end_tests.json ${{ github.workspace }}\..\test_end2end_tests.json
+
+    # Organization has automatic merging disabled.
+    # To re-enable, a custom "auto merge" workflow, linux_auto_merge.yaml is used.
+    # However, automerge always triggers before checks are completed or "all green".
+    # To workaround this issue, add a new trigger when the last job completes (this workflow).
+    # The final set in the last job should generate a repository_dispatch event, to trigger automerge.
+    # Note: REPO_ACCESS_TOKEN must be a PAT with `public_repo` (write-access) scope.
+    - name: Trigger automerge
+      uses: peter-evans/repository-dispatch@v1
+      with:
+        token: ${{ secrets.REPO_ACCESS_TOKEN }}
+        event-type: checks-complete


### PR DESCRIPTION
Auto merge doesn't trigger AFTER checks are all green. To workaround the issue, a trigger event is manually dispatched (end of the slowest workflow).