### PR TITLE
Fix casting warnings on 32-bit builds.

### DIFF
--- a/src/gpgmm/common/SlabMemoryAllocator.h
+++ b/src/gpgmm/common/SlabMemoryAllocator.h
@@ -130,7 +130,7 @@ namespace gpgmm {
             explicit SlabAllocatorCacheEntry(uint64_t blockSize) : mBlockSize(blockSize) {
             }
 
-            size_t GetKey() const {
+            uint64_t GetKey() const {
                 return mBlockSize;
             }
 

--- a/src/gpgmm/d3d12/ResourceAllocationD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocationD3D12.h
@@ -49,7 +49,7 @@ namespace gpgmm::d3d12 {
 
          Always zero when the resource is placed in a heap or created with it's own heap.
         */
-        uint64_t OffsetFromResource;
+        size_t OffsetFromResource;
 
         /** \brief Method to describe how the allocation was created.
 

--- a/src/gpgmm/utils/Math.cpp
+++ b/src/gpgmm/utils/Math.cpp
@@ -99,11 +99,11 @@ namespace gpgmm {
         return number % multiple == 0;
     }
 
-    uint64_t RoundUp(uint64_t n, uint64_t m) {
-        ASSERT(m > 0);
-        ASSERT(n > 0);
-        ASSERT(m <= std::numeric_limits<uint64_t>::max() - n);
-        return ((n + m - 1) / m) * m;
+    uint64_t RoundUp(uint64_t number, uint64_t multiple) {
+        ASSERT(multiple > 0);
+        ASSERT(number > 0);
+        ASSERT(multiple <= std::numeric_limits<uint64_t>::max() - number);
+        return ((number + multiple - 1) / multiple) * multiple;
     }
 
 }  // namespace gpgmm

--- a/src/gpgmm/utils/Math.h
+++ b/src/gpgmm/utils/Math.h
@@ -35,27 +35,19 @@ namespace gpgmm {
     uint64_t NextPowerOfTwo(uint64_t number);
     bool IsAligned(uint64_t number, size_t multiple);
 
-    template <typename T>
-    T AlignToPowerOfTwo(T number, size_t alignment) {
-        ASSERT(number <= std::numeric_limits<T>::max() - (alignment - 1));
-        ASSERT(IsPowerOfTwo(alignment));
-        ASSERT(alignment != 0);
-        const T& alignmentT = static_cast<T>(alignment);
-        return (number + (alignmentT - 1)) & ~(alignmentT - 1);
-    }
-
-    template <typename T>
-    T AlignTo(T number, size_t multiple) {
-        if (IsPowerOfTwo(multiple)) {
-            return AlignToPowerOfTwo(number, multiple);
-        }
-        ASSERT(number <= std::numeric_limits<T>::max() - (multiple - 1));
+    // Aligns number to the nearest power-of-two multiple.
+    // Compatible with 32-bit or 64-bit numbers.
+    template <typename T1, typename T2>
+    auto AlignTo(T1 number, T2 multiple) {
+        ASSERT(number <= std::numeric_limits<T1>::max() - (multiple - 1));
+        ASSERT(IsPowerOfTwo(multiple));
         ASSERT(multiple != 0);
-        const T& multipleT = static_cast<T>(multiple);
-        return ((number + multipleT - 1) / multipleT) * multipleT;
+        // Use of bitwise not (~) must be avoided since a 64-bit multiple would be always ~'d to a
+        // 32-bit range.
+        return (number + (multiple - 1)) - ((number + (multiple - 1)) & (multiple - 1));
     }
 
-    uint64_t RoundUp(uint64_t n, uint64_t m);
+    uint64_t RoundUp(uint64_t number, uint64_t multiple);
 
     // Evaluates a/b, avoiding division by zero.
     template <typename T>

--- a/src/tests/unittests/MathTests.cpp
+++ b/src/tests/unittests/MathTests.cpp
@@ -68,14 +68,9 @@ TEST(MathTests, AlignTo) {
     EXPECT_EQ(AlignTo(10u, 16), 16u);
     EXPECT_EQ(AlignTo(16u, 16u), 16u);
 
-    // Align NPOT number with NPOT multiple.
-    EXPECT_EQ(AlignTo(10u, 14), 14u);
-    EXPECT_EQ(AlignTo(10u, 10u), 10u);
-
     // Align UINT32_MAX to POT multiple.
-    ASSERT_EQ(AlignTo(static_cast<uint64_t>(0xFFFFFFFF), 4), 0x100000000u);
-    ASSERT_EQ(AlignTo(static_cast<uint64_t>(0xFFFFFFFF), 7), 0x100000000u + 3u);
+    ASSERT_EQ(AlignTo(static_cast<uint64_t>(0xFFFFFFFF), 4ull), 0x100000000u);
 
     // Align UINT64_MAX to POT multiple.
-    ASSERT_EQ(AlignTo(static_cast<uint64_t>(0xFFFFFFFFFFFFFFFF), 1), 0xFFFFFFFFFFFFFFFFull);
+    ASSERT_EQ(AlignTo(static_cast<uint64_t>(0xFFFFFFFFFFFFFFFF), 1ull), 0xFFFFFFFFFFFFFFFFull);
 }


### PR DESCRIPTION
AlignTo is now safe to use with 32-bit multiples and fixed other number type mismatches.