### PR TITLE
 Depreciate ResourceAllocation::UpdateResidency.

### DIFF
--- a/src/gpgmm/d3d12/ResourceAllocationD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocationD3D12.cpp
@@ -148,10 +148,6 @@ namespace gpgmm::d3d12 {
         mResource->Unmap(subresource, newWrittenRangePtr);
     }
 
-    HRESULT ResourceAllocation::UpdateResidency(ResidencySet* residencySet) const {
-        return residencySet->Insert(GetMemory());
-    }
-
     bool ResourceAllocation::IsResident() const {
         const Heap* resourceHeap = GetMemory();
         ASSERT(resourceHeap != nullptr);

--- a/src/gpgmm/d3d12/ResourceAllocationD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocationD3D12.h
@@ -153,9 +153,6 @@ namespace gpgmm::d3d12 {
         */
         ID3D12Resource* GetResource() const;
 
-        // Tracks the resource allocation memory for residency.
-        HRESULT UpdateResidency(ResidencySet* residencySet) const;
-
         /** \brief Check if the resource allocation was made resident or not.
 
         \return True if resident, else, false.


### PR DESCRIPTION
Removes the convience function UpdateResidency, since apps could easy implement it themselves.