### PR TITLE
Simplify MemoryPool interface.

### DIFF
--- a/src/gpgmm/common/Error.h
+++ b/src/gpgmm/common/Error.h
@@ -19,6 +19,10 @@
 
 namespace gpgmm {
 
+#define GPGMM_ERROR_INVALID_ALLOCATION \
+    MemoryAllocation {                 \
+    }
+
 #define GPGMM_TRY_ASSIGN(expr, value)            \
     {                                            \
         auto result = expr;                      \

--- a/src/gpgmm/common/IndexedMemoryPool.h
+++ b/src/gpgmm/common/IndexedMemoryPool.h
@@ -27,15 +27,14 @@ namespace gpgmm {
         ~IndexedMemoryPool() override = default;
 
         // MemoryPool interface
-        std::unique_ptr<MemoryAllocation> AcquireFromPool(uint64_t memoryIndex) override;
-        void ReturnToPool(std::unique_ptr<MemoryAllocation> allocation,
-                          uint64_t memoryIndex) override;
+        MemoryAllocation AcquireFromPool(uint64_t indexInPool) override;
+        void ReturnToPool(MemoryAllocation allocation, uint64_t indexInPool) override;
         uint64_t ReleasePool(uint64_t bytesToRelease) override;
 
         uint64_t GetPoolSize() const override;
 
       private:
-        std::vector<std::unique_ptr<MemoryAllocation>> mPool;
+        std::vector<MemoryAllocation> mPool;
     };
 
 }  // namespace gpgmm

--- a/src/gpgmm/common/LIFOMemoryPool.cpp
+++ b/src/gpgmm/common/LIFOMemoryPool.cpp
@@ -24,10 +24,10 @@ namespace gpgmm {
     LIFOMemoryPool::LIFOMemoryPool(uint64_t memorySize) : MemoryPool(memorySize) {
     }
 
-    std::unique_ptr<MemoryAllocation> LIFOMemoryPool::AcquireFromPool(uint64_t memoryIndex) {
-        ASSERT(memoryIndex == kInvalidIndex);
+    MemoryAllocation LIFOMemoryPool::AcquireFromPool(uint64_t indexInPool) {
+        ASSERT(indexInPool == kInvalidIndex);
 
-        std::unique_ptr<MemoryAllocation> allocation;
+        MemoryAllocation allocation = {};
         if (!mPool.empty()) {
             allocation = std::move(mPool.front());
             mPool.pop_front();
@@ -35,11 +35,9 @@ namespace gpgmm {
         return allocation;
     }
 
-    void LIFOMemoryPool::ReturnToPool(std::unique_ptr<MemoryAllocation> allocation,
-                                      uint64_t memoryIndex) {
-        ASSERT(allocation != nullptr);
-        ASSERT(memoryIndex == kInvalidIndex);
-        ASSERT(allocation->GetSize() == GetMemorySize());
+    void LIFOMemoryPool::ReturnToPool(MemoryAllocation allocation, uint64_t indexInPool) {
+        ASSERT(indexInPool == kInvalidIndex);
+        ASSERT(allocation.GetSize() == GetMemorySize());
 
         mPool.push_front(std::move(allocation));
     }

--- a/src/gpgmm/common/LIFOMemoryPool.h
+++ b/src/gpgmm/common/LIFOMemoryPool.h
@@ -28,16 +28,15 @@ namespace gpgmm {
         ~LIFOMemoryPool() override = default;
 
         // MemoryPool interface
-        std::unique_ptr<MemoryAllocation> AcquireFromPool(
-            uint64_t memoryIndex = kInvalidIndex) override;
-        void ReturnToPool(std::unique_ptr<MemoryAllocation> allocation,
-                          uint64_t memoryIndex = kInvalidIndex) override;
+        MemoryAllocation AcquireFromPool(uint64_t indexInPool = kInvalidIndex) override;
+        void ReturnToPool(MemoryAllocation allocation,
+                          uint64_t indexInPool = kInvalidIndex) override;
         uint64_t ReleasePool(uint64_t bytesToFree = kInvalidSize) override;
 
         uint64_t GetPoolSize() const override;
 
       private:
-        std::deque<std::unique_ptr<MemoryAllocation>> mPool;
+        std::deque<MemoryAllocation> mPool;
     };
 
 }  // namespace gpgmm

--- a/src/gpgmm/common/MemoryAllocation.h
+++ b/src/gpgmm/common/MemoryAllocation.h
@@ -19,8 +19,6 @@
 #include "gpgmm/utils/Limits.h"
 #include "include/gpgmm_export.h"
 
-#include <cstdint>
-
 namespace gpgmm {
 
     /** \enum AllocationMethod

--- a/src/tests/unittests/MemoryPoolTests.cpp
+++ b/src/tests/unittests/MemoryPoolTests.cpp
@@ -41,7 +41,7 @@ TEST_F(LIFOMemoryPoolTests, SingleAllocation) {
     EXPECT_EQ(pool.ReleasePool(), 0u);
     EXPECT_EQ(pool.GetInfo().SizeInBytes, 0u);
 
-    pool.ReturnToPool(allocator.TryAllocateMemory(CreateBasicRequest(kDefaultMemorySize)));
+    pool.ReturnToPool(*allocator.TryAllocateMemory(CreateBasicRequest(kDefaultMemorySize)));
     EXPECT_EQ(pool.GetInfo().SizeInBytes, kDefaultMemorySize);
     EXPECT_EQ(pool.GetPoolSize(), 1u);
 
@@ -66,7 +66,7 @@ TEST_F(LIFOMemoryPoolTests, MultipleAllocations) {
 
     constexpr uint64_t kPoolSize = 64;
     while (pool.GetPoolSize() < kPoolSize) {
-        pool.ReturnToPool(allocator.TryAllocateMemory(CreateBasicRequest(kDefaultMemorySize)));
+        pool.ReturnToPool(*allocator.TryAllocateMemory(CreateBasicRequest(kDefaultMemorySize)));
     }
 
     EXPECT_EQ(pool.GetInfo().SizeInBytes, kDefaultMemorySize * kPoolSize);


### PR DESCRIPTION
Removes indirection of wrapping MemoryAllocation in a unique pointer. This allows memory pools to be easily stored in sequence containers.

Support pooled dynamic memory allocation for CPU allocations. #321