### PR TITLE
Rounding error fix for SafeDivide.

### DIFF
--- a/src/gpgmm/common/BuddyMemoryAllocator.cpp
+++ b/src/gpgmm/common/BuddyMemoryAllocator.cpp
@@ -38,7 +38,7 @@ namespace gpgmm {
 
     uint64_t BuddyMemoryAllocator::GetMemoryIndex(uint64_t offset) const {
         ASSERT(offset != kInvalidOffset);
-        return SafeDivide(offset, mMemorySize);
+        return static_cast<uint64_t>(SafeDivide(offset, mMemorySize));
     }
 
     std::unique_ptr<MemoryAllocation> BuddyMemoryAllocator::TryAllocateMemory(

--- a/src/gpgmm/common/SlabMemoryAllocator.cpp
+++ b/src/gpgmm/common/SlabMemoryAllocator.cpp
@@ -199,7 +199,8 @@ namespace gpgmm {
                 }
             }
 
-            Slab* pNewFreeSlab = new Slab(SafeDivide(slabSize, mBlockSize), mBlockSize);
+            Slab* pNewFreeSlab =
+                new Slab(static_cast<uint64_t>(SafeDivide(slabSize, mBlockSize)), mBlockSize);
             pCache->FreeList.push_front(pNewFreeSlab);
             pFreeSlab = pNewFreeSlab;
         }
@@ -268,9 +269,9 @@ namespace gpgmm {
         bool allowSlabPrefetch = mAllowSlabPrefetch;
         if (allowSlabPrefetch &&
             mInfo.PrefetchedMemoryMissesEliminated < mInfo.PrefetchedMemoryMisses) {
-            const double currentCoverage = static_cast<double>(
+            const double currentCoverage =
                 SafeDivide(mInfo.PrefetchedMemoryMissesEliminated,
-                           mInfo.PrefetchedMemoryMissesEliminated + mInfo.PrefetchedMemoryMisses));
+                           mInfo.PrefetchedMemoryMissesEliminated + mInfo.PrefetchedMemoryMisses);
             if (currentCoverage < kPrefetchCoverageWarnMinThreshold) {
                 WarnEvent(GetTypename(), EventMessageId::PrefetchFailed)
                     << "Allow prefetch disabled, coverage went below threshold: ("

--- a/src/gpgmm/utils/Math.h
+++ b/src/gpgmm/utils/Math.h
@@ -59,11 +59,11 @@ namespace gpgmm {
 
     // Evaluates a/b, avoiding division by zero.
     template <typename T>
-    T SafeDivide(T dividend, T divisor) {
+    double SafeDivide(T dividend, T divisor) {
         if (divisor == 0) {
-            return divisor;
+            return 0.0;
         } else {
-            return dividend / divisor;
+            return dividend / static_cast<double>(divisor);
         }
     }
 

--- a/src/gpgmm/utils/WindowsTime.cpp
+++ b/src/gpgmm/utils/WindowsTime.cpp
@@ -29,7 +29,7 @@ namespace gpgmm {
             LARGE_INTEGER curTime;
             const bool success = QueryPerformanceCounter(&curTime);
             ASSERT(success);
-            return static_cast<double>(SafeDivide(curTime.QuadPart, GetFrequency()));
+            return SafeDivide(curTime.QuadPart, GetFrequency());
         }
 
         void StartElapsedTime() override {

--- a/src/tests/unittests/MathTests.cpp
+++ b/src/tests/unittests/MathTests.cpp
@@ -18,6 +18,13 @@
 
 using namespace gpgmm;
 
+TEST(MathTests, Basic) {
+    // a/b = c
+    EXPECT_EQ(SafeDivide(100, 0), 0.0);
+    EXPECT_EQ(SafeDivide(100, 10), 10);
+    EXPECT_EQ(SafeDivide(1.25, 2.0), 0.625);
+}
+
 TEST(MathTests, IsPowerOfTwo) {
     // Check if number is POT.
     EXPECT_FALSE(IsPowerOfTwo(0u));  // 2^0 = 0


### PR DESCRIPTION
SafeDivide was performing integer instead of floating-point division which caused results to be always zero.