### PR TITLE
Fix --dump option from not capturing.

### DIFF
--- a/src/gpgmm/common/MemoryAllocator.cpp
+++ b/src/gpgmm/common/MemoryAllocator.cpp
@@ -27,7 +27,6 @@ namespace gpgmm {
         }
 
         void operator()() override {
-            DebugLog() << "AllocateMemoryTask: " << JSONSerializer::Serialize(mRequest).ToString();
             mAllocation = mAllocator->TryAllocateMemory(mRequest);
         }
 

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -275,8 +275,7 @@ namespace gpgmm::d3d12 {
                 // NeverAllocate always fails, so suppress it.
                 if (!request.NeverAllocate) {
                     InfoEvent(allocator->GetTypename(), EventMessageId::AllocatorFailed)
-                        << "Failed to allocate memory for request: " +
-                               gpgmm::JSONSerializer::Serialize(request).ToString();
+                        << "Failed to allocate memory for request";
                 }
                 return E_FAIL;
             }
@@ -284,9 +283,7 @@ namespace gpgmm::d3d12 {
             HRESULT hr = createResourceFn(*allocation);
             if (FAILED(hr)) {
                 InfoEvent(allocator->GetTypename(), EventMessageId::AllocatorFailed)
-                    << "Failed to create resource using allocation: " +
-                           gpgmm::JSONSerializer::Serialize(allocation->GetInfo()).ToString() +
-                           " due to error: " + GetErrorMessage(hr);
+                    << "Failed to create resource using allocation: " + GetErrorMessage(hr);
                 allocator->DeallocateMemory(std::move(allocation));
             }
             return hr;

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -129,11 +129,11 @@ namespace gpgmm::d3d12 {
 
         /** \brief Scopes events per process (or multiple allocators).
          */
-        ALLOCATOR_RECORD_SCOPE_PER_PROCESS = 0x0,
+        ALLOCATOR_RECORD_SCOPE_PER_PROCESS = 0x1,
 
         /** \brief Scopes events per allocator object.
          */
-        ALLOCATOR_RECORD_SCOPE_PER_INSTANCE = 0x1,
+        ALLOCATOR_RECORD_SCOPE_PER_INSTANCE = 0x2,
     };
 
     using ALLOCATOR_RECORD_SCOPE_TYPE = Flags<ALLOCATOR_RECORD_SCOPE>;


### PR DESCRIPTION
Process-wide tracing was always disabled because EventScope never had a enum bit set. Also, the 
recorded event messages were causing parsing failures because they encoded non-escaped messages as JSON.