### PR TITLE
Fix OOM when creating heaps larger then the residency LRU.

### DIFF
--- a/src/gpgmm/d3d12/HeapD3D12.cpp
+++ b/src/gpgmm/d3d12/HeapD3D12.cpp
@@ -44,7 +44,8 @@ namespace gpgmm::d3d12 {
         // Ensure enough free memory exists before allocating to avoid an out-of-memory error
         // when over budget.
         if (pResidencyManager != nullptr && descriptor.AlwaysInBudget) {
-            ReturnIfFailed(pResidencyManager->Evict(descriptor.SizeInBytes, memorySegmentGroup));
+            ReturnIfFailed(pResidencyManager->EnsureCreatedHeapResident(descriptor.SizeInBytes,
+                                                                        memorySegmentGroup));
         }
 
         ComPtr<ID3D12Pageable> pageable;

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.h
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.h
@@ -241,8 +241,8 @@ namespace gpgmm::d3d12 {
 
         ResidencyManager(const RESIDENCY_DESC& descriptor, std::unique_ptr<Fence> fence);
 
-        HRESULT Evict(uint64_t evictSizeInBytes,
-                      const DXGI_MEMORY_SEGMENT_GROUP& memorySegmentGroup);
+        HRESULT EnsureCreatedHeapResident(uint64_t evictSizeInBytes,
+                                          const DXGI_MEMORY_SEGMENT_GROUP& memorySegmentGroup);
 
         HRESULT EvictInternal(uint64_t evictSizeInBytes,
                               const DXGI_MEMORY_SEGMENT_GROUP& memorySegmentGroup,

--- a/src/tests/end2end/D3D12ResidencyManagerTests.cpp
+++ b/src/tests/end2end/D3D12ResidencyManagerTests.cpp
@@ -228,6 +228,21 @@ TEST_F(D3D12ResidencyManagerTests, CreateResidencyManagerNoLeak) {
     GPGMM_TEST_MEMORY_LEAK_END();
 }
 
+TEST_F(D3D12ResidencyManagerTests, OverBudgetFail) {
+    ComPtr<ResidencyManager> residencyManager;
+    ASSERT_SUCCEEDED(ResidencyManager::CreateResidencyManager(
+        CreateBasicResidencyDesc(kDefaultBudget), &residencyManager));
+
+    ComPtr<ResourceAllocator> resourceAllocator;
+    ASSERT_SUCCEEDED(ResourceAllocator::CreateAllocator(
+        CreateBasicAllocatorDesc(), residencyManager.Get(), &resourceAllocator));
+
+    // Attempting to create a resource over the budget should always fail.
+    ASSERT_FAILED(resourceAllocator->CreateResource(
+        {}, CreateBasicBufferDesc(kDefaultBudget + GPGMM_MB_TO_BYTES(1)),
+        D3D12_RESOURCE_STATE_COMMON, nullptr, nullptr));
+}
+
 // Keeps allocating until it goes over the limited |kDefaultBudget| size budget.
 TEST_F(D3D12ResidencyManagerTests, OverBudget) {
     RESIDENCY_DESC residencyDesc = CreateBasicResidencyDesc(kDefaultBudget);


### PR DESCRIPTION
When a large heap exceeded the residency LRU, `ResidencyManager::Evict` would be unable to page out enough space, where calling ID3D12Device::CreateHeap would crash the process instead of error.

This fix prevents ID3D12Device::CreateHeap from being attempted if there isn't enough budget, which allows OOM to be generated by GPGMM instead of D3D12 which prevents OOM-runtime crashes related to the fuzzer.