### PR TITLE
Enable log level for all gtests.

### DIFF
--- a/src/tests/D3D12Test.cpp
+++ b/src/tests/D3D12Test.cpp
@@ -18,6 +18,22 @@
 
 namespace gpgmm::d3d12 {
 
+    D3D12_MESSAGE_SEVERITY GetMessageSeverity(LogSeverity logSeverity) {
+        switch (logSeverity) {
+            case LogSeverity::Error:
+                return D3D12_MESSAGE_SEVERITY_ERROR;
+            case LogSeverity::Warning:
+                return D3D12_MESSAGE_SEVERITY_WARNING;
+            case LogSeverity::Info:
+                return D3D12_MESSAGE_SEVERITY_INFO;
+            case LogSeverity::Debug:
+                return D3D12_MESSAGE_SEVERITY_MESSAGE;
+            default:
+                UNREACHABLE();
+                return {};
+        }
+    }
+
     void D3D12TestBase::SetUp() {
         GPGMMTestBase::SetUp();
 
@@ -71,7 +87,7 @@ namespace gpgmm::d3d12 {
             desc.Flags |= ALLOCATOR_FLAG_DISABLE_MEMORY_PREFETCH;
         }
 
-        desc.MinLogLevel = GetDefaultLogLevel();
+        desc.MinLogLevel = GetMessageSeverity(GetLogLevel());
 
         if (IsDumpAllEventsEnabled()) {
             desc.RecordOptions.Flags |= EVENT_RECORD_FLAG_ALL_EVENTS;
@@ -135,14 +151,6 @@ namespace gpgmm::d3d12 {
         return false;
 #else
         return true;
-#endif
-    }
-
-    D3D12_MESSAGE_SEVERITY D3D12TestBase::GetDefaultLogLevel() const {
-#if defined(NDEBUG)
-        return D3D12_MESSAGE_SEVERITY_WARNING;
-#else
-        return D3D12_MESSAGE_SEVERITY_MESSAGE;
 #endif
     }
 

--- a/src/tests/D3D12Test.h
+++ b/src/tests/D3D12Test.h
@@ -33,6 +33,8 @@ namespace gpgmm::d3d12 {
     class ResourceAllocator;
     class ResourceAllocation;
 
+    D3D12_MESSAGE_SEVERITY GetMessageSeverity(LogSeverity logSeverity);
+
     class D3D12TestBase : public GPGMMTestBase {
       public:
         void SetUp();

--- a/src/tests/GPGMMTest.h
+++ b/src/tests/GPGMMTest.h
@@ -62,6 +62,7 @@ class GPGMMTestBase {
     gpgmm::DebugPlatform* GetDebugPlatform();
 
     bool IsDumpAllEventsEnabled() const;
+    gpgmm::LogSeverity GetLogLevel() const;
 
     static std::vector<MEMORY_ALLOCATION_EXPECT> GenerateTestAllocations(uint64_t alignment);
 };
@@ -77,9 +78,16 @@ class GPGMMTestEnvironment : public testing::Environment {
     void SetUp() override;
 
     bool IsDumpAllEventsEnabled() const;
+    gpgmm::LogSeverity GetLogLevel() const;
 
   private:
     bool mIsDumpAllEventsEnabled = false;
+
+#if defined(NDEBUG)
+    gpgmm::LogSeverity mLogLevel = gpgmm::LogSeverity::Warning;
+#else
+    gpgmm::LogSeverity mLogLevel = gpgmm::LogSeverity::Info;
+#endif
 };
 
 #endif  // TESTS_GPGMMTEST_H_

--- a/src/tests/capture_replay_tests/D3D12EventTraceReplay.cpp
+++ b/src/tests/capture_replay_tests/D3D12EventTraceReplay.cpp
@@ -93,22 +93,6 @@ namespace {
         return (args.isMember("Description") && args.isMember("ID"));
     }
 
-    D3D12_MESSAGE_SEVERITY GetMessageSeverity(gpgmm::LogSeverity logSeverity) {
-        switch (logSeverity) {
-            case gpgmm::LogSeverity::Error:
-                return D3D12_MESSAGE_SEVERITY_ERROR;
-            case gpgmm::LogSeverity::Warning:
-                return D3D12_MESSAGE_SEVERITY_WARNING;
-            case gpgmm::LogSeverity::Info:
-                return D3D12_MESSAGE_SEVERITY_INFO;
-            case gpgmm::LogSeverity::Debug:
-                return D3D12_MESSAGE_SEVERITY_MESSAGE;
-            default:
-                UNREACHABLE();
-                return D3D12_MESSAGE_SEVERITY_MESSAGE;
-        }
-    }
-
 }  // namespace
 
 class D3D12EventTraceReplay : public D3D12TestBase, public CaptureReplayTestWithParams {
@@ -324,7 +308,7 @@ class D3D12EventTraceReplay : public D3D12TestBase, public CaptureReplayTestWith
                         residencyDesc.EvictBatchSize = snapshot["EvictBatchSize"].asUInt64();
                         residencyDesc.InitialFenceValue = snapshot["InitialFenceValue"].asUInt64();
 
-                        if (envParams.LogLevel <= gpgmm::LogSeverity::Warning &&
+                        if (GetLogLevel() <= gpgmm::LogSeverity::Warning &&
                             residencyDesc.IsUMA != snapshot["IsUMA"].asBool() &&
                             iterationIndex == 0) {
                             gpgmm::WarningLog()
@@ -339,7 +323,7 @@ class D3D12EventTraceReplay : public D3D12TestBase, public CaptureReplayTestWith
                                 static_cast<EVENT_RECORD_FLAGS_TYPE>(envParams.CaptureEventMask);
                             residencyDesc.RecordOptions.TraceFile = traceFile.path;
                             residencyDesc.RecordOptions.MinMessageLevel =
-                                GetMessageSeverity(envParams.LogLevel);
+                                GetMessageSeverity(GetLogLevel());
 
                             // Keep recording across multiple playback iterations to ensure all
                             // events will be captured instead of overwritten per iteration.
@@ -349,7 +333,7 @@ class D3D12EventTraceReplay : public D3D12TestBase, public CaptureReplayTestWith
                             }
                         }
 
-                        residencyDesc.MinLogLevel = GetMessageSeverity(envParams.LogLevel);
+                        residencyDesc.MinLogLevel = GetMessageSeverity(GetLogLevel());
 
                         ComPtr<ResidencyManager> residencyManager;
                         ASSERT_SUCCEEDED(ResidencyManager::CreateResidencyManager(
@@ -421,7 +405,7 @@ class D3D12EventTraceReplay : public D3D12TestBase, public CaptureReplayTestWith
                                 static_cast<EVENT_RECORD_FLAGS_TYPE>(envParams.CaptureEventMask);
                             allocatorDesc.RecordOptions.TraceFile = traceFile.path;
                             allocatorDesc.RecordOptions.MinMessageLevel =
-                                GetMessageSeverity(envParams.LogLevel);
+                                GetMessageSeverity(GetLogLevel());
 
                             // Keep recording across multiple playback iterations to ensure all
                             // events will be captured instead of overwritten per iteration.
@@ -431,9 +415,9 @@ class D3D12EventTraceReplay : public D3D12TestBase, public CaptureReplayTestWith
                             }
                         }
 
-                        allocatorDesc.MinLogLevel = GetMessageSeverity(envParams.LogLevel);
+                        allocatorDesc.MinLogLevel = GetMessageSeverity(GetLogLevel());
 
-                        if (envParams.LogLevel <= gpgmm::LogSeverity::Warning &&
+                        if (GetLogLevel() <= gpgmm::LogSeverity::Warning &&
                             allocatorDesc.ResourceHeapTier !=
                                 snapshot["ResourceHeapTier"].asInt() &&
                             iterationIndex == 0) {

--- a/src/tests/capture_replay_tests/GPGMMCaptureReplayTests.cpp
+++ b/src/tests/capture_replay_tests/GPGMMCaptureReplayTests.cpp
@@ -30,22 +30,6 @@ namespace {
 
     GPGMMCaptureReplayTestEnvironment* gTestEnv = nullptr;
 
-    std::string LogSeverityToString(const gpgmm::LogSeverity& severity) {
-        switch (severity) {
-            case gpgmm::LogSeverity::Debug:
-                return "DEBUG";
-            case gpgmm::LogSeverity::Info:
-                return "INFO";
-            case gpgmm::LogSeverity::Warning:
-                return "WARN";
-            case gpgmm::LogSeverity::Error:
-                return "ERROR";
-            default:
-                UNREACHABLE();
-                return "";
-        }
-    }
-
     std::string AllocatorProfileToString(const AllocatorProfile& profile) {
         switch (profile) {
             case AllocatorProfile::ALLOCATOR_PROFILE_MAX_PERFORMANCE:
@@ -116,29 +100,6 @@ GPGMMCaptureReplayTestEnvironment::GPGMMCaptureReplayTestEnvironment(int argc, c
             continue;
         }
 
-        constexpr const char kLogLevel[] = "--log-level";
-        arglen = sizeof(kLogLevel) - 1;
-        if (strncmp(argv[i], kLogLevel, arglen) == 0) {
-            const char* level = argv[i] + arglen;
-            if (level[0] != '\0') {
-                if (strcmp(level, "=DEBUG") == 0) {
-                    mParams.LogLevel = gpgmm::LogSeverity::Debug;
-                } else if (strcmp(level, "=INFO") == 0) {
-                    mParams.LogLevel = gpgmm::LogSeverity::Info;
-                } else if (strcmp(level, "=WARN") == 0) {
-                    mParams.LogLevel = gpgmm::LogSeverity::Warning;
-                } else if (strcmp(level, "=ERROR") == 0) {
-                    mParams.LogLevel = gpgmm::LogSeverity::Error;
-                } else {
-                    gpgmm::ErrorLog() << "Invalid log message level " << level << ".\n";
-                    UNREACHABLE();
-                }
-            } else {
-                mParams.LogLevel = gpgmm::LogSeverity::Warning;
-            }
-            continue;
-        }
-
         constexpr const char kPlaybackFile[] = "--playback-file=";
         arglen = sizeof(kPlaybackFile) - 1;
         if (strncmp(argv[i], kPlaybackFile, arglen) == 0) {
@@ -170,8 +131,6 @@ GPGMMCaptureReplayTestEnvironment::GPGMMCaptureReplayTestEnvironment(int argc, c
                 << "Playback options:"
                 << " [--iterations=X]\n"
                 << " --iterations: Number of times to run playback.\n"
-                << " --log-level=[DEBUG|INFO|WARN|ERROR]: Log severity "
-                   "level for log messages.\n"
                 << " --capture-mask: Event mask to record during capture.\n"
                 << " --playback-file: Path to captured file to playback.\n"
                 << " --same-caps: Captured device must be compatible with playback device.\n"
@@ -201,7 +160,6 @@ void GPGMMCaptureReplayTestEnvironment::PrintCaptureReplaySettings() const {
     gpgmm::InfoLog() << "Playback settings\n"
                         "-----------------\n"
                      << "Iterations per test: " << mParams.Iterations << "\n"
-                     << "Log level: " << LogSeverityToString(mParams.LogLevel) << "\n"
                      << "Must use same caps: " << (mParams.IsSameCapsRequired ? "true" : "false")
                      << "\n"
                      << "No Allocations: "

--- a/src/tests/capture_replay_tests/GPGMMCaptureReplayTests.h
+++ b/src/tests/capture_replay_tests/GPGMMCaptureReplayTests.h
@@ -17,8 +17,6 @@
 
 #include "tests/GPGMMTest.h"
 
-#include "gpgmm/utils/Log.h"
-
 #include <regex>
 #include <string>
 
@@ -44,8 +42,7 @@ enum class AllocatorProfile {
 };
 
 struct TestEnviromentParams {
-    uint64_t Iterations = 1;                                 // Number of test iterations to run.
-    gpgmm::LogSeverity LogLevel = gpgmm::LogSeverity::Info;  // Level of logging.
+    uint64_t Iterations = 1;  // Number of test iterations to run.
     int CaptureEventMask = 0;
 
     bool IsSameCapsRequired = false;  // Caps of test device must match capture caps.

--- a/src/tests/end2end/D3D12ResidencyManagerTests.cpp
+++ b/src/tests/end2end/D3D12ResidencyManagerTests.cpp
@@ -68,7 +68,7 @@ class D3D12ResidencyManagerTests : public D3D12TestBase, public ::testing::Test 
         residencyDesc.Adapter = mAdapter;
         residencyDesc.Device = mDevice;
 
-        residencyDesc.MinLogLevel = GetDefaultLogLevel();
+        residencyDesc.MinLogLevel = GetMessageSeverity(GetLogLevel());
 
         if (IsDumpAllEventsEnabled()) {
             residencyDesc.RecordOptions.Flags |= EVENT_RECORD_FLAG_ALL_EVENTS;


### PR DESCRIPTION
Use "--log-level=<level>" for any test to control logging output.