### PR TITLE
Fix overflow in SetMaxResource* related functions.

### DIFF
--- a/src/gpgmm/d3d12/CapsD3D12.cpp
+++ b/src/gpgmm/d3d12/CapsD3D12.cpp
@@ -15,6 +15,7 @@
 #include "gpgmm/d3d12/CapsD3D12.h"
 
 #include "gpgmm/d3d12/ErrorD3D12.h"
+#include "gpgmm/utils/Limits.h"
 
 #include <memory>
 
@@ -25,12 +26,13 @@ namespace gpgmm::d3d12 {
         ReturnIfFailed(
             device->CheckFeatureSupport(D3D12_FEATURE_GPU_VIRTUAL_ADDRESS_SUPPORT, &feature,
                                         sizeof(D3D12_FEATURE_DATA_GPU_VIRTUAL_ADDRESS_SUPPORT)));
-        // Prevent possible overflow.
-        if (feature.MaxGPUVirtualAddressBitsPerResource == 0) {
-            return E_INVALIDARG;
+        // Check for overflow.
+        if (feature.MaxGPUVirtualAddressBitsPerResource == 0 ||
+            feature.MaxGPUVirtualAddressBitsPerResource > GetNumOfBits<uint64_t>()) {
+            return E_FAIL;
         }
 
-        *sizeOut = (1 << (feature.MaxGPUVirtualAddressBitsPerResource - 1)) - 1;
+        *sizeOut = (1ull << (feature.MaxGPUVirtualAddressBitsPerResource - 1)) - 1;
         return S_OK;
     }
 
@@ -39,12 +41,13 @@ namespace gpgmm::d3d12 {
         ReturnIfFailed(
             device->CheckFeatureSupport(D3D12_FEATURE_GPU_VIRTUAL_ADDRESS_SUPPORT, &feature,
                                         sizeof(D3D12_FEATURE_DATA_GPU_VIRTUAL_ADDRESS_SUPPORT)));
-        // Prevent possible overflow.
-        if (feature.MaxGPUVirtualAddressBitsPerResource == 0) {
-            return E_INVALIDARG;
+        // Check for overflow.
+        if (feature.MaxGPUVirtualAddressBitsPerResource == 0 ||
+            feature.MaxGPUVirtualAddressBitsPerResource > GetNumOfBits<uint64_t>()) {
+            return E_FAIL;
         }
 
-        *sizeOut = (1 << (feature.MaxGPUVirtualAddressBitsPerResource - 1)) - 1;
+        *sizeOut = (1ull << (feature.MaxGPUVirtualAddressBitsPerResource - 1)) - 1;
         return S_OK;
     }
 

--- a/src/gpgmm/utils/Limits.h
+++ b/src/gpgmm/utils/Limits.h
@@ -15,6 +15,7 @@
 #ifndef GPGMM_UTILS_LIMITS_H_
 #define GPGMM_UTILS_LIMITS_H_
 
+#include <climits>  // CHAR_BIT
 #include <cstdint>
 #include <limits>
 
@@ -23,6 +24,12 @@ namespace gpgmm {
     static constexpr uint64_t kInvalidOffset = std::numeric_limits<uint64_t>::max();
     static constexpr uint64_t kInvalidSize = std::numeric_limits<uint64_t>::max();
     static constexpr uint64_t kInvalidIndex = std::numeric_limits<uint64_t>::max();
+
+    template <typename T>
+    constexpr size_t GetNumOfBits() {
+        static_assert(CHAR_BIT == 8, "Size of a char is not 8 bits.");
+        return sizeof(T) * CHAR_BIT;
+    }
 
 }  // namespace gpgmm
 


### PR DESCRIPTION
If the number of bits exceeds UINT32_MAX bits, SetMaxResource* would overflow. This only occured if the adapter supports >32 bit addresses.