### PR TITLE
Make RefCounted in IUnknown-based objects private.

### DIFF
--- a/src/gpgmm/d3d12/DebugResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/DebugResourceAllocatorD3D12.cpp
@@ -17,6 +17,7 @@
 #include "gpgmm/common/EventMessage.h"
 #include "gpgmm/d3d12/BackendD3D12.h"
 #include "gpgmm/d3d12/ErrorD3D12.h"
+#include "gpgmm/d3d12/JSONSerializerD3D12.h"
 #include "gpgmm/d3d12/ResourceAllocationD3D12.h"
 #include "gpgmm/utils/Utils.h"
 
@@ -52,7 +53,7 @@ namespace gpgmm::d3d12 {
             const ResourceAllocation* allocation = allocationEntry->GetValue().GetAllocation();
             gpgmm::WarnEvent(allocation->GetAllocator()->GetTypename())
                 << "Live ResourceAllocation at " << ToString(allocation) << ", "
-                << "RefCount: " << allocation->GetRefCount();
+                << JSONSerializer::Serialize(allocation->GetInfo()).ToString();
         }
     }
 

--- a/src/gpgmm/d3d12/IUnknownImplD3D12.cpp
+++ b/src/gpgmm/d3d12/IUnknownImplD3D12.cpp
@@ -15,7 +15,7 @@
 #include "gpgmm/d3d12/IUnknownImplD3D12.h"
 
 namespace gpgmm::d3d12 {
-    IUnknownImpl::IUnknownImpl() : RefCounted(1) {
+    IUnknownImpl::IUnknownImpl() : mRefs(1) {
     }
 
     HRESULT IUnknownImpl::QueryInterface(REFIID riid, void** ppvObject) {
@@ -29,19 +29,20 @@ namespace gpgmm::d3d12 {
         if (riid == IID_IUnknown) {
             // Increment reference and return pointer.
             *ppvObject = this;
-            Ref();
+            mRefs.Ref();
             return S_OK;
         }
+
         return E_NOINTERFACE;
     }
 
     ULONG IUnknownImpl::AddRef() {
-        Ref();
-        return GetRefCount();
+        mRefs.Ref();
+        return mRefs.GetRefCount();
     }
 
     ULONG IUnknownImpl::Release() {
-        const ULONG refCount = Unref() ? 0 : GetRefCount();
+        const ULONG refCount = mRefs.Unref() ? 0 : mRefs.GetRefCount();
         if (refCount == 0) {
             DeleteThis();
         }

--- a/src/gpgmm/d3d12/IUnknownImplD3D12.h
+++ b/src/gpgmm/d3d12/IUnknownImplD3D12.h
@@ -21,7 +21,7 @@
 
 namespace gpgmm::d3d12 {
 
-    class GPGMM_EXPORT IUnknownImpl : public IUnknown, public RefCounted {
+    class GPGMM_EXPORT IUnknownImpl : public IUnknown {
       public:
         IUnknownImpl();
         virtual ~IUnknownImpl() = default;
@@ -31,8 +31,12 @@ namespace gpgmm::d3d12 {
         ULONG STDMETHODCALLTYPE AddRef() override;
         ULONG STDMETHODCALLTYPE Release() override;
 
+      protected:
         // Derived class may override this if they require a custom deleter.
         virtual void DeleteThis();
+
+      private:
+        RefCounted mRefs;  // Maintains the COM ref-count of this object.
     };
 
 }  // namespace gpgmm::d3d12


### PR DESCRIPTION
Removes the need to also publically define RefCounted with IUnknown impl and enforces private-only linkage.