### PR TITLE
Depreciate Heap::As with ComPtr<Heap>::As.

### DIFF
--- a/src/gpgmm/d3d12/HeapD3D12.cpp
+++ b/src/gpgmm/d3d12/HeapD3D12.cpp
@@ -146,4 +146,8 @@ namespace gpgmm::d3d12 {
     HRESULT Heap::SetDebugNameImpl(const std::string& name) {
         return SetDebugObjectName(mPageable.Get(), name);
     }
+
+    HRESULT STDMETHODCALLTYPE Heap::QueryInterface(REFIID riid, void** ppvObject) {
+        return mPageable->QueryInterface(riid, ppvObject);
+    }
 }  // namespace gpgmm::d3d12

--- a/src/gpgmm/d3d12/HeapD3D12.h
+++ b/src/gpgmm/d3d12/HeapD3D12.h
@@ -168,16 +168,20 @@ namespace gpgmm::d3d12 {
 
         \code
         ComPtr<ID3D12Heap> heap;
-        HRESULT hr = resourceHeap->As(&heap);
+        HRESULT hr = resourceHeap.As(&heap);
         \endcode
 
         \return Error HRESULT if the specified interface was not represented by the
         heap.
+
+        \deprecated Use ComPtr<Heap::As instead of Heap::As.
         */
         template <typename T>
         HRESULT As(Microsoft::WRL::Details::ComPtrRef<ComPtr<T>> ptr) const {
             return mPageable.As(ptr);
         }
+
+        HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject) override;
 
         /** \brief Determine if the heap is resident or not.
 

--- a/src/gpgmm/d3d12/JSONSerializerD3D12.cpp
+++ b/src/gpgmm/d3d12/JSONSerializerD3D12.cpp
@@ -192,7 +192,6 @@ namespace gpgmm::d3d12 {
         dict.AddItem("HeapOffset", desc.HeapOffset);
         dict.AddItem("OffsetFromResource", desc.OffsetFromResource);
         dict.AddItem("Method", desc.Method);
-        dict.AddItem("ResourceHeap", gpgmm::JSONSerializer::Serialize(desc.ResourceHeap));
         if (!desc.DebugName.empty()) {
             dict.AddItem("DebugName", desc.DebugName);
         }

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
@@ -254,7 +254,7 @@ namespace gpgmm::d3d12 {
 
         if (!heap->IsResident()) {
             ComPtr<ID3D12Pageable> pageable;
-            ReturnIfFailed(heap->As(&pageable));
+            ReturnIfFailed(heap->QueryInterface(IID_PPV_ARGS(&pageable)));
             ReturnIfFailed(MakeResident(heap->GetMemorySegmentGroup(), heap->GetSize(), 1,
                                         pageable.GetAddressOf()));
         }
@@ -530,7 +530,7 @@ namespace gpgmm::d3d12 {
             evictedSizeInBytes += heap->GetSize();
 
             ComPtr<ID3D12Pageable> pageable;
-            ReturnIfFailed(heap->As(&pageable));
+            ReturnIfFailed(heap->QueryInterface(IID_PPV_ARGS(&pageable)));
 
             objectsToEvict.push_back(pageable.Get());
         }
@@ -592,7 +592,7 @@ namespace gpgmm::d3d12 {
                 heap->RemoveFromList();
             } else {
                 ComPtr<ID3D12Pageable> pageable;
-                ReturnIfFailed(heap->As(&pageable));
+                ReturnIfFailed(heap->QueryInterface(IID_PPV_ARGS(&pageable)));
 
                 if (heap->GetMemorySegmentGroup() == DXGI_MEMORY_SEGMENT_GROUP_LOCAL) {
                     localSizeToMakeResident += heap->GetSize();

--- a/src/gpgmm/d3d12/ResourceAllocationD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocationD3D12.cpp
@@ -44,13 +44,14 @@ namespace gpgmm::d3d12 {
     // static
     HRESULT ResourceAllocation::CreateResourceAllocation(
         const RESOURCE_ALLOCATION_DESC& descriptor,
-        ResidencyManager* residencyManager,
-        MemoryAllocator* allocator,
-        MemoryBlock* block,
+        ResidencyManager* pResidencyManager,
+        MemoryAllocator* pAllocator,
+        Heap* pResourceHeap,
+        MemoryBlock* pBlock,
         ComPtr<ID3D12Resource> resource,
         ResourceAllocation** ppResourceAllocationOut) {
         std::unique_ptr<ResourceAllocation> resourceAllocation(new ResourceAllocation(
-            descriptor, residencyManager, allocator, block, std::move(resource)));
+            descriptor, pResidencyManager, pAllocator, pResourceHeap, pBlock, std::move(resource)));
 
         if (!descriptor.DebugName.empty()) {
             ReturnIfFailed(resourceAllocation->SetDebugName(descriptor.DebugName));
@@ -66,10 +67,11 @@ namespace gpgmm::d3d12 {
     ResourceAllocation::ResourceAllocation(const RESOURCE_ALLOCATION_DESC& desc,
                                            ResidencyManager* residencyManager,
                                            MemoryAllocator* allocator,
+                                           Heap* resourceHeap,
                                            MemoryBlock* block,
                                            ComPtr<ID3D12Resource> resource)
         : MemoryAllocation(allocator,
-                           desc.ResourceHeap,
+                           resourceHeap,
                            desc.HeapOffset,
                            desc.Method,
                            block,
@@ -77,7 +79,7 @@ namespace gpgmm::d3d12 {
           mResidencyManager(residencyManager),
           mResource(std::move(resource)),
           mOffsetFromResource(desc.OffsetFromResource) {
-        ASSERT(desc.ResourceHeap != nullptr);
+        ASSERT(resourceHeap != nullptr);
         GPGMM_TRACE_EVENT_OBJECT_NEW(this);
     }
 

--- a/src/gpgmm/d3d12/ResourceAllocationD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocationD3D12.h
@@ -57,12 +57,6 @@ namespace gpgmm::d3d12 {
         */
         AllocationMethod Method;
 
-        /** \brief Pointer to underlying Heap used for the resource allocation.
-
-        Must be valid for the duration of the resource allocation.
-        */
-        Heap* ResourceHeap;
-
         /** \brief Debug name associated with the resource allocation.
          */
         std::string DebugName;
@@ -102,19 +96,21 @@ namespace gpgmm::d3d12 {
         /** \brief Constructs a resource allocation using memory containing one or more resources.
 
         @param desc A RESOURCE_ALLOCATION_DESC describing the resource allocation.
-        @param residencyManager A pointer to ResidencyManager which manages residency for the
+        @param pResidencyManager A pointer to ResidencyManager which manages residency for the
         resource allocation.
-        @param allocator A pointer to MemoryAllocator which created the resourceHeap for the
+        @param pAllocator A pointer to MemoryAllocator which created the resourceHeap for the
         resource.
-        @param block A pointer to MemoryBlock which describes the region in Heap being allocated.
+        @param pResourceHeap A pointer to the Heap used for the resource allocation.
+        @param pBlock A pointer to MemoryBlock which describes the region in Heap being allocated.
         @param resource A pointer to the ID3D12Resource used for the allocation.
         @param[out] ppResourceAllocationOut Pointer to a resource allocation that recieves a pointer
         to the resource allocation.
         */
         static HRESULT CreateResourceAllocation(const RESOURCE_ALLOCATION_DESC& desc,
-                                                ResidencyManager* residencyManager,
-                                                MemoryAllocator* allocator,
-                                                MemoryBlock* block,
+                                                ResidencyManager* pResidencyManager,
+                                                MemoryAllocator* pAllocator,
+                                                Heap* pResourceHeap,
+                                                MemoryBlock* pBlock,
                                                 ComPtr<ID3D12Resource> resource,
                                                 ResourceAllocation** ppResourceAllocationOut);
 
@@ -198,6 +194,7 @@ namespace gpgmm::d3d12 {
         ResourceAllocation(const RESOURCE_ALLOCATION_DESC& desc,
                            ResidencyManager* residencyManager,
                            MemoryAllocator* allocator,
+                           Heap* resourceHeap,
                            MemoryBlock* block,
                            ComPtr<ID3D12Resource> resource);
 

--- a/src/tests/end2end/D3D12ResidencyManagerTests.cpp
+++ b/src/tests/end2end/D3D12ResidencyManagerTests.cpp
@@ -127,7 +127,7 @@ TEST_F(D3D12ResidencyManagerTests, CreateResourceHeap) {
     EXPECT_EQ(residencyManager->GetInfo().ResidentMemoryCount, 1u);
 
     ComPtr<ID3D12Heap> heap;
-    resourceHeap->As(&heap);
+    resourceHeap.As(&heap);
 
     EXPECT_NE(heap, nullptr);
 

--- a/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
+++ b/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
@@ -334,8 +334,11 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBuffer) {
             nullptr, &allocation));
         ASSERT_NE(allocation, nullptr);
 
-        ComPtr<ID3D12Heap> heap;
-        ASSERT_FAILED(allocation->GetMemory()->As(&heap));
+        ComPtr<Heap> heap = allocation->GetMemory();
+        ASSERT_NE(heap, nullptr);
+
+        ComPtr<ID3D12Heap> d3dHeap;
+        ASSERT_FAILED(heap.As(&d3dHeap));
     }
 
     // Creating a buffer with required but invalid heap flag should always fail.
@@ -464,11 +467,11 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferAlwaysCommitted) {
     EXPECT_EQ(allocation->GetSize(), kDefaultBufferSize);
 
     // Commmitted resources cannot be backed by a D3D12 heap.
-    Heap* resourceHeap = allocation->GetMemory();
+    ComPtr<Heap> resourceHeap = allocation->GetMemory();
     ASSERT_NE(resourceHeap, nullptr);
 
     ComPtr<ID3D12Heap> heap;
-    ASSERT_FAILED(resourceHeap->As(&heap));
+    ASSERT_FAILED(resourceHeap.As(&heap));
 
     // Commited resources must use all the memory allocated.
     EXPECT_EQ(resourceAllocator->GetInfo().UsedMemoryUsage, kDefaultBufferSize);


### PR DESCRIPTION
Since d3d12::Heap is COM-ified, this changes adds support to cast to other underlying D3D heap types via QueryInterface. Internally, GPGMM keeps the ref-count always at 1, unless GetHeap is called.