### PR TITLE
Refactor ResidencyManager query info API.

### DIFF
--- a/src/fuzzers/D3D12ResidencyManagerFuzzer.cpp
+++ b/src/fuzzers/D3D12ResidencyManagerFuzzer.cpp
@@ -30,10 +30,10 @@ namespace {
         if (residencyManager == nullptr) {
             return 0;
         }
-        DXGI_QUERY_VIDEO_MEMORY_INFO* segment =
-            gResidencyManager->GetVideoMemoryInfo(memorySegmentGroup);
-        return (segment->Budget > segment->CurrentUsage) ? (segment->Budget - segment->CurrentUsage)
-                                                         : 0;
+        DXGI_QUERY_VIDEO_MEMORY_INFO segment = {};
+        gResidencyManager->QueryVideoMemoryInfo(memorySegmentGroup, &segment);
+        return (segment.Budget > segment.CurrentUsage) ? (segment.Budget - segment.CurrentUsage)
+                                                       : 0;
     }
 
 }  // namespace

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.h
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.h
@@ -209,15 +209,16 @@ namespace gpgmm::d3d12 {
         /** \brief  Get the current budget and memory usage.
 
         @param memorySegmentGroup Memory segment to retrieve info from.
-
-        \return A pointer to DXGI_QUERY_VIDEO_MEMORY_INFO struct of the video memory segment info.
+        @param[out] pVideoMemoryInfoOut Pointer to DXGI_QUERY_VIDEO_MEMORY_INFO to populate.
         */
-        DXGI_QUERY_VIDEO_MEMORY_INFO* GetVideoMemoryInfo(
-            const DXGI_MEMORY_SEGMENT_GROUP& memorySegmentGroup);
+        HRESULT QueryVideoMemoryInfo(const DXGI_MEMORY_SEGMENT_GROUP& memorySegmentGroup,
+                                     DXGI_QUERY_VIDEO_MEMORY_INFO* pVideoMemoryInfoOut);
 
-        /** \brief Manually update the video memory budgets.
-         */
-        HRESULT UpdateVideoMemorySegments();
+        /** \brief  Update and retrieve the current budget and memory usage.
+
+        @param memorySegmentGroup Memory segment to update info.
+        */
+        HRESULT UpdateMemorySegment(const DXGI_MEMORY_SEGMENT_GROUP& memorySegmentGroup);
 
         /** \brief  Return the current residency manager usage.
 
@@ -268,10 +269,10 @@ namespace gpgmm::d3d12 {
 
         LRUCache* GetVideoMemorySegmentCache(const DXGI_MEMORY_SEGMENT_GROUP& memorySegmentGroup);
 
-        HRESULT QueryVideoMemoryInfo(const DXGI_MEMORY_SEGMENT_GROUP& memorySegmentGroup,
-                                     DXGI_QUERY_VIDEO_MEMORY_INFO* pVideoMemoryInfo) const;
+        DXGI_QUERY_VIDEO_MEMORY_INFO* GetVideoMemoryInfo(
+            const DXGI_MEMORY_SEGMENT_GROUP& memorySegmentGroup);
 
-        HRESULT UpdateVideoMemorySegmentsInternal();
+        HRESULT UpdateMemorySegmentInternal(const DXGI_MEMORY_SEGMENT_GROUP& memorySegmentGroup);
 
         HRESULT StartBudgetNotificationUpdates();
         void StopBudgetNotificationUpdates();

--- a/src/tests/end2end/D3D12ResidencyManagerTests.cpp
+++ b/src/tests/end2end/D3D12ResidencyManagerTests.cpp
@@ -81,10 +81,10 @@ class D3D12ResidencyManagerTests : public D3D12TestBase, public ::testing::Test 
 
     uint64_t GetBudgetLeft(ResidencyManager* residencyManager,
                            const DXGI_MEMORY_SEGMENT_GROUP& memorySegmentGroup) {
-        DXGI_QUERY_VIDEO_MEMORY_INFO* segment =
-            residencyManager->GetVideoMemoryInfo(memorySegmentGroup);
-        return (segment->Budget > segment->CurrentUsage) ? (segment->Budget - segment->CurrentUsage)
-                                                         : 0;
+        DXGI_QUERY_VIDEO_MEMORY_INFO segment = {};
+        residencyManager->QueryVideoMemoryInfo(memorySegmentGroup, &segment);
+        return (segment.Budget > segment.CurrentUsage) ? (segment.Budget - segment.CurrentUsage)
+                                                       : 0;
     }
 };
 


### PR DESCRIPTION
Renames GetVideoMemoryInfo to QueryVideoMemoryInfo and emits error codes. UpdateVideoMemorySegments also was refactored to be per-group or UpdateMemorySegment for consistency.