### PR TITLE
Eliminate block malloc/free from slab allocator.

### DIFF
--- a/src/gpgmm/common/SlabBlockAllocator.h
+++ b/src/gpgmm/common/SlabBlockAllocator.h
@@ -19,6 +19,15 @@
 
 namespace gpgmm {
 
+    struct Slab;
+
+    // SlabBlock keeps a reference back to the slab to avoid creating a copy of the block with the
+    // slab being allocated from.
+    struct SlabBlock : public MemoryBlock {
+        SlabBlock* pNext = nullptr;
+        Slab* pSlab = nullptr;
+    };
+
     // SlabBlockAllocator uses the slab allocation technique to satisfy an
     // a block-allocation request. A slab consists of contiguious memory carved up into
     // fixed-size blocks (also called "pages" or "chunks"). The slab allocator
@@ -40,10 +49,6 @@ namespace gpgmm {
         const char* GetTypename() const override;
 
       private:
-        struct SlabBlock : public MemoryBlock {
-            SlabBlock* pNext = nullptr;
-        };
-
         struct BlockList {
             SlabBlock* pHead = nullptr;  // First free block in slab.
         };

--- a/src/gpgmm/common/SlabMemoryAllocator.h
+++ b/src/gpgmm/common/SlabMemoryAllocator.h
@@ -72,44 +72,6 @@ namespace gpgmm {
 
         bool IsPrefetchCoverageBelowThreshold() const;
 
-        // Slab is a node in a doubly-linked list that contains a free-list of blocks
-        // and a reference to underlying memory.
-        struct Slab : public LinkNode<Slab>, public RefCounted {
-            Slab(uint64_t blockCount, uint64_t blockSize)
-                : RefCounted(0), Allocator(blockCount, blockSize) {
-            }
-
-            ~Slab() {
-                ASSERT(SlabMemory == nullptr);
-                if (IsInList()) {
-                    RemoveFromList();
-                }
-            }
-
-            uint64_t GetBlockCount() const {
-                return Allocator.GetBlockCount();
-            }
-
-            bool IsFull() const {
-                return static_cast<uint32_t>(GetRefCount()) == Allocator.GetBlockCount();
-            }
-
-            double GetUsedPercent() const {
-                return static_cast<uint32_t>(GetRefCount()) /
-                       static_cast<double>(Allocator.GetBlockCount());
-            }
-
-            SlabBlockAllocator Allocator;
-            std::unique_ptr<MemoryAllocation> SlabMemory;
-        };
-
-        // Stores a reference back to the slab containing the block so DeallocateMemory
-        // knows which slab (and block allocator) to use.
-        struct BlockInSlab : public MemoryBlock {
-            MemoryBlock* pBlock = nullptr;
-            Slab* pSlab = nullptr;
-        };
-
         // Group of one or more slabs of the same size.
         struct SlabCache {
             SizedLinkedList<Slab> FreeList;  // Slabs that contain partial or empty


### PR DESCRIPTION
Removes the need to wrap the block in a slab as a new type in favor of expanding the exiting block type which is assigned the slab.