### PR TITLE
Fix AV crash when recycling slabs.

### DIFF
--- a/src/gpgmm/common/SlabMemoryAllocator.cpp
+++ b/src/gpgmm/common/SlabMemoryAllocator.cpp
@@ -161,7 +161,7 @@ namespace gpgmm {
             Slab* freeSlab = cache->FreeList.head()->value();
             ASSERT(freeSlab != nullptr);
 
-            if (freeSlab->Allocation->GetSize() >= slabSize) {
+            if (freeSlab->Allocation && freeSlab->Allocation->GetSize() >= slabSize) {
                 return freeSlab->Allocation->GetSize();
             }
         }


### PR DESCRIPTION
Recycling a previously de-allocated slab would mistakenly get de-referenced.