### PR TITLE
Use unsigned integral type for RefCounted.

### DIFF
--- a/src/gpgmm/d3d12/HeapD3D12.h
+++ b/src/gpgmm/d3d12/HeapD3D12.h
@@ -56,7 +56,7 @@ namespace gpgmm::d3d12 {
 
         A count of 0 means the entire heap is being used.
         */
-        int SubAllocatedRefs;
+        uint64_t SubAllocatedRefs;
 
         /** \brief The pool this heap is assigned to.
 

--- a/src/gpgmm/utils/RefCount.cpp
+++ b/src/gpgmm/utils/RefCount.cpp
@@ -16,7 +16,7 @@
 
 namespace gpgmm {
 
-    RefCounted::RefCounted(int_fast32_t initialCount) : mRef(initialCount) {
+    RefCounted::RefCounted(uint_fast32_t initialCount) : mRef(initialCount) {
     }
 
     void RefCounted::Ref() {
@@ -30,7 +30,7 @@ namespace gpgmm {
         return false;
     }
 
-    int_fast32_t RefCounted::GetRefCount() const {
+    uint_fast32_t RefCounted::GetRefCount() const {
         return mRef.load(std::memory_order_acquire);
     }
 

--- a/src/gpgmm/utils/RefCount.h
+++ b/src/gpgmm/utils/RefCount.h
@@ -31,7 +31,7 @@ namespace gpgmm {
         // what is being referenced (count vs object).
         RefCounted() = delete;
 
-        explicit RefCounted(int_fast32_t initialCount);
+        explicit RefCounted(uint_fast32_t initialCount);
 
         // Increments ref by one.
         void Ref();
@@ -41,7 +41,7 @@ namespace gpgmm {
         bool Unref();
 
         // Get the ref count.
-        int_fast32_t GetRefCount() const;
+        uint_fast32_t GetRefCount() const;
 
         // Returns true if calling Unref() will reach a zero refcount.
         bool HasOneRef() const;
@@ -49,7 +49,7 @@ namespace gpgmm {
       private:
         friend ScopedRef<RefCounted>;
 
-        mutable std::atomic_int_fast32_t mRef;
+        mutable std::atomic_uint_fast32_t mRef;
     };
 
     // RAII style wrapper around RefCounted based objects.

--- a/src/tests/unittests/MemoryCacheTests.cpp
+++ b/src/tests/unittests/MemoryCacheTests.cpp
@@ -33,19 +33,19 @@ TEST(MemoryCacheTests, SingleEntry) {
 
     auto firstEntry = cache.GetOrCreate(FakeObject{0}, false);
     ASSERT_NE(firstEntry.Get(), nullptr);
-    EXPECT_EQ(firstEntry.Get()->GetRefCount(), 1);
+    EXPECT_EQ(firstEntry.Get()->GetRefCount(), 1u);
     EXPECT_EQ(cache.GetStats().NumOfMisses, 1u);
     EXPECT_EQ(cache.GetStats().NumOfHits, 0u);
 
     auto secondEntry = cache.GetOrCreate(FakeObject{0}, false);
     ASSERT_NE(secondEntry.Get(), nullptr);
-    EXPECT_EQ(secondEntry.Get()->GetRefCount(), 2);
+    EXPECT_EQ(secondEntry.Get()->GetRefCount(), 2u);
     EXPECT_EQ(cache.GetStats().NumOfMisses, 1u);
     EXPECT_EQ(cache.GetStats().NumOfHits, 1u);
 
     EXPECT_EQ(firstEntry.Get(), secondEntry.Get());
-    EXPECT_EQ(secondEntry.Get()->GetRefCount(), 2);
-    EXPECT_EQ(firstEntry.Get()->GetRefCount(), 2);
+    EXPECT_EQ(secondEntry.Get()->GetRefCount(), 2u);
+    EXPECT_EQ(firstEntry.Get()->GetRefCount(), 2u);
 }
 
 // Verify multiple objects maps to seperate entries.
@@ -59,8 +59,8 @@ TEST(MemoryCacheTests, MultipleEntries) {
     ASSERT_NE(firstEntry.Get(), nullptr);
 
     EXPECT_NE(firstEntry.Get(), secondEntry.Get());
-    EXPECT_EQ(firstEntry.Get()->GetRefCount(), 1);
-    EXPECT_EQ(secondEntry.Get()->GetRefCount(), 1);
+    EXPECT_EQ(firstEntry.Get()->GetRefCount(), 1u);
+    EXPECT_EQ(secondEntry.Get()->GetRefCount(), 1u);
 
     auto thirdEntry = cache.GetOrCreate(FakeObject{1}, false);
     ASSERT_NE(thirdEntry.Get(), nullptr);
@@ -70,8 +70,8 @@ TEST(MemoryCacheTests, MultipleEntries) {
 
     EXPECT_EQ(firstEntry.Get(), thirdEntry.Get());
     EXPECT_EQ(secondEntry.Get(), forthEntry.Get());
-    EXPECT_EQ(thirdEntry.Get()->GetRefCount(), 2);
-    EXPECT_EQ(forthEntry.Get()->GetRefCount(), 2);
+    EXPECT_EQ(thirdEntry.Get()->GetRefCount(), 2u);
+    EXPECT_EQ(forthEntry.Get()->GetRefCount(), 2u);
 }
 
 // Verify entries grow and shrink cache by scope.
@@ -90,5 +90,5 @@ TEST(MemoryCacheTests, ShrinkCache) {
 
     auto entryOne = cache.GetOrCreate(FakeObject{1}, false);
     auto entryTwo = cache.GetOrCreate(FakeObject{1}, false);
-    EXPECT_EQ(entryOne.Get()->GetRefCount(), 2);
+    EXPECT_EQ(entryOne.Get()->GetRefCount(), 2u);
 }

--- a/src/tests/unittests/RefCountTests.cpp
+++ b/src/tests/unittests/RefCountTests.cpp
@@ -27,12 +27,12 @@ class DummyObject : public RefCounted {
 TEST(RefCountTests, IncrementDecrement) {
     RefCounted refcount(2);
     EXPECT_FALSE(refcount.Unref());
-    EXPECT_EQ(refcount.GetRefCount(), 1);
+    EXPECT_EQ(refcount.GetRefCount(), 1u);
 
     EXPECT_TRUE(refcount.HasOneRef());
 
     EXPECT_TRUE(refcount.Unref());
-    EXPECT_EQ(refcount.GetRefCount(), 0);
+    EXPECT_EQ(refcount.GetRefCount(), 0u);
 
     EXPECT_FALSE(refcount.HasOneRef());
 }
@@ -40,31 +40,31 @@ TEST(RefCountTests, IncrementDecrement) {
 // Verify semantics of attach, detach, and aquire.
 TEST(RefCountTests, ScopedRefAttachDetach) {
     ScopedRef<DummyObject> firstRef(new DummyObject());
-    EXPECT_EQ(firstRef->GetRefCount(), 1);
+    EXPECT_EQ(firstRef->GetRefCount(), 1u);
 
     ScopedRef<DummyObject> secondRef = firstRef;
-    EXPECT_EQ(secondRef->GetRefCount(), 2);
+    EXPECT_EQ(secondRef->GetRefCount(), 2u);
 
     DummyObject* ptr = firstRef.Detach();
     ASSERT_NE(ptr, nullptr);
-    EXPECT_EQ(ptr->GetRefCount(), 2);
+    EXPECT_EQ(ptr->GetRefCount(), 2u);
 
     ScopedRef<DummyObject> firstRefAgain;
     firstRefAgain.Attach(ptr);
-    EXPECT_EQ(ptr->GetRefCount(), 2);
+    EXPECT_EQ(ptr->GetRefCount(), 2u);
 
     EXPECT_TRUE(firstRefAgain == secondRef);
     EXPECT_FALSE(firstRef == firstRefAgain);
 
     ScopedRef<DummyObject> firstRefAgainAquired =
         ScopedRef<DummyObject>::Acquire(firstRefAgain.Detach());
-    EXPECT_EQ(firstRefAgainAquired->GetRefCount(), 2);
+    EXPECT_EQ(firstRefAgainAquired->GetRefCount(), 2u);
 
     EXPECT_TRUE(firstRefAgainAquired == secondRef);
     EXPECT_FALSE(firstRef == firstRefAgainAquired);
 
     firstRefAgainAquired = nullptr;
-    EXPECT_EQ(secondRef->GetRefCount(), 1);
+    EXPECT_EQ(secondRef->GetRefCount(), 1u);
 
     secondRef = nullptr;
     EXPECT_TRUE(secondRef == nullptr);
@@ -83,12 +83,12 @@ TEST(RefCountTests, ScopedRefSafeRelease) {
 TEST(RefCountTests, ScopedRefMove) {
     DummyObject* obj = new DummyObject();
     ScopedRef<DummyObject> firstRef(obj);
-    EXPECT_EQ(firstRef->GetRefCount(), 1);
+    EXPECT_EQ(firstRef->GetRefCount(), 1u);
 
     firstRef->Ref();
 
     ScopedRef<DummyObject> secondRef(std::move(firstRef));
     EXPECT_EQ(firstRef, nullptr);
-    EXPECT_EQ(secondRef->GetRefCount(), 2);
+    EXPECT_EQ(secondRef->GetRefCount(), 2u);
     EXPECT_EQ(secondRef.Get(), obj);
 }


### PR DESCRIPTION
RefCounted based types like IUnknown require a unsigned ref-counter type.