### PR TITLE
Make ScopedTraceBufferInTLS thread safe.

### DIFF
--- a/src/gpgmm/common/EventTraceWriter.h
+++ b/src/gpgmm/common/EventTraceWriter.h
@@ -32,11 +32,10 @@ namespace gpgmm {
         EventTraceWriter();
         ~EventTraceWriter();
 
-        void SetConfiguration(const std::string& traceFile,
-                              const TraceEventPhase& ignoreMask,
-                              bool flushOnDestruct);
+        void SetConfiguration(const std::string& traceFile, const TraceEventPhase& ignoreMask);
 
-        void EnqueueTraceEvent(char phase,
+        void EnqueueTraceEvent(std::shared_ptr<EventTraceWriter> writer,
+                               char phase,
                                TraceEventCategory category,
                                const char* name,
                                uint64_t id,
@@ -50,14 +49,13 @@ namespace gpgmm {
         size_t GetQueuedEventsForTesting() const;
 
       private:
-        std::vector<TraceEvent>* GetOrCreateBufferFromTLS();
+        ScopedTraceBufferInTLS* GetOrCreateBufferFromTLS(std::shared_ptr<EventTraceWriter> writer);
         std::vector<TraceEvent> MergeAndClearBuffers();
 
         std::string mTraceFile;
-        std::unique_ptr<PlatformTime> mPlatformTime;
-
         TraceEventPhase mIgnoreMask;
-        bool mFlushOnDestruct = true;
+
+        std::unique_ptr<PlatformTime> mPlatformTime;
 
         mutable std::mutex mMutex;
 

--- a/src/gpgmm/common/TraceEvent.h
+++ b/src/gpgmm/common/TraceEvent.h
@@ -176,8 +176,7 @@ namespace gpgmm {
     class PlatformTime;
 
     void StartupEventTrace(const std::string& traceFile,
-                           const TraceEventPhase& ignoreMask,
-                           bool flushOnDestruct);
+                           const TraceEventPhase& ignoreMask);
 
     void FlushEventTraceToDisk();
 

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
@@ -164,8 +164,7 @@ namespace gpgmm::d3d12 {
 
         if (descriptor.RecordOptions.Flags != EVENT_RECORD_FLAG_NONE) {
             StartupEventTrace(descriptor.RecordOptions.TraceFile,
-                              static_cast<TraceEventPhase>(~descriptor.RecordOptions.Flags | 0),
-                              descriptor.RecordOptions.EventScope & EVENT_RECORD_SCOPE_PER_PROCESS);
+                              static_cast<TraceEventPhase>(~descriptor.RecordOptions.Flags | 0));
 
             SetEventMessageLevel(GetLogSeverity(descriptor.RecordOptions.MinMessageLevel));
         }

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -342,10 +342,8 @@ namespace gpgmm::d3d12 {
 
         if (pResidencyManager == nullptr &&
             newDescriptor.RecordOptions.Flags != EVENT_RECORD_FLAG_NONE) {
-            StartupEventTrace(
-                allocatorDescriptor.RecordOptions.TraceFile,
-                static_cast<TraceEventPhase>(~newDescriptor.RecordOptions.Flags | 0),
-                allocatorDescriptor.RecordOptions.EventScope & EVENT_RECORD_SCOPE_PER_PROCESS);
+            StartupEventTrace(allocatorDescriptor.RecordOptions.TraceFile,
+                              static_cast<TraceEventPhase>(~newDescriptor.RecordOptions.Flags | 0));
 
             SetEventMessageLevel(GetLogSeverity(newDescriptor.RecordOptions.MinMessageLevel));
         } else {

--- a/src/tests/unittests/EventTraceWriterTests.cpp
+++ b/src/tests/unittests/EventTraceWriterTests.cpp
@@ -26,7 +26,7 @@ using namespace gpgmm;
 class EventTraceWriterTests : public testing::Test {
   public:
     void SetUp() override {
-        StartupEventTrace(kDummyTrace, TraceEventPhase::None, /*flushOnDestruct*/ true);
+        StartupEventTrace(kDummyTrace, TraceEventPhase::None);
     }
 
     void TearDown() override {


### PR DESCRIPTION
Prevents unsafe access to trace event buffer when using multiple threads.