### PR TITLE
Fix OverBudget tests from never terminating.

### DIFF
--- a/src/gpgmm/d3d12/HeapD3D12.cpp
+++ b/src/gpgmm/d3d12/HeapD3D12.cpp
@@ -38,8 +38,7 @@ namespace gpgmm::d3d12 {
 
         // Else, infer the memory segment using the heap type.
         if (pResidencyManager != nullptr && descriptor.MemorySegment == RESIDENCY_SEGMENT_UNKNOWN) {
-            memorySegmentGroup =
-                pResidencyManager->GetPreferredMemorySegmentGroup(descriptor.HeapType);
+            memorySegmentGroup = pResidencyManager->GetMemorySegmentGroup(descriptor.HeapType);
         }
 
         // Ensure enough free memory exists before allocating to avoid an out-of-memory error

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
@@ -264,8 +264,8 @@ namespace gpgmm::d3d12 {
             heap->RemoveFromList();
 
             // Untracked heaps are not attributed toward residency usage.
-            mInfo.MemoryCount++;
-            mInfo.MemoryUsage += heap->GetSize();
+            mInfo.ResidentMemoryCount++;
+            mInfo.ResidentMemoryUsage += heap->GetSize();
         }
 
         heap->AddResidencyLockRef();
@@ -302,8 +302,8 @@ namespace gpgmm::d3d12 {
         ReturnIfFailed(InsertHeapInternal(heap));
 
         // Heaps tracked for residency are always attributed in residency usage.
-        mInfo.MemoryCount--;
-        mInfo.MemoryUsage -= heap->GetSize();
+        mInfo.ResidentMemoryCount--;
+        mInfo.ResidentMemoryUsage -= heap->GetSize();
 
         return S_OK;
     }
@@ -692,13 +692,13 @@ namespace gpgmm::d3d12 {
     RESIDENCY_INFO ResidencyManager::GetInfo() const {
         RESIDENCY_INFO info = mInfo;
         for (const auto& node : mLocalVideoMemorySegment.cache) {
-            info.MemoryUsage += node.value()->GetSize();
-            info.MemoryCount++;
+            info.ResidentMemoryUsage += node.value()->GetSize();
+            info.ResidentMemoryCount++;
         }
 
         for (const auto& node : mNonLocalVideoMemorySegment.cache) {
-            info.MemoryUsage += node.value()->GetSize();
-            info.MemoryCount++;
+            info.ResidentMemoryUsage += node.value()->GetSize();
+            info.ResidentMemoryCount++;
         }
 
         return info;
@@ -736,7 +736,7 @@ namespace gpgmm::d3d12 {
         mBudgetNotificationUpdateEvent = nullptr;
     }
 
-    DXGI_MEMORY_SEGMENT_GROUP ResidencyManager::GetPreferredMemorySegmentGroup(
+    DXGI_MEMORY_SEGMENT_GROUP ResidencyManager::GetMemorySegmentGroup(
         D3D12_HEAP_TYPE heapType) const {
         if (mIsUMA) {
             return DXGI_MEMORY_SEGMENT_GROUP_LOCAL;

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.h
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.h
@@ -127,11 +127,11 @@ namespace gpgmm::d3d12 {
     struct RESIDENCY_INFO {
         /** \brief Amount of memory, in bytes, being made resident.
          */
-        uint64_t MemoryUsage = 0;
+        uint64_t ResidentMemoryUsage = 0;
 
         /** \brief Number of heaps currently being made resident.
          */
-        uint64_t MemoryCount = 0;
+        uint64_t ResidentMemoryCount = 0;
     };
 
     class BudgetUpdateEvent;
@@ -243,6 +243,16 @@ namespace gpgmm::d3d12 {
         */
         RESIDENCY_INFO GetInfo() const;
 
+        /** \brief Divugles the memory segment used for the specified heap type.
+
+        @param heapType A D3D12_HEAP_TYPE-typed value that specifies the heap to get the memory
+        segment for.
+
+        \return A DXGI_MEMORY_SEGMENT_GROUP that provides the memory segment for the specified heap
+        type.
+        */
+        DXGI_MEMORY_SEGMENT_GROUP GetMemorySegmentGroup(D3D12_HEAP_TYPE heapType) const;
+
       private:
         friend Heap;
         friend ResourceAllocator;
@@ -268,8 +278,6 @@ namespace gpgmm::d3d12 {
                              uint64_t sizeToMakeResident,
                              uint32_t numberOfObjectsToMakeResident,
                              ID3D12Pageable** allocations);
-
-        DXGI_MEMORY_SEGMENT_GROUP GetPreferredMemorySegmentGroup(D3D12_HEAP_TYPE heapType) const;
 
         LRUCache* GetVideoMemorySegmentCache(const DXGI_MEMORY_SEGMENT_GROUP& memorySegmentGroup);
 

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -794,7 +794,7 @@ namespace gpgmm::d3d12 {
         // Limit available memory to unused budget when residency is enabled.
         if (mResidencyManager != nullptr) {
             const DXGI_MEMORY_SEGMENT_GROUP segment =
-                mResidencyManager->GetPreferredMemorySegmentGroup(allocationDescriptor.HeapType);
+                mResidencyManager->GetMemorySegmentGroup(allocationDescriptor.HeapType);
             DXGI_QUERY_VIDEO_MEMORY_INFO* currentVideoInfo =
                 mResidencyManager->GetVideoMemoryInfo(segment);
 


### PR DESCRIPTION
Creating a resource which made the current usage equal to budget would result in IsOverBudget never terminating. This fix replaces IsOverBudget with GetBudgetLeft so created resources never exceed the budget.