### PR TITLE
Remove isUMA from ResourceAllocator.

### DIFF
--- a/src/gpgmm/d3d12/JSONSerializerD3D12.cpp
+++ b/src/gpgmm/d3d12/JSONSerializerD3D12.cpp
@@ -39,7 +39,6 @@ namespace gpgmm::d3d12 {
         JSONDict dict;
         dict.AddItem("Flags", desc.Flags);
         dict.AddItem("RecordOptions", Serialize(desc.RecordOptions));
-        dict.AddItem("IsUMA", desc.IsUMA);
         dict.AddItem("ResourceHeapTier", desc.ResourceHeapTier);
         dict.AddItem("PreferredResourceHeapSize", desc.PreferredResourceHeapSize);
         dict.AddItem("MaxResourceHeapSize", desc.MaxResourceHeapSize);

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -389,7 +389,6 @@ namespace gpgmm::d3d12 {
         : mDevice(std::move(descriptor.Device)),
           mResidencyManager(std::move(residencyManager)),
           mCaps(std::move(caps)),
-          mIsUMA(descriptor.IsUMA),
           mResourceHeapTier(descriptor.ResourceHeapTier),
           mIsAlwaysCommitted(descriptor.Flags & ALLOCATOR_FLAG_ALWAYS_COMMITED),
           mIsAlwaysInBudget(descriptor.Flags & ALLOCATOR_FLAG_ALWAYS_IN_BUDGET),

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -581,7 +581,6 @@ namespace gpgmm::d3d12 {
 
         std::unique_ptr<Caps> mCaps;
 
-        const bool mIsUMA;
         const D3D12_RESOURCE_HEAP_TIER mResourceHeapTier;
         const bool mIsAlwaysCommitted;
         const bool mIsAlwaysInBudget;

--- a/src/tests/capture_replay_tests/D3D12EventTraceReplay.cpp
+++ b/src/tests/capture_replay_tests/D3D12EventTraceReplay.cpp
@@ -324,6 +324,16 @@ class D3D12EventTraceReplay : public D3D12TestBase, public CaptureReplayTestWith
                         residencyDesc.EvictBatchSize = snapshot["EvictBatchSize"].asUInt64();
                         residencyDesc.InitialFenceValue = snapshot["InitialFenceValue"].asUInt64();
 
+                        if (envParams.LogLevel <= gpgmm::LogSeverity::Warning &&
+                            residencyDesc.IsUMA != snapshot["IsUMA"].asBool() &&
+                            iterationIndex == 0) {
+                            gpgmm::WarningLog()
+                                << "Capture device does not match playback device (IsUMA: " +
+                                       std::to_string(snapshot["IsUMA"].asBool()) + " vs " +
+                                       std::to_string(residencyDesc.IsUMA) + ").";
+                            GPGMM_SKIP_TEST_IF(envParams.IsSameCapsRequired);
+                        }
+
                         if (envParams.CaptureEventMask != 0) {
                             residencyDesc.RecordOptions.Flags |=
                                 static_cast<EVENT_RECORD_FLAGS_TYPE>(envParams.CaptureEventMask);
@@ -422,16 +432,6 @@ class D3D12EventTraceReplay : public D3D12TestBase, public CaptureReplayTestWith
                         }
 
                         allocatorDesc.MinLogLevel = GetMessageSeverity(envParams.LogLevel);
-
-                        if (envParams.LogLevel <= gpgmm::LogSeverity::Warning &&
-                            allocatorDesc.IsUMA != snapshot["IsUMA"].asBool() &&
-                            iterationIndex == 0) {
-                            gpgmm::WarningLog()
-                                << "Capture device does not match playback device (IsUMA: " +
-                                       std::to_string(snapshot["IsUMA"].asBool()) + " vs " +
-                                       std::to_string(allocatorDesc.IsUMA) + ").";
-                            GPGMM_SKIP_TEST_IF(envParams.IsSameCapsRequired);
-                        }
 
                         if (envParams.LogLevel <= gpgmm::LogSeverity::Warning &&
                             allocatorDesc.ResourceHeapTier !=


### PR DESCRIPTION
Recongizing UMA is only needed for ResidencyManager.