### PR TITLE
Fix re-capture when using residency manager.

### DIFF
--- a/src/gpgmm/common/TraceEvent.cpp
+++ b/src/gpgmm/common/TraceEvent.cpp
@@ -37,7 +37,8 @@ namespace gpgmm {
                            const TraceEventPhase& ignoreMask,
                            bool flushOnDestruct) {
 #if defined(GPGMM_DISABLE_TRACING)
-        gpgmm::WarningLog() << "Event tracing enabled but unable to record due to GPGMM_DISABLE_TRACING.";
+        gpgmm::WarningLog()
+            << "Event tracing enabled but unable to record due to GPGMM_DISABLE_TRACING.";
 #endif
 
         GetInstance()->SetConfiguration(traceFile, ignoreMask, flushOnDestruct);
@@ -45,7 +46,10 @@ namespace gpgmm {
                               "GPGMM_MainThread");
     }
 
-    void ShutdownEventTrace() {
+    void FlushEventTraceToDisk() {
+        if (!IsEventTraceEnabled()) {
+            return;
+        }
         GetInstance()->FlushQueuedEventsToDisk();
     }
 

--- a/src/gpgmm/common/TraceEvent.h
+++ b/src/gpgmm/common/TraceEvent.h
@@ -179,7 +179,7 @@ namespace gpgmm {
                            const TraceEventPhase& ignoreMask,
                            bool flushOnDestruct);
 
-    void ShutdownEventTrace();
+    void FlushEventTraceToDisk();
 
     bool IsEventTraceEnabled();
 

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
@@ -222,8 +222,8 @@ namespace gpgmm::d3d12 {
                                                          : descriptor.EvictBatchSize),
           mIsUMA(descriptor.IsUMA),
           mIsBudgetChangeEventsDisabled(descriptor.UpdateBudgetByPolling),
-          mShutdownEventTrace(descriptor.RecordOptions.EventScope &
-                              EVENT_RECORD_SCOPE_PER_INSTANCE),
+          mFlushEventBuffersOnDestruct(descriptor.RecordOptions.EventScope &
+                                       EVENT_RECORD_SCOPE_PER_INSTANCE),
           mThreadPool(ThreadPool::Create()) {
         GPGMM_TRACE_EVENT_OBJECT_NEW(this);
 
@@ -236,8 +236,8 @@ namespace gpgmm::d3d12 {
         GPGMM_TRACE_EVENT_OBJECT_DESTROY(this);
         StopBudgetNotificationUpdates();
 
-        if (mShutdownEventTrace) {
-            ShutdownEventTrace();
+        if (mFlushEventBuffersOnDestruct) {
+            FlushEventTraceToDisk();
         }
     }
 

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.h
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.h
@@ -288,7 +288,7 @@ namespace gpgmm::d3d12 {
         const uint64_t mEvictBatchSize;
         const bool mIsUMA;
         const bool mIsBudgetChangeEventsDisabled;
-        const bool mShutdownEventTrace;
+        const bool mFlushEventBuffersOnDestruct;
 
         VideoMemorySegment mLocalVideoMemorySegment;
         VideoMemorySegment mNonLocalVideoMemorySegment;

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -586,7 +586,7 @@ namespace gpgmm::d3d12 {
         const bool mIsAlwaysCommitted;
         const bool mIsAlwaysInBudget;
         const uint64_t mMaxResourceHeapSize;
-        const bool mShutdownEventTrace;
+        const bool mFlushEventBuffersOnDestruct;
         const bool mUseDetailedTimingEvents;
 
         static constexpr uint64_t kNumOfResourceHeapTypes = 8u;

--- a/src/tests/unittests/EventTraceWriterTests.cpp
+++ b/src/tests/unittests/EventTraceWriterTests.cpp
@@ -30,7 +30,7 @@ class EventTraceWriterTests : public testing::Test {
     }
 
     void TearDown() override {
-        ShutdownEventTrace();
+        FlushEventTraceToDisk();
     }
 };
 


### PR DESCRIPTION
Allows D3D12EventTraceReplay to configure event tracing for capture when using a residency manager.