### PR TITLE
Move resource alignment behind build flag.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,7 @@ option_if_not_defined(GPGMM_ENABLE_ALLOCATOR_LEAK_CHECKS "Enables checking of al
 option_if_not_defined(GPGMM_ENABLE_ASSERT_ON_WARNING "Enables ASSERT on severity functionality" OFF)
 option_if_not_defined(GPGMM_DISABLE_SIZE_CACHE "Enables warming of caches with common resource sizes" OFF)
 option_if_not_defined(GPGMM_ENABLE_MEMORY_LEAK_CHECKS "Enables memory leak detection." OFF)
+option_if_not_defined(gpgmm_enable_resource_memory_align_checks "Enables checking of resource alignment." OFF)
 
 # The Vulkan loader is an optional dependency.
 if (GPGMM_ENABLE_VK)
@@ -190,6 +191,14 @@ else()
   )
 endif()
 
+if(GPGMM_ENABLE_RESOURCE_MEMORY_ALIGN_CHECKS)
+  target_compile_definitions(gpgmm_common_config INTERFACE "GPGMM_ENABLE_RESOURCE_MEMORY_ALIGN_CHECKS")
+else()
+  target_compile_definitions(gpgmm_common_config INTERFACE
+    $<$<CONFIG:Debug>:GPGMM_ENABLE_RESOURCE_MEMORY_ALIGN_CHECKS>
+  )
+endif()
+
 if(WIN32)
   target_compile_definitions(gpgmm_common_config INTERFACE "NOMINMAX" "WIN32_LEAN_AND_MEAN")
 endif()
@@ -213,7 +222,7 @@ endif()
 # ###############################################################################
 # Install GPGMM
 # ###############################################################################
-install(TARGETS gpgmm 
+install(TARGETS gpgmm
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib

--- a/build_overrides/gpgmm_features.gni
+++ b/build_overrides/gpgmm_features.gni
@@ -64,6 +64,10 @@ declare_args() {
   # Sets -dGPGMM_ENABLE_MEMORY_LEAK_CHECKS
   gpgmm_enable_memory_leak_checks = is_debug
 
+  # Enables checking of resource alignment.
+  # Sets -dGPGMM_ENABLE_RESOURCE_MEMORY_ALIGN_CHECKS
+  gpgmm_enable_resource_memory_align_checks = is_debug
+
   # Configures Vulkan functions by statically importing them (ie. importing the Vulkan loader symbols).
   gpgmm_vk_static_functions = true
 

--- a/src/gpgmm/common/BUILD.gn
+++ b/src/gpgmm/common/BUILD.gn
@@ -85,6 +85,10 @@ config("gpgmm_common_config") {
     defines += [ "GPGMM_ENABLE_MEMORY_LEAK_CHECKS" ]
   }
 
+  if (gpgmm_enable_resource_memory_align_checks) {
+    defines += [ "GPGMM_ENABLE_RESOURCE_MEMORY_ALIGN_CHECKS" ]
+  }
+
   # Only internal build targets can use this config, this means only targets in
   # this BUILD.gn file and related subdirs.
   visibility = [ "../../*" ]

--- a/src/gpgmm/common/MemoryAllocator.cpp
+++ b/src/gpgmm/common/MemoryAllocator.cpp
@@ -128,7 +128,7 @@ namespace gpgmm {
         // Check request size cannot overflow.
         if (request.SizeInBytes > std::numeric_limits<uint64_t>::max() - (request.Alignment - 1)) {
             DebugEvent(GetTypename(), EventMessageId::SizeExceeded)
-                << "Requested size will overflow:" + std::to_string(request.SizeInBytes)
+                << "Requested size rejected due to overflow: " + std::to_string(request.SizeInBytes)
                 << " bytes.";
             return false;
         }

--- a/src/gpgmm/d3d12/DebugResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/DebugResourceAllocatorD3D12.cpp
@@ -59,13 +59,6 @@ namespace gpgmm::d3d12 {
     void DebugResourceAllocator::AddLiveAllocation(ResourceAllocation* allocation) {
         std::lock_guard<std::mutex> lock(mMutex);
 
-        if (allocation->GetSize() > allocation->GetRequestSize()) {
-            DebugEvent(GetTypename(), EventMessageId::AlignmentMismatch)
-                << "Resource allocation is larger then the requested size (" +
-                       std::to_string(allocation->GetSize()) + " vs " +
-                       std::to_string(allocation->GetRequestSize()) + " bytes).";
-        }
-
         mLiveAllocations.GetOrCreate(
             ResourceAllocationEntry(allocation, allocation->GetAllocator()), true);
 


### PR DESCRIPTION
Moves resource-allocation alignment check out from DebugResourceAllocator to CreateResource, and puts it behind a build-time flag.