### PR TITLE
Remove unused MemoryPool dependency from d3d12::Heap.

### DIFF
--- a/src/gpgmm/common/Memory.h
+++ b/src/gpgmm/common/Memory.h
@@ -74,7 +74,7 @@ namespace gpgmm {
         const uint64_t mSize;
         const uint64_t mAlignment;
 
-        MemoryPool* mPool = nullptr;
+        MemoryPool* mPool = nullptr;  // nullptr means no pool is assigned.
     };
 
 }  // namespace gpgmm

--- a/src/gpgmm/d3d12/HeapD3D12.cpp
+++ b/src/gpgmm/d3d12/HeapD3D12.cpp
@@ -141,7 +141,7 @@ namespace gpgmm::d3d12 {
     }
 
     HEAP_INFO Heap::GetInfo() const {
-        return {IsResident(), GetRefCount(), GetPool()};
+        return {IsResident()};
     }
 
     HRESULT Heap::SetDebugNameImpl(const std::string& name) {

--- a/src/gpgmm/d3d12/HeapD3D12.h
+++ b/src/gpgmm/d3d12/HeapD3D12.h
@@ -21,7 +21,6 @@
 #include "gpgmm/d3d12/IUnknownImplD3D12.h"
 #include "gpgmm/utils/Limits.h"
 #include "gpgmm/utils/LinkedList.h"
-#include "gpgmm/utils/RefCount.h"
 #include "include/gpgmm_export.h"
 
 #include <functional>  // for std::function
@@ -29,7 +28,6 @@
 
 namespace gpgmm::d3d12 {
 
-    class ResidencyList;
     class ResidencyManager;
     class ResourceAllocator;
 
@@ -52,18 +50,6 @@ namespace gpgmm::d3d12 {
         /** \brief Check if the heap is resident or not.
          */
         bool IsResident;
-
-        /** \brief The number of sub-allocations made using this heap.
-
-        A count of 0 means the entire heap is being used.
-        */
-        uint64_t SubAllocatedRefs;
-
-        /** \brief The pool this heap is assigned to.
-
-        A NULL pool means this heap cannot be recycled by GPGMM.
-        */
-        MemoryPool* MemoryPool;
     };
 
     /** \struct HEAP_DESC

--- a/src/gpgmm/d3d12/JSONSerializerD3D12.cpp
+++ b/src/gpgmm/d3d12/JSONSerializerD3D12.cpp
@@ -176,12 +176,6 @@ namespace gpgmm::d3d12 {
     JSONDict JSONSerializer::Serialize(const HEAP_INFO& info) {
         JSONDict dict;
         dict.AddItem("IsResident", info.IsResident);
-        dict.AddItem("SubAllocatedRefs", info.SubAllocatedRefs);
-
-        if (info.MemoryPool != nullptr) {
-            dict.AddItem("MemoryPool", gpgmm::JSONSerializer::Serialize(info.MemoryPool));
-        }
-
         return dict;
     }
 


### PR DESCRIPTION
MemoryPool is internal/private to GPGMM and should not be exported.