### PR TITLE
Explicity check if created heaps are within budget when required.

### DIFF
--- a/src/gpgmm/d3d12/HeapD3D12.cpp
+++ b/src/gpgmm/d3d12/HeapD3D12.cpp
@@ -44,7 +44,8 @@ namespace gpgmm::d3d12 {
         // Ensure enough free memory exists before allocating to avoid an out-of-memory error
         // when over budget.
         if (pResidencyManager != nullptr && descriptor.AlwaysInBudget) {
-            ReturnIfFailed(pResidencyManager->Evict(descriptor.SizeInBytes, memorySegmentGroup));
+            ReturnIfFailed(
+                pResidencyManager->EnsureInBudget(descriptor.SizeInBytes, memorySegmentGroup));
         }
 
         ComPtr<ID3D12Pageable> pageable;

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.h
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.h
@@ -241,12 +241,12 @@ namespace gpgmm::d3d12 {
 
         ResidencyManager(const RESIDENCY_DESC& descriptor, std::unique_ptr<Fence> fence);
 
-        HRESULT Evict(uint64_t evictSizeInBytes,
-                      const DXGI_MEMORY_SEGMENT_GROUP& memorySegmentGroup);
+        HRESULT EnsureInBudget(uint64_t bytesToEvict,
+                               const DXGI_MEMORY_SEGMENT_GROUP& memorySegmentGroup);
 
-        HRESULT EvictInternal(uint64_t evictSizeInBytes,
+        HRESULT EvictInternal(uint64_t bytesToEvict,
                               const DXGI_MEMORY_SEGMENT_GROUP& memorySegmentGroup,
-                              uint64_t* evictedSizeInBytesOut = nullptr);
+                              uint64_t* bytesEvictedOut = nullptr);
 
         HRESULT InsertHeap(Heap* heap);
 

--- a/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.cpp
@@ -29,11 +29,13 @@ namespace gpgmm::d3d12 {
     ResourceHeapAllocator::ResourceHeapAllocator(ResidencyManager* residencyManager,
                                                  ID3D12Device* device,
                                                  D3D12_HEAP_TYPE heapType,
-                                                 D3D12_HEAP_FLAGS heapFlags)
+                                                 D3D12_HEAP_FLAGS heapFlags,
+                                                 bool alwaysInBudget)
         : mResidencyManager(residencyManager),
           mDevice(device),
           mHeapType(heapType),
-          mHeapFlags(heapFlags) {
+          mHeapFlags(heapFlags),
+          mAlwaysInBudget(alwaysInBudget) {
     }
 
     std::unique_ptr<MemoryAllocation> ResourceHeapAllocator::TryAllocateMemory(
@@ -59,10 +61,9 @@ namespace gpgmm::d3d12 {
 
         HEAP_DESC resourceHeapDesc = {};
         resourceHeapDesc.SizeInBytes = heapSize;
-        resourceHeapDesc.IsExternal = false;
         resourceHeapDesc.DebugName = "Resource heap";
         resourceHeapDesc.Alignment = request.Alignment;
-        resourceHeapDesc.AlwaysInBudget = !(mHeapFlags & D3D12_HEAP_FLAG_CREATE_NOT_RESIDENT);
+        resourceHeapDesc.AlwaysInBudget = mAlwaysInBudget;
         resourceHeapDesc.HeapType = mHeapType;
 
         Heap* resourceHeap = nullptr;

--- a/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.h
@@ -29,7 +29,8 @@ namespace gpgmm::d3d12 {
         ResourceHeapAllocator(ResidencyManager* residencyManager,
                               ID3D12Device* device,
                               D3D12_HEAP_TYPE heapType,
-                              D3D12_HEAP_FLAGS heapFlags);
+                              D3D12_HEAP_FLAGS heapFlags,
+                              bool alwaysInBudget);
         ~ResourceHeapAllocator() override = default;
 
         // MemoryAllocator interface
@@ -44,6 +45,7 @@ namespace gpgmm::d3d12 {
         ID3D12Device* const mDevice;
         const D3D12_HEAP_TYPE mHeapType;
         const D3D12_HEAP_FLAGS mHeapFlags;
+        const bool mAlwaysInBudget;
     };
 
 }  // namespace gpgmm::d3d12


### PR DESCRIPTION
This prevents CreateHeap from creating a resident heap when there is no budget left.

By default, a heap is created not resident, if supported. Otherwise, it is assumed to be created resident, and therefore must considered to be in-budget too.