### PR TITLE
Enable setting thread name.

### DIFF
--- a/src/gpgmm/common/MemoryAllocator.cpp
+++ b/src/gpgmm/common/MemoryAllocator.cpp
@@ -94,8 +94,8 @@ namespace gpgmm {
         const MemoryAllocationRequest& request) {
         std::shared_ptr<AllocateMemoryTask> task =
             std::make_shared<AllocateMemoryTask>(this, request);
-        return std::make_shared<MemoryAllocationEvent>(ThreadPool::PostTask(mThreadPool, task),
-                                                       task);
+        return std::make_shared<MemoryAllocationEvent>(
+            ThreadPool::PostTask(mThreadPool, task, "GPGMM_ThreadPrefetchWorker"), task);
     }
 
     uint64_t MemoryAllocator::ReleaseMemory(uint64_t bytesToRelease) {

--- a/src/gpgmm/common/WorkerThread.h
+++ b/src/gpgmm/common/WorkerThread.h
@@ -60,11 +60,13 @@ namespace gpgmm {
         static std::shared_ptr<ThreadPool> Create();
 
         static std::shared_ptr<Event> PostTask(std::shared_ptr<ThreadPool> pool,
-                                               std::shared_ptr<VoidCallback> callback);
+                                               std::shared_ptr<VoidCallback> callback,
+                                               const char* name);
 
       private:
         // Return event to wait on until the callback runs.
-        virtual std::shared_ptr<Event> postTaskImpl(std::shared_ptr<VoidCallback> callback) = 0;
+        virtual std::shared_ptr<Event> postTaskImpl(std::shared_ptr<VoidCallback> callback,
+                                                    const char* name) = 0;
     };
 
 }  // namespace gpgmm

--- a/src/gpgmm/utils/PlatformUtils.h
+++ b/src/gpgmm/utils/PlatformUtils.h
@@ -27,6 +27,7 @@ namespace gpgmm {
     bool SetEnvironmentVar(const char* variableName, const char* value);
     std::string GetExecutableDirectory();
     uint32_t GetPID();
+    void SetThreadName(const char* name);
 
 }  // namespace gpgmm
 


### PR DESCRIPTION
Allows thread names to appear in debugger, ETW traces, etc.