### PR TITLE
Enable event tracing for residency.

### DIFF
--- a/.github/workflows/.patches/dawn.diff
+++ b/.github/workflows/.patches/dawn.diff
@@ -1,4 +1,4 @@
-From e41eefd8175a3cd7125699987d452dbfac72fb44 Mon Sep 17 00:00:00 2001
+From 25b98595af5e7bcc4cc46d964be139601d3a4a70 Mon Sep 17 00:00:00 2001
 From: Bryan Bernhart <bryan.bernhart@intel.com>
 Date: Tue, 15 Feb 2022 17:25:29 -0800
 Subject: [PATCH] Use GPGMM for D3D12 backend.
@@ -495,7 +495,7 @@ index 9747b41c0..50db56dbd 100644
  
  AdapterDiscoveryOptions::AdapterDiscoveryOptions()
 diff --git a/src/dawn/native/d3d12/DeviceD3D12.cpp b/src/dawn/native/d3d12/DeviceD3D12.cpp
-index 90ddc3041..8545685aa 100644
+index 90ddc3041..8d94ead35 100644
 --- a/src/dawn/native/d3d12/DeviceD3D12.cpp
 +++ b/src/dawn/native/d3d12/DeviceD3D12.cpp
 @@ -130,8 +130,43 @@ MaybeError Device::Initialize(const DeviceDescriptor* descriptor) {
@@ -525,17 +525,17 @@ index 90ddc3041..8545685aa 100644
 +        allocatorDesc.Flags |= gpgmm::d3d12::ALLOCATOR_FLAG_ALWAYS_IN_BUDGET;
 +    }
 +
++    if (IsToggleEnabled(Toggle::DumpResourceAllocator)) {
++        residencyDesc.RecordOptions.Flags |= gpgmm::d3d12::EVENT_RECORD_FLAG_ALL_EVENTS;
++        residencyDesc.RecordOptions.EventScope = gpgmm::d3d12::EVENT_RECORD_SCOPE_PER_INSTANCE;
++        residencyDesc.RecordOptions.TraceFile = "dawn_resource_allocator_dump.json";
++    }
++
 +    if (IsToggleEnabled(Toggle::UseD3D12ResidencyManagement)) {
 +        residencyDesc.VideoMemoryBudget = 0.95;  // Use up to 95%
 +        DAWN_TRY(CheckHRESULT(gpgmm::d3d12::ResidencyManager::CreateResidencyManager(
 +                                  residencyDesc, &mResidencyManager),
 +                              "D3D12 create residency manager"));
-+    }
-+
-+    if (IsToggleEnabled(Toggle::DumpResourceAllocator)) {
-+        allocatorDesc.RecordOptions.Flags |= gpgmm::d3d12::ALLOCATOR_RECORD_FLAG_ALL_EVENTS;
-+        allocatorDesc.RecordOptions.EventScope = gpgmm::d3d12::ALLOCATOR_RECORD_SCOPE_PER_INSTANCE;
-+        allocatorDesc.RecordOptions.TraceFile = "dawn_resource_allocator_dump.json";
 +    }
 +
 +    DAWN_TRY(CheckHRESULT(gpgmm::d3d12::ResourceAllocator::CreateAllocator(

--- a/src/gpgmm/d3d12/EventRecordD3D12.h
+++ b/src/gpgmm/d3d12/EventRecordD3D12.h
@@ -1,0 +1,116 @@
+// Copyright 2021 The GPGMM Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GPGMM_D3D12_EVENTRECORDD3D12_H_
+#define GPGMM_D3D12_EVENTRECORDD3D12_H_
+
+#include "gpgmm/d3d12/d3d12_platform.h"
+#include "gpgmm/utils/Flags.h"
+
+namespace gpgmm::d3d12 {
+
+    /** \enum EVENT_RECORD_FLAGS
+    Represents different event categories to record.
+    */
+    enum EVENT_RECORD_FLAGS {
+
+        /** \brief Record nothing.
+         */
+        EVENT_RECORD_FLAG_NONE = 0x0,
+
+        /** \brief Record lifetimes of API objects created by GPGMM.
+         */
+        EVENT_RECORD_FLAG_API_OBJECTS = 0x1,
+
+        /** \brief Record API calls made to GPGMM.
+         */
+        EVENT_RECORD_FLAG_API_CALLS = 0x2,
+
+        /** \brief Record duration of GPGMM API calls.
+         */
+        EVENT_RECORD_FLAG_API_TIMINGS = 0x4,
+
+        /** \brief Record metrics made to GPGMM API calls.
+         */
+        EVENT_RECORD_FLAG_COUNTERS = 0x8,
+
+        /** \brief Record events required for playback.
+
+         Bitwise OR'd combination of EVENT_RECORD_FLAG_API_OBJECTS and
+         EVENT_RECORD_FLAG_API_CALLS.
+         */
+        EVENT_RECORD_FLAG_CAPTURE = 0x3,
+
+        /** \brief Record everything.
+         */
+        EVENT_RECORD_FLAG_ALL_EVENTS = 0xFF,
+    };
+
+    using EVENT_RECORD_FLAGS_TYPE = Flags<EVENT_RECORD_FLAGS>;
+    DEFINE_OPERATORS_FOR_FLAGS(EVENT_RECORD_FLAGS_TYPE)
+
+    /** \enum EVENT_RECORD_SCOPE
+    Represents recording scopes to limit event recording.
+    */
+    enum EVENT_RECORD_SCOPE {
+
+        /** \brief Scopes events per process (or multiple instances).
+         */
+        EVENT_RECORD_SCOPE_PER_PROCESS = 0x1,
+
+        /** \brief Scopes events per instance.
+         */
+        EVENT_RECORD_SCOPE_PER_INSTANCE = 0x2,
+    };
+
+    /** \struct EVENT_RECORD_OPTIONS
+    Represents additional controls for recording.
+    */
+    struct EVENT_RECORD_OPTIONS {
+        /** \brief Flags used to decide what to record.
+
+        Optional parameter. By default, nothing is recorded.
+        */
+        EVENT_RECORD_FLAGS_TYPE Flags = EVENT_RECORD_FLAG_NONE;
+
+        /** \brief Minimum severity level to record messages.
+
+        Messages with lower severity will be ignored.
+
+        Optional parameter. By default, the minimum severity level is WARN.
+        */
+        D3D12_MESSAGE_SEVERITY MinMessageLevel = D3D12_MESSAGE_SEVERITY_WARNING;
+
+        /** \brief Specifies the scope of the events.
+
+        Optional parameter. By default, recording is per process.
+        */
+        EVENT_RECORD_SCOPE EventScope = EVENT_RECORD_SCOPE_PER_PROCESS;
+
+        /** \brief Record detailed timing events.
+
+        Optional parameter. By default, detailed timing events are disabled.
+        */
+        bool UseDetailedTimingEvents = false;
+
+        /** \brief Path to trace file.
+
+        Optional parameter. By default, a trace file is created for you.
+        */
+        std::string TraceFile;
+    };
+
+}  // namespace gpgmm::d3d12
+
+#endif  // GPGMM_D3D12_EVENTRECORDD3D12_H_

--- a/src/gpgmm/d3d12/JSONSerializerD3D12.cpp
+++ b/src/gpgmm/d3d12/JSONSerializerD3D12.cpp
@@ -82,7 +82,7 @@ namespace gpgmm::d3d12 {
     }
 
     // static
-    JSONDict JSONSerializer::Serialize(const ALLOCATOR_RECORD_OPTIONS& desc) {
+    JSONDict JSONSerializer::Serialize(const EVENT_RECORD_OPTIONS& desc) {
         JSONDict dict;
         dict.AddItem("Flags", desc.Flags);
         dict.AddItem("MinMessageLevel", desc.MinMessageLevel);

--- a/src/gpgmm/d3d12/JSONSerializerD3D12.h
+++ b/src/gpgmm/d3d12/JSONSerializerD3D12.h
@@ -23,7 +23,7 @@ namespace gpgmm::d3d12 {
     // Forward declare backend types.
     struct ALLOCATION_DESC;
     struct ALLOCATOR_DESC;
-    struct ALLOCATOR_RECORD_OPTIONS;
+    struct EVENT_RECORD_OPTIONS;
     struct HEAP_DESC;
     struct HEAP_INFO;
     struct RESOURCE_ALLOCATION_DESC;
@@ -62,7 +62,7 @@ namespace gpgmm::d3d12 {
         static JSONDict Serialize(const RESIDENCY_DESC& desc);
 
       private:
-        static JSONDict Serialize(const ALLOCATOR_RECORD_OPTIONS& desc);
+        static JSONDict Serialize(const EVENT_RECORD_OPTIONS& desc);
         static JSONDict Serialize(const D3D12_DEPTH_STENCIL_VALUE& depthStencilValue);
         static JSONDict Serialize(const FLOAT rgba[4]);
         static JSONDict Serialize(const D3D12_CLEAR_VALUE* clearValue);

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.h
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.h
@@ -16,6 +16,7 @@
 #ifndef GPGMM_D3D12_RESIDENCYMANAGERD3D12_H_
 #define GPGMM_D3D12_RESIDENCYMANAGERD3D12_H_
 
+#include "gpgmm/d3d12/EventRecordD3D12.h"
 #include "gpgmm/d3d12/IUnknownImplD3D12.h"
 #include "gpgmm/utils/LinkedList.h"
 #include "include/gpgmm_export.h"
@@ -58,6 +59,22 @@ namespace gpgmm::d3d12 {
         Required parameter. Use CheckFeatureSupport to determine if supported.
         */
         bool IsUMA;
+
+        /** \brief Minimum severity level to log messages to console.
+
+        Messages with lower severity will be ignored.
+
+        Optional parameter. By default, will log only corruption messages.
+        */
+        D3D12_MESSAGE_SEVERITY MinLogLevel = D3D12_MESSAGE_SEVERITY_WARNING;
+
+        /** \brief Specifies recording options.
+
+        For example, what events to record, and where to record them.
+
+        Optional parameter. By default, no options are specified for recording.
+        */
+        EVENT_RECORD_OPTIONS RecordOptions;
 
         /** \brief Total budget of video memory, expressed as a percentage.
 
@@ -271,6 +288,7 @@ namespace gpgmm::d3d12 {
         const uint64_t mEvictBatchSize;
         const bool mIsUMA;
         const bool mIsBudgetChangeEventsDisabled;
+        const bool mShutdownEventTrace;
 
         VideoMemorySegment mLocalVideoMemorySegment;
         VideoMemorySegment mNonLocalVideoMemorySegment;

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -17,6 +17,7 @@
 #define GPGMM_D3D12_RESOURCEALLOCATORD3D12_H_
 
 #include "gpgmm/common/MemoryAllocator.h"
+#include "gpgmm/d3d12/EventRecordD3D12.h"
 #include "gpgmm/d3d12/IUnknownImplD3D12.h"
 #include "gpgmm/utils/Flags.h"
 #include "include/gpgmm_export.h"
@@ -81,104 +82,6 @@ namespace gpgmm::d3d12 {
 
     using ALLOCATOR_FLAGS_TYPE = Flags<ALLOCATOR_FLAGS>;
     DEFINE_OPERATORS_FOR_FLAGS(ALLOCATOR_FLAGS_TYPE)
-
-    /** \enum ALLOCATOR_RECORD_FLAGS
-    Represents different event categories to record.
-    */
-    enum ALLOCATOR_RECORD_FLAGS {
-
-        /** \brief Record nothing.
-         */
-        ALLOCATOR_RECORD_FLAG_NONE = 0x0,
-
-        /** \brief Record lifetimes of API objects created by GPGMM.
-         */
-        ALLOCATOR_RECORD_FLAG_API_OBJECTS = 0x1,
-
-        /** \brief Record API calls made to GPGMM.
-         */
-        ALLOCATOR_RECORD_FLAG_API_CALLS = 0x2,
-
-        /** \brief Record duration of GPGMM API calls.
-         */
-        ALLOCATOR_RECORD_FLAG_API_TIMINGS = 0x4,
-
-        /** \brief Record metrics made to GPGMM API calls.
-         */
-        ALLOCATOR_RECORD_FLAG_COUNTERS = 0x8,
-
-        /** \brief Record events required for playback.
-
-         Bitwise OR'd combination of ALLOCATOR_RECORD_FLAG_API_OBJECTS and
-         ALLOCATOR_RECORD_FLAG_API_CALLS.
-         */
-        ALLOCATOR_RECORD_FLAG_CAPTURE = 0x3,
-
-        /** \brief Record everything.
-         */
-        ALLOCATOR_RECORD_FLAG_ALL_EVENTS = 0xFF,
-    };
-
-    using ALLOCATOR_RECORD_FLAGS_TYPE = Flags<ALLOCATOR_RECORD_FLAGS>;
-    DEFINE_OPERATORS_FOR_FLAGS(ALLOCATOR_RECORD_FLAGS_TYPE)
-
-    /** \enum ALLOCATOR_RECORD_SCOPE
-    Represents recording scopes to limit event recording.
-    */
-    enum ALLOCATOR_RECORD_SCOPE {
-
-        /** \brief Scopes events per process (or multiple allocators).
-         */
-        ALLOCATOR_RECORD_SCOPE_PER_PROCESS = 0x1,
-
-        /** \brief Scopes events per allocator object.
-         */
-        ALLOCATOR_RECORD_SCOPE_PER_INSTANCE = 0x2,
-    };
-
-    using ALLOCATOR_RECORD_SCOPE_TYPE = Flags<ALLOCATOR_RECORD_SCOPE>;
-    DEFINE_OPERATORS_FOR_FLAGS(ALLOCATOR_RECORD_SCOPE_TYPE)
-
-    /** \struct ALLOCATOR_RECORD_OPTIONS
-    Represents additional controls for recording.
-    */
-    struct ALLOCATOR_RECORD_OPTIONS {
-        /** \brief Flags used to decide what to record.
-
-        Optional parameter. By default, nothing is recorded.
-        */
-        ALLOCATOR_RECORD_FLAGS_TYPE Flags = ALLOCATOR_RECORD_FLAG_NONE;
-
-        /** \brief Minimum severity level to record messages.
-
-        Messages with lower severity will be ignored.
-
-        Optional parameter. By default, the minimum severity level is WARN.
-        */
-        D3D12_MESSAGE_SEVERITY MinMessageLevel = D3D12_MESSAGE_SEVERITY_WARNING;
-
-        /** \brief Specifies the scope of the events.
-
-        Optional parameter. By default, recording is per process.
-        */
-        ALLOCATOR_RECORD_SCOPE EventScope = ALLOCATOR_RECORD_SCOPE_PER_PROCESS;
-
-        /** \brief Record detailed timing events.
-
-        Records detailed trace events when a resource allocation is created. Details include the
-        current usage by the allocator.
-
-        Optional parameter. By default, detailed timing events will only be recorded when the App
-        calls GetInfo() directly.
-        */
-        bool UseDetailedTimingEvents = false;
-
-        /** \brief Path to trace file.
-
-        Optional parameter. By default, a trace file is created for you.
-        */
-        std::string TraceFile;
-    };
 
     /** \enum ALLOCATOR_ALGORITHM
     Specify the algorithms used for allocation.
@@ -260,7 +163,7 @@ namespace gpgmm::d3d12 {
 
         For example, what events to record, and where to record them.
         */
-        ALLOCATOR_RECORD_OPTIONS RecordOptions;
+        EVENT_RECORD_OPTIONS RecordOptions;
 
         /** \brief Specifies if unified memory architecture (UMA) support is enabled.
 

--- a/src/gpgmm/d3d12/UtilsD3D12.cpp
+++ b/src/gpgmm/d3d12/UtilsD3D12.cpp
@@ -19,6 +19,23 @@
 
 namespace gpgmm::d3d12 {
 
+    LogSeverity GetLogSeverity(D3D12_MESSAGE_SEVERITY messageSeverity) {
+        switch (messageSeverity) {
+            case D3D12_MESSAGE_SEVERITY_CORRUPTION:
+            case D3D12_MESSAGE_SEVERITY_ERROR:
+                return LogSeverity::Error;
+            case D3D12_MESSAGE_SEVERITY_WARNING:
+                return LogSeverity::Warning;
+            case D3D12_MESSAGE_SEVERITY_INFO:
+                return LogSeverity::Info;
+            case D3D12_MESSAGE_SEVERITY_MESSAGE:
+                return LogSeverity::Debug;
+            default:
+                UNREACHABLE();
+                return LogSeverity::Debug;
+        }
+    }
+
     DXGI_MEMORY_SEGMENT_GROUP GetPreferredMemorySegmentGroup(ID3D12Device* device,
                                                              bool isUMA,
                                                              D3D12_HEAP_TYPE heapType) {

--- a/src/gpgmm/d3d12/UtilsD3D12.h
+++ b/src/gpgmm/d3d12/UtilsD3D12.h
@@ -16,10 +16,13 @@
 
 #include "gpgmm/d3d12/d3d12_platform.h"
 
+#include "gpgmm/utils/Log.h"
+
 #include <string>
 
 namespace gpgmm::d3d12 {
 
+    LogSeverity GetLogSeverity(D3D12_MESSAGE_SEVERITY messageSeverity);
     DXGI_MEMORY_SEGMENT_GROUP GetPreferredMemorySegmentGroup(ID3D12Device* device,
                                                              bool isUMA,
                                                              D3D12_HEAP_TYPE heapType);

--- a/src/tests/D3D12Test.cpp
+++ b/src/tests/D3D12Test.cpp
@@ -71,16 +71,12 @@ namespace gpgmm::d3d12 {
             desc.Flags |= ALLOCATOR_FLAG_DISABLE_MEMORY_PREFETCH;
         }
 
-#if defined(NDEBUG)
-        desc.MinLogLevel = D3D12_MESSAGE_SEVERITY_WARNING;
-#else
-        desc.MinLogLevel = D3D12_MESSAGE_SEVERITY_MESSAGE;
-        desc.RecordOptions.UseDetailedTimingEvents = true;
-#endif
+        desc.MinLogLevel = GetDefaultLogLevel();
 
-        if (IsDumpResourceAllocatorEnabled()) {
-            desc.RecordOptions.Flags |= ALLOCATOR_RECORD_FLAG_ALL_EVENTS;
+        if (IsDumpAllEventsEnabled()) {
+            desc.RecordOptions.Flags |= EVENT_RECORD_FLAG_ALL_EVENTS;
             desc.RecordOptions.MinMessageLevel = desc.MinLogLevel;
+            desc.RecordOptions.UseDetailedTimingEvents = true;
         }
 
         return desc;
@@ -139,6 +135,14 @@ namespace gpgmm::d3d12 {
         return false;
 #else
         return true;
+#endif
+    }
+
+    D3D12_MESSAGE_SEVERITY D3D12TestBase::GetDefaultLogLevel() const {
+#if defined(NDEBUG)
+        return D3D12_MESSAGE_SEVERITY_WARNING;
+#else
+        return D3D12_MESSAGE_SEVERITY_MESSAGE;
 #endif
     }
 

--- a/src/tests/D3D12Test.h
+++ b/src/tests/D3D12Test.h
@@ -52,6 +52,8 @@ namespace gpgmm::d3d12 {
 
         bool IsSizeCacheEnabled() const;
 
+        D3D12_MESSAGE_SEVERITY GetDefaultLogLevel() const;
+
       protected:
         ComPtr<IDXGIAdapter3> mAdapter;
         ComPtr<ID3D12Device> mDevice;

--- a/src/tests/GPGMMTest.cpp
+++ b/src/tests/GPGMMTest.cpp
@@ -36,8 +36,8 @@ gpgmm::DebugPlatform* GPGMMTestBase::GetDebugPlatform() {
     return mDebugPlatform.get();
 }
 
-bool GPGMMTestBase::IsDumpResourceAllocatorEnabled() const {
-    return gTestEnv->IsDumpResourceAllocatorEnabled();
+bool GPGMMTestBase::IsDumpAllEventsEnabled() const {
+    return gTestEnv->IsDumpAllEventsEnabled();
 }
 
 // static
@@ -97,7 +97,7 @@ void InitGPGMMEnd2EndTestEnvironment(int argc, char** argv) {
 GPGMMTestEnvironment::GPGMMTestEnvironment(int argc, char** argv) {
     for (int i = 1; i < argc; ++i) {
         if (strcmp("--dump", argv[i]) == 0) {
-            mIsDumpResourceAllocatorEnabled = true;
+            mIsDumpAllEventsEnabled = true;
             continue;
         }
 
@@ -117,6 +117,6 @@ void GPGMMTestEnvironment::SetEnvironment(GPGMMTestEnvironment* env) {
 void GPGMMTestEnvironment::SetUp() {
 }
 
-bool GPGMMTestEnvironment::IsDumpResourceAllocatorEnabled() const {
-    return mIsDumpResourceAllocatorEnabled;
+bool GPGMMTestEnvironment::IsDumpAllEventsEnabled() const {
+    return mIsDumpAllEventsEnabled;
 }

--- a/src/tests/GPGMMTest.h
+++ b/src/tests/GPGMMTest.h
@@ -61,7 +61,7 @@ class GPGMMTestBase {
 
     gpgmm::DebugPlatform* GetDebugPlatform();
 
-    bool IsDumpResourceAllocatorEnabled() const;
+    bool IsDumpAllEventsEnabled() const;
 
     static std::vector<MEMORY_ALLOCATION_EXPECT> GenerateTestAllocations(uint64_t alignment);
 };
@@ -76,10 +76,10 @@ class GPGMMTestEnvironment : public testing::Environment {
 
     void SetUp() override;
 
-    bool IsDumpResourceAllocatorEnabled() const;
+    bool IsDumpAllEventsEnabled() const;
 
   private:
-    bool mIsDumpResourceAllocatorEnabled = false;
+    bool mIsDumpAllEventsEnabled = false;
 };
 
 #endif  // TESTS_GPGMMTEST_H_

--- a/src/tests/capture_replay_tests/D3D12EventTraceReplay.cpp
+++ b/src/tests/capture_replay_tests/D3D12EventTraceReplay.cpp
@@ -393,9 +393,8 @@ class D3D12EventTraceReplay : public D3D12TestBase, public CaptureReplayTestWith
 
                         if (envParams.CaptureEventMask != 0) {
                             allocatorDesc.RecordOptions.Flags |=
-                                static_cast<ALLOCATOR_RECORD_FLAGS_TYPE>(
-                                    envParams.CaptureEventMask);
-                            allocatorDesc.RecordOptions.Flags |= ALLOCATOR_RECORD_FLAG_CAPTURE;
+                                static_cast<EVENT_RECORD_FLAGS_TYPE>(envParams.CaptureEventMask);
+                            allocatorDesc.RecordOptions.Flags |= EVENT_RECORD_FLAG_CAPTURE;
                             allocatorDesc.RecordOptions.TraceFile = traceFile.path;
                             allocatorDesc.RecordOptions.MinMessageLevel =
                                 GetMessageSeverity(envParams.LogLevel);
@@ -404,7 +403,7 @@ class D3D12EventTraceReplay : public D3D12TestBase, public CaptureReplayTestWith
                             // events will be captured instead of overwritten per iteration.
                             if (envParams.Iterations == 1) {
                                 allocatorDesc.RecordOptions.EventScope =
-                                    ALLOCATOR_RECORD_SCOPE_PER_INSTANCE;
+                                    EVENT_RECORD_SCOPE_PER_INSTANCE;
                             }
                         }
 
@@ -577,10 +576,10 @@ TEST_P(D3D12EventTraceReplay, NeverAllocate) {
 TEST_P(D3D12EventTraceReplay, Recapture) {
     TestEnviromentParams forceParams = {};
 
-    forceParams.CaptureEventMask = ALLOCATOR_RECORD_FLAG_CAPTURE;
+    forceParams.CaptureEventMask = EVENT_RECORD_FLAG_CAPTURE;
     RunSingleTest(forceParams);
 
-    forceParams.CaptureEventMask = ALLOCATOR_RECORD_FLAG_NONE;
+    forceParams.CaptureEventMask = EVENT_RECORD_FLAG_NONE;
     RunSingleTest(forceParams);
 }
 

--- a/src/tests/end2end/D3D12ResidencyManagerTests.cpp
+++ b/src/tests/end2end/D3D12ResidencyManagerTests.cpp
@@ -68,6 +68,14 @@ class D3D12ResidencyManagerTests : public D3D12TestBase, public ::testing::Test 
         residencyDesc.Adapter = mAdapter;
         residencyDesc.Device = mDevice;
 
+        residencyDesc.MinLogLevel = GetDefaultLogLevel();
+
+        if (IsDumpAllEventsEnabled()) {
+            residencyDesc.RecordOptions.Flags |= EVENT_RECORD_FLAG_ALL_EVENTS;
+            residencyDesc.RecordOptions.MinMessageLevel = residencyDesc.MinLogLevel;
+            residencyDesc.RecordOptions.UseDetailedTimingEvents = true;
+        }
+
         return residencyDesc;
     }
 


### PR DESCRIPTION
Changes allocator specific event recording types to be more generic and re-used for residency events.

The residency manager takes precedence for configuring event tracing (and similarly, specifying the log level).