### PR TITLE
Fix MaxResourceHeapSize value from being incorrectly specified.

### DIFF
--- a/src/gpgmm/d3d12/CapsD3D12.cpp
+++ b/src/gpgmm/d3d12/CapsD3D12.cpp
@@ -42,12 +42,12 @@ namespace gpgmm::d3d12 {
             device->CheckFeatureSupport(D3D12_FEATURE_GPU_VIRTUAL_ADDRESS_SUPPORT, &feature,
                                         sizeof(D3D12_FEATURE_DATA_GPU_VIRTUAL_ADDRESS_SUPPORT)));
         // Check for overflow.
-        if (feature.MaxGPUVirtualAddressBitsPerResource == 0 ||
-            feature.MaxGPUVirtualAddressBitsPerResource > GetNumOfBits<uint64_t>()) {
+        if (feature.MaxGPUVirtualAddressBitsPerProcess == 0 ||
+            feature.MaxGPUVirtualAddressBitsPerProcess > GetNumOfBits<uint64_t>()) {
             return E_FAIL;
         }
 
-        *sizeOut = (1ull << (feature.MaxGPUVirtualAddressBitsPerResource - 1)) - 1;
+        *sizeOut = (1ull << (feature.MaxGPUVirtualAddressBitsPerProcess - 1)) - 1;
         return S_OK;
     }
 

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -576,7 +576,6 @@ namespace gpgmm::d3d12 {
         const D3D12_RESOURCE_HEAP_TIER mResourceHeapTier;
         const bool mIsAlwaysCommitted;
         const bool mIsAlwaysInBudget;
-        const uint64_t mMaxResourceHeapSize;
         const bool mFlushEventBuffersOnDestruct;
         const bool mUseDetailedTimingEvents;
 


### PR DESCRIPTION
Uses max value of the process (heaps) instead of virtual address space (resource).