### PR TITLE
Fix bug preventing resource heaps from being evicted.

### DIFF
--- a/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.cpp
@@ -62,6 +62,7 @@ namespace gpgmm::d3d12 {
         resourceHeapDesc.IsExternal = false;
         resourceHeapDesc.DebugName = "Resource heap";
         resourceHeapDesc.Alignment = request.Alignment;
+        resourceHeapDesc.AlwaysInBudget = !(mHeapFlags & D3D12_HEAP_FLAG_CREATE_NOT_RESIDENT);
         resourceHeapDesc.HeapType = mHeapType;
 
         Heap* resourceHeap = nullptr;


### PR DESCRIPTION
PR #495 mistakenly forgot to specify the HEAP_DESC::AlwaysInBudget.