### PR TITLE
Move size-aware LinkedList into seperate type.

### DIFF
--- a/src/gpgmm/common/SegmentedMemoryAllocator.cpp
+++ b/src/gpgmm/common/SegmentedMemoryAllocator.cpp
@@ -96,7 +96,7 @@ namespace gpgmm {
         if (existingFreeSegment == mFreeSegments.end()) {
             ASSERT(mFreeSegments.empty());
             MemorySegment* newFreeSegment = new MemorySegment{memorySize};
-            mFreeSegments.push_back(newFreeSegment);
+            newFreeSegment->InsertAfter(mFreeSegments.tail());
             return newFreeSegment;
         }
 

--- a/src/gpgmm/common/SlabMemoryAllocator.h
+++ b/src/gpgmm/common/SlabMemoryAllocator.h
@@ -112,10 +112,10 @@ namespace gpgmm {
 
         // Group of one or more slabs of the same size.
         struct SlabCache {
-            LinkedList<Slab> FreeList;  // Slabs that contain partial or empty
-                                        // slabs or some free blocks.
-            LinkedList<Slab> FullList;  // Slabs that are full or all blocks
-                                        // are marked as used.
+            SizedLinkedList<Slab> FreeList;  // Slabs that contain partial or empty
+                                             // slabs or some free blocks.
+            SizedLinkedList<Slab> FullList;  // Slabs that are full or all blocks
+                                             // are marked as used.
         };
 
         SlabCache* GetOrCreateCache(uint64_t slabSize);

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
@@ -189,7 +189,7 @@ namespace gpgmm::d3d12 {
         LRUCache* cache = GetVideoMemorySegmentCache(heap->GetMemorySegmentGroup());
         ASSERT(cache != nullptr);
 
-        cache->push_back(heap);
+        heap->InsertAfter(cache->tail());
 
         ASSERT(heap->IsInList());
 

--- a/src/gpgmm/utils/LinkedList.h
+++ b/src/gpgmm/utils/LinkedList.h
@@ -227,32 +227,7 @@ namespace gpgmm {
 
         // Using LinkedList in std::vector or STL container requires the move constructor to not
         // throw.
-        LinkedList(LinkedList&& other) noexcept
-            : root_(std::move(other.root_)), size_(other.size_) {
-            other.size_ = 0;
-        }
-
-        // Appends |e| to the end of the linked list.
-        void push_back(LinkNode<T>* e) {
-            e->InsertBefore(&root_);
-            size_++;
-        }
-
-        // Prepend |e| to the start of the linked list.
-        void push_front(LinkNode<T>* e) {
-            e->InsertBefore(head());
-            size_++;
-        }
-
-        // Removes the first node in the linked list.
-        void pop_front() {
-            remove(head());
-        }
-
-        // Removes |e| from the linked list, decreasing the size by 1.
-        void remove(LinkNode<T>* e) {
-            e->RemoveFromList();
-            size_--;
+        LinkedList(LinkedList&& other) noexcept : root_(std::move(other.root_)) {
         }
 
         LinkNode<T>* head() const {
@@ -275,11 +250,6 @@ namespace gpgmm {
                 SafeDelete(curr.value());
             }
             ASSERT(empty());
-            size_ = 0;
-        }
-
-        size_t size() const {
-            return size_;
         }
 
         iterator begin() {
@@ -300,6 +270,48 @@ namespace gpgmm {
 
       private:
         LinkNode<T> root_;
+    };
+
+    // SizedLinkedList is like LinkedList but also keeps track of the number of nodes in the
+    // list. Random insertion is not supported, only deletion. To insert, push from start or end
+    // of the list.
+    template <typename T>
+    class SizedLinkedList : public LinkedList<T> {
+      public:
+        // Appends |e| to the end of the linked list.
+        void push_back(LinkNode<T>* e) {
+            e->InsertBefore(LinkedList<T>::end());
+            size_++;
+        }
+
+        // Prepend |e| to the start of the linked list.
+        void push_front(LinkNode<T>* e) {
+            e->InsertBefore(LinkedList<T>::head());
+            size_++;
+        }
+
+        // Removes the first node in the linked list.
+        void pop_front() {
+            remove(LinkedList<T>::head());
+        }
+
+        // Removes |e| from the linked list, decreasing the size by 1.
+        void remove(LinkNode<T>* e) {
+            ASSERT(size_ > 0);
+            e->RemoveFromList();
+            size_--;
+        }
+
+        size_t size() const {
+            return size_;
+        }
+
+        void clear() {
+            LinkedList<T>::clear();
+            size_ = 0;
+        }
+
+      private:
         size_t size_ = 0;
     };
 

--- a/src/tests/unittests/LinkedListTests.cpp
+++ b/src/tests/unittests/LinkedListTests.cpp
@@ -41,15 +41,14 @@ TEST_F(LinkedListTests, Insert) {
     LinkNode<FakeObject>* end = new FakeObject();
 
     LinkedList<FakeObject> list;
-    list.push_front(middle);
-    list.push_front(start);
-    list.push_back(end);
+    start->InsertAfter(list.tail());
+    middle->InsertAfter(list.tail());
+    end->InsertAfter(list.tail());
 
     EXPECT_EQ(list.head(), start);
     EXPECT_EQ(list.tail(), end);
 
     EXPECT_FALSE(list.empty());
-    EXPECT_EQ(list.size(), 3u);
 }
 
 TEST_F(LinkedListTests, Remove) {
@@ -58,16 +57,15 @@ TEST_F(LinkedListTests, Remove) {
     LinkNode<FakeObject>* end = new FakeObject();
 
     LinkedList<FakeObject> list;
-    list.push_back(start);
-    list.push_back(middle);
-    list.push_back(end);
+    start->InsertAfter(list.tail());
+    middle->InsertAfter(list.tail());
+    end->InsertAfter(list.tail());
 
-    list.remove(middle);
-    list.remove(start);
-    list.remove(end);
+    start->RemoveFromList();
+    middle->RemoveFromList();
+    end->RemoveFromList();
 
     EXPECT_TRUE(list.empty());
-    EXPECT_EQ(list.size(), 0u);
 }
 
 TEST_F(LinkedListTests, Clear) {
@@ -76,31 +74,26 @@ TEST_F(LinkedListTests, Clear) {
     LinkNode<FakeObject>* third = new FakeObject();
 
     LinkedList<FakeObject> list;
-    list.push_back(first);
-    list.push_back(second);
-    list.push_back(third);
-
-    EXPECT_EQ(list.size(), 3u);
+    first->InsertAfter(list.tail());
+    second->InsertAfter(list.tail());
+    third->InsertAfter(list.tail());
 
     list.clear();
 
     EXPECT_TRUE(list.empty());
-    EXPECT_EQ(list.size(), 0u);
 }
 
 TEST_F(LinkedListTests, Move) {
     LinkNode<FakeObject>* objectInFirstList = new FakeObject();
 
     LinkedList<FakeObject> firstList;
-    firstList.push_back(objectInFirstList);
-    EXPECT_EQ(firstList.size(), 1u);
+    objectInFirstList->InsertAfter(firstList.tail());
     EXPECT_FALSE(firstList.empty());
 
     EXPECT_EQ(firstList.head(), objectInFirstList);
     EXPECT_EQ(firstList.tail(), objectInFirstList);
 
     LinkedList<FakeObject> secondList(std::move(firstList));
-    EXPECT_EQ(secondList.size(), 1u);
     EXPECT_FALSE(secondList.empty());
 
     EXPECT_EQ(secondList.head(), objectInFirstList);
@@ -108,10 +101,14 @@ TEST_F(LinkedListTests, Move) {
 }
 
 TEST_F(LinkedListTests, Iterator) {
+    LinkNode<FakeObject>* first = new FakeObject(1);
+    LinkNode<FakeObject>* second = new FakeObject(2);
+    LinkNode<FakeObject>* third = new FakeObject(3);
+
     LinkedList<FakeObject> list;
-    list.push_back(new FakeObject(1));
-    list.push_back(new FakeObject(2));
-    list.push_back(new FakeObject(3));
+    first->InsertAfter(list.tail());
+    second->InsertAfter(list.tail());
+    third->InsertAfter(list.tail());
 
     // Iterate through the whole range.
     size_t index = 0;
@@ -119,22 +116,42 @@ TEST_F(LinkedListTests, Iterator) {
         EXPECT_EQ(node.value()->mId, ++index);
     }
 
-    EXPECT_EQ(index, list.size());
-
     // Iterate through the whole range again (but using const).
     index = 0;
     for (const auto& node : list) {
         EXPECT_EQ(node.value()->mId, ++index);
     }
 
-    // Iterate through the whole range but remove the first.
+    // Iterate through the whole range but have the first remove itself.
     index = 0;
     for (auto& node : list) {
         if (node.value()->mId == 1) {
-            list.remove(node.value());
+            node.RemoveFromList();
         }
         EXPECT_EQ(node.value()->mId, ++index);
     }
+}
 
-    EXPECT_EQ(index, list.size() + 1);
+TEST_F(LinkedListTests, ListWithSize) {
+    LinkNode<FakeObject>* first = new FakeObject(1);
+    LinkNode<FakeObject>* second = new FakeObject(2);
+    LinkNode<FakeObject>* third = new FakeObject(3);
+
+    SizedLinkedList<FakeObject> list;
+    list.push_front(first);
+    list.push_front(second);
+    list.push_front(third);
+
+    EXPECT_EQ(list.size(), 3u);
+
+    list.pop_front();
+    EXPECT_EQ(list.head(), second);
+    EXPECT_EQ(list.size(), 2u);
+
+    list.remove(second);
+    EXPECT_EQ(list.head(), first);
+    EXPECT_EQ(list.size(), 1u);
+
+    list.clear();
+    EXPECT_EQ(list.size(), 0u);
 }


### PR DESCRIPTION
Previously, LinkedList has two different usages. The first usage was meant for fast random (non-iterator) based insertion, the second usage was non-random insertion where the size was known. This splits the latter usage into a seperate type, SizedLinkedList.

This change also identified a corner case bug where de-allocate incorrectly assumed the slab size was always equal to the memory size.