### PR TITLE
Attribute locked heaps toward residency usage.

### DIFF
--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.h
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.h
@@ -287,8 +287,6 @@ namespace gpgmm::d3d12 {
         ComPtr<IDXGIAdapter3> mAdapter;
         ComPtr<ID3D12Device3> mDevice3;
 
-        std::unique_ptr<Fence> mFence;
-
         const float mVideoMemoryBudget;
         const bool mIsBudgetRestricted;
         const uint64_t mEvictBatchSize;
@@ -296,10 +294,13 @@ namespace gpgmm::d3d12 {
         const bool mIsBudgetChangeEventsDisabled;
         const bool mFlushEventBuffersOnDestruct;
 
+        std::mutex mMutex;
+
+        std::unique_ptr<Fence> mFence;
+
         VideoMemorySegment mLocalVideoMemorySegment;
         VideoMemorySegment mNonLocalVideoMemorySegment;
-
-        std::mutex mMutex;
+        RESIDENCY_INFO mInfo = {};
 
         std::shared_ptr<ThreadPool> mThreadPool;
         std::shared_ptr<BudgetUpdateEvent> mBudgetNotificationUpdateEvent;

--- a/src/tests/end2end/D3D12ResidencyManagerTests.cpp
+++ b/src/tests/end2end/D3D12ResidencyManagerTests.cpp
@@ -127,10 +127,25 @@ TEST_F(D3D12ResidencyManagerTests, CreateResourceHeap) {
         Heap::CreateHeap(resourceHeapDesc, residencyManager.Get(), createHeapFn, &resourceHeap));
     ASSERT_NE(resourceHeap, nullptr);
 
+    EXPECT_EQ(residencyManager->GetInfo().MemoryUsage, kHeapSize);
+    EXPECT_EQ(residencyManager->GetInfo().MemoryCount, 1u);
+
     ComPtr<ID3D12Heap> heap;
     resourceHeap->As(&heap);
 
     EXPECT_NE(heap, nullptr);
+
+    ASSERT_SUCCEEDED(residencyManager->LockHeap(resourceHeap.Get()));
+
+    EXPECT_EQ(residencyManager->GetInfo().MemoryUsage, kHeapSize);
+    EXPECT_EQ(residencyManager->GetInfo().MemoryCount, 1u);
+
+    ASSERT_SUCCEEDED(residencyManager->UnlockHeap(resourceHeap.Get()));
+
+    EXPECT_EQ(residencyManager->GetInfo().MemoryUsage, kHeapSize);
+    EXPECT_EQ(residencyManager->GetInfo().MemoryCount, 1u);
+
+    ASSERT_FAILED(residencyManager->UnlockHeap(resourceHeap.Get()));  // Not locked
 }
 
 TEST_F(D3D12ResidencyManagerTests, CreateResidencySet) {


### PR DESCRIPTION
Includes always resident heaps in  ResidencyManager::GetInfo().