### PR TITLE
Remove path triggers from required workflows.

### DIFF
--- a/.github/workflows/win_clang_dbg_x64.yaml
+++ b/.github/workflows/win_clang_dbg_x64.yaml
@@ -1,15 +1,10 @@
 name: win_clang_dbg_x64
 
 on:
+  # This is a required workflow specified in branch enforcement
+  # and must run unconditionally to allow merges.
   push:
-    paths:
-      - 'src/**'
-      - 'DEPS'
-
   pull_request:
-    paths:
-      - 'src/**'
-      - 'DEPS'
 
 jobs:
 

--- a/.github/workflows/win_clang_rel_x64.yaml
+++ b/.github/workflows/win_clang_rel_x64.yaml
@@ -1,15 +1,10 @@
 name: win_clang_rel_x64
 
 on:
+  # This is a required workflow specified in branch enforcement
+  # and must run unconditionally to allow merges.
   push:
-    paths:
-      - 'src/**'
-      - 'DEPS'
-
   pull_request:
-    paths:
-      - 'src/**'
-      - 'DEPS'
 
 jobs:
 

--- a/.github/workflows/win_msvc_dbg_x64.yaml
+++ b/.github/workflows/win_msvc_dbg_x64.yaml
@@ -1,15 +1,10 @@
 name: win_msvc_dbg_x64
 
 on:
+  # This is a required workflow specified in branch enforcement
+  # and must run unconditionally to allow merges.
   push:
-    paths:
-      - 'src/**'
-      - 'DEPS'
-
   pull_request:
-    paths:
-      - 'src/**'
-      - 'DEPS'
 
 jobs:
 

--- a/.github/workflows/win_msvc_dbg_x64_cmake.yaml
+++ b/.github/workflows/win_msvc_dbg_x64_cmake.yaml
@@ -1,17 +1,10 @@
 name: win_msvc_dbg_x64_cmake
 
 on:
+  # This is a required workflow specified in branch enforcement
+  # and must run unconditionally to allow merges.
   push:
-    paths:
-      - 'src/**'
-      - '**/CMakeLists.txt'
-      - '**/*_cmake.yaml'
-
   pull_request:
-    paths:
-      - 'src/**'
-      - '**/CMakeLists.txt'
-      - '**/*_cmake.yaml'
 
 jobs:
 

--- a/.github/workflows/win_msvc_rel_x64.yaml
+++ b/.github/workflows/win_msvc_rel_x64.yaml
@@ -1,15 +1,10 @@
 name: win_msvc_rel_x64
 
 on:
+  # This is a required workflow specified in branch enforcement
+  # and must run unconditionally to allow merges.
   push:
-    paths:
-      - 'src/**'
-      - 'DEPS'
-
   pull_request:
-    paths:
-      - 'src/**'
-      - 'DEPS'
 
 jobs:
 

--- a/.github/workflows/win_msvc_rel_x64_cmake.yaml
+++ b/.github/workflows/win_msvc_rel_x64_cmake.yaml
@@ -1,17 +1,10 @@
 name: win_msvc_rel_x64_cmake
 
 on:
+  # This is a required workflow specified in branch enforcement
+  # and must run unconditionally to allow merges.
   push:
-    paths:
-      - 'src/**'
-      - '**/CMakeLists.txt'
-      - '**/*_cmake.yaml'
-
   pull_request:
-    paths:
-      - 'src/**'
-      - '**/CMakeLists.txt'
-      - '**/*_cmake.yaml'
 
 jobs:
 


### PR DESCRIPTION
Workflows specified in branch enforcement must run in order to merge but if the triggers only run on certain path changes, not all required workflows will run.

This change removes the paths so the required workflows always run, reguardless.