### PR TITLE
Support explicitly creating ResidencyManager.

### DIFF
--- a/src/gpgmm/d3d12/JSONSerializerD3D12.cpp
+++ b/src/gpgmm/d3d12/JSONSerializerD3D12.cpp
@@ -45,7 +45,6 @@ namespace gpgmm::d3d12 {
         dict.AddItem("MaxResourceHeapSize", desc.MaxResourceHeapSize);
         dict.AddItem("MaxVideoMemoryBudget", desc.MaxVideoMemoryBudget);
         dict.AddItem("Budget", desc.Budget);
-        dict.AddItem("EvictBatchSize", desc.EvictBatchSize);
         dict.AddItem("MemoryFragmentationLimit", desc.MemoryFragmentationLimit);
         return dict;
     }

--- a/src/tests/capture_replay_tests/D3D12EventTraceReplay.cpp
+++ b/src/tests/capture_replay_tests/D3D12EventTraceReplay.cpp
@@ -379,7 +379,6 @@ class D3D12EventTraceReplay : public D3D12TestBase, public CaptureReplayTestWith
                             allocatorDesc.MaxVideoMemoryBudget =
                                 snapshot["MaxVideoMemoryBudget"].asFloat();
                             allocatorDesc.Budget = snapshot["Budget"].asUInt64();
-                            allocatorDesc.EvictBatchSize = snapshot["EvictBatchSize"].asUInt64();
                             allocatorDesc.MemoryFragmentationLimit =
                                 snapshot["MemoryFragmentationLimit"].asDouble();
                         } else if (envParams.AllocatorProfile ==


### PR DESCRIPTION
Allows ResidencyManager to be created and configured seperately from ResourceAllocator. This allows for more configurability (and prevent duplicatation between ALLOCATOR_DESC and RESIDENCY_DESC).