### PR TITLE
Remove default-initialization from D3D descriptor structures.

### DIFF
--- a/src/gpgmm/d3d12/EventRecordD3D12.h
+++ b/src/gpgmm/d3d12/EventRecordD3D12.h
@@ -68,11 +68,11 @@ namespace gpgmm::d3d12 {
 
         /** \brief Scopes events per process (or multiple instances).
          */
-        EVENT_RECORD_SCOPE_PER_PROCESS = 0x1,
+        EVENT_RECORD_SCOPE_PER_PROCESS = 0x0,
 
         /** \brief Scopes events per instance.
          */
-        EVENT_RECORD_SCOPE_PER_INSTANCE = 0x2,
+        EVENT_RECORD_SCOPE_PER_INSTANCE = 0x1,
     };
 
     /** \struct EVENT_RECORD_OPTIONS
@@ -83,7 +83,7 @@ namespace gpgmm::d3d12 {
 
         Optional parameter. By default, nothing is recorded.
         */
-        EVENT_RECORD_FLAGS Flags = EVENT_RECORD_FLAG_NONE;
+        EVENT_RECORD_FLAGS Flags;
 
         /** \brief Minimum severity level to record messages.
 
@@ -91,19 +91,19 @@ namespace gpgmm::d3d12 {
 
         Optional parameter. By default, the minimum severity level is WARN.
         */
-        D3D12_MESSAGE_SEVERITY MinMessageLevel = D3D12_MESSAGE_SEVERITY_WARNING;
+        D3D12_MESSAGE_SEVERITY MinMessageLevel;
 
         /** \brief Specifies the scope of the events.
 
         Optional parameter. By default, recording is per process.
         */
-        EVENT_RECORD_SCOPE EventScope = EVENT_RECORD_SCOPE_PER_PROCESS;
+        EVENT_RECORD_SCOPE EventScope;
 
         /** \brief Record detailed timing events.
 
         Optional parameter. By default, detailed timing events are disabled.
         */
-        bool UseDetailedTimingEvents = false;
+        bool UseDetailedTimingEvents;
 
         /** \brief Path to trace file.
 

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.h
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.h
@@ -67,7 +67,7 @@ namespace gpgmm::d3d12 {
 
         Optional parameter. By default, will log only corruption messages.
         */
-        D3D12_MESSAGE_SEVERITY MinLogLevel = D3D12_MESSAGE_SEVERITY_WARNING;
+        D3D12_MESSAGE_SEVERITY MinLogLevel;
 
         /** \brief Specifies recording options.
 

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -338,6 +338,15 @@ namespace gpgmm::d3d12 {
                                                ? allocatorDescriptor.MemoryGrowthFactor
                                                : kDefaultMemoryGrowthFactor;
 
+        // By default, slab-allocate from a sorted segmented list.
+        if (newDescriptor.PoolAlgorithm == ALLOCATOR_ALGORITHM_DEFAULT) {
+            newDescriptor.PoolAlgorithm = ALLOCATOR_ALGORITHM_SEGMENTED_POOL;
+        }
+
+        if (newDescriptor.SubAllocationAlgorithm == ALLOCATOR_ALGORITHM_DEFAULT) {
+            newDescriptor.SubAllocationAlgorithm = ALLOCATOR_ALGORITHM_SLAB;
+        }
+
         // ID3D12Device::CreateCommittedResource and ID3D12Device::CreateHeap implicity
         // call ID3D12Device::MakeResident, requiring resource heaps to be "created in budget".
         // But this can be disabled if D3D12_HEAP_FLAG_CREATE_NOT_RESIDENT is supported.

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -86,6 +86,10 @@ namespace gpgmm::d3d12 {
     Specify the algorithms used for allocation.
     */
     enum ALLOCATOR_ALGORITHM {
+        /** \brief Use default allocation mechanism.
+         */
+        ALLOCATOR_ALGORITHM_DEFAULT = 0x0,
+
         /** \brief Use the slab allocation mechanism.
 
         Slab allocation allocates/deallocates in O(1) time using O(N * pageSize) space.
@@ -93,7 +97,7 @@ namespace gpgmm::d3d12 {
         Slab allocation does not suffer from internal fragmentation but could externally fragment
         when many unique request sizes are used.
         */
-        ALLOCATOR_ALGORITHM_SLAB = 0x0,
+        ALLOCATOR_ALGORITHM_SLAB = 0x1,
 
         /** \brief Use the buddy system mechanism.
 
@@ -107,7 +111,7 @@ namespace gpgmm::d3d12 {
         requests can fit within the specified PreferredResourceHeapSize but not too large where
         creating the larger resource heap becomes a bigger bottleneck.
         */
-        ALLOCATOR_ALGORITHM_BUDDY_SYSTEM = 0x1,
+        ALLOCATOR_ALGORITHM_BUDDY_SYSTEM = 0x2,
 
         /** \brief Recycles resource heaps of a size being specified.
 
@@ -117,13 +121,13 @@ namespace gpgmm::d3d12 {
         PreferredResourceHeapSize. A PreferredResourceHeapSize of zero is effectively
         equivelent to ALLOCATOR_FLAG_ALWAYS_ON_DEMAND.
         */
-        ALLOCATOR_ALGORITHM_FIXED_POOL = 0x2,
+        ALLOCATOR_ALGORITHM_FIXED_POOL = 0x3,
 
         /** \brief Recycles resource heaps of any size using multiple pools.
 
         Segmented pool allocate/deallocates in O(Log2) time using O(N * K) space.
         */
-        ALLOCATOR_ALGORITHM_SEGMENTED_POOL = 0x3,
+        ALLOCATOR_ALGORITHM_SEGMENTED_POOL = 0x4,
     };
 
     DEFINE_ENUM_FLAG_OPERATORS(ALLOCATOR_ALGORITHM)
@@ -149,13 +153,13 @@ namespace gpgmm::d3d12 {
         For example, whether the allocator can reuse memory, or resources should be resident upon
         creation.
         */
-        ALLOCATOR_FLAGS Flags = ALLOCATOR_FLAG_NONE;
+        ALLOCATOR_FLAGS Flags;
 
         /** \brief Minimum severity level to log messages to console.
 
         Messages with lower severity will be ignored.
         */
-        D3D12_MESSAGE_SEVERITY MinLogLevel = D3D12_MESSAGE_SEVERITY_WARNING;
+        D3D12_MESSAGE_SEVERITY MinLogLevel;
 
         /** \brief Specifies recording options.
 
@@ -179,7 +183,7 @@ namespace gpgmm::d3d12 {
 
         Optional parameter. By default, the slab allocator is used.
         */
-        ALLOCATOR_ALGORITHM SubAllocationAlgorithm = ALLOCATOR_ALGORITHM_SLAB;
+        ALLOCATOR_ALGORITHM SubAllocationAlgorithm;
 
         /** \brief Specifies the algorithm to use for resource heap pooling.
 
@@ -188,7 +192,7 @@ namespace gpgmm::d3d12 {
 
         Optional parameter. By default, the slab allocator is used.
         */
-        ALLOCATOR_ALGORITHM PoolAlgorithm = ALLOCATOR_ALGORITHM_SEGMENTED_POOL;
+        ALLOCATOR_ALGORITHM PoolAlgorithm;
 
         /** \brief Specifies the preferred size of the resource heap.
 
@@ -311,13 +315,13 @@ namespace gpgmm::d3d12 {
 
         Optional parameter. By default, GPGMM will decide automatically.
         */
-        ALLOCATION_FLAGS Flags = ALLOCATION_FLAG_NONE;
+        ALLOCATION_FLAGS Flags;
 
         /** \brief Heap type that the resource to be allocated requires.
 
-        Required parameter. GPGMM always initializes to D3D12_HEAP_TYPE_DEFAULT.
+        Required parameter.
         */
-        D3D12_HEAP_TYPE HeapType = D3D12_HEAP_TYPE_DEFAULT;
+        D3D12_HEAP_TYPE HeapType;
 
         /** \brief Additional heap flags that the resource requires.
 
@@ -330,7 +334,7 @@ namespace gpgmm::d3d12 {
 
         Optional parameter.
         */
-        D3D12_HEAP_FLAGS ExtraRequiredHeapFlags = D3D12_HEAP_FLAG_NONE;
+        D3D12_HEAP_FLAGS ExtraRequiredHeapFlags;
 
         /** \brief Require additional bytes to be appended to the resource allocation.
 
@@ -342,7 +346,7 @@ namespace gpgmm::d3d12 {
 
         Optional parameter. No extra padding is applied by default.
         */
-        uint64_t RequireResourceHeapPadding = 0;
+        uint64_t RequireResourceHeapPadding;
 
         /** \brief Associates a name with the given allocation.
 

--- a/src/tests/end2end/D3D12ResidencyManagerTests.cpp
+++ b/src/tests/end2end/D3D12ResidencyManagerTests.cpp
@@ -149,9 +149,13 @@ TEST_F(D3D12ResidencyManagerTests, CreateResidencyList) {
     ASSERT_SUCCEEDED(ResourceAllocator::CreateAllocator(CreateBasicAllocatorDesc(),
                                                         &resourceAllocator, nullptr));
 
+    ALLOCATION_DESC allocationDesc = {};
+    allocationDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
+
     ComPtr<ResourceAllocation> allocation;
-    ASSERT_SUCCEEDED(resourceAllocator->CreateResource(
-        {}, CreateBasicBufferDesc(1), D3D12_RESOURCE_STATE_COMMON, nullptr, &allocation));
+    ASSERT_SUCCEEDED(resourceAllocator->CreateResource(allocationDesc, CreateBasicBufferDesc(1),
+                                                       D3D12_RESOURCE_STATE_COMMON, nullptr,
+                                                       &allocation));
 
     // Inserting a non-existant heap should always fail
     {
@@ -252,7 +256,7 @@ TEST_F(D3D12ResidencyManagerTests, OverBudget) {
     while (resourceAllocator->GetInfo().UsedMemoryUsage + kBufferMemorySize < memoryUnderBudget) {
         ComPtr<ResourceAllocation> allocation;
         ASSERT_SUCCEEDED(resourceAllocator->CreateResource(
-            {}, bufferDesc, D3D12_RESOURCE_STATE_COMMON, nullptr, &allocation));
+            bufferAllocationDesc, bufferDesc, D3D12_RESOURCE_STATE_COMMON, nullptr, &allocation));
         allocationsBelowBudget.push_back(std::move(allocation));
     }
 
@@ -271,7 +275,7 @@ TEST_F(D3D12ResidencyManagerTests, OverBudget) {
     while (currentMemoryUsage + kMemoryOverBudget > resourceAllocator->GetInfo().UsedMemoryUsage) {
         ComPtr<ResourceAllocation> allocation;
         ASSERT_SUCCEEDED(resourceAllocator->CreateResource(
-            {}, bufferDesc, D3D12_RESOURCE_STATE_COMMON, nullptr, &allocation));
+            bufferAllocationDesc, bufferDesc, D3D12_RESOURCE_STATE_COMMON, nullptr, &allocation));
         allocationsAboveBudget.push_back(std::move(allocation));
     }
 

--- a/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
+++ b/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
@@ -164,10 +164,13 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferSubAllocated) {
         ASSERT_SUCCEEDED(ResourceAllocator::CreateAllocator(newAllocatorDesc, &resourceAllocator));
         ASSERT_NE(resourceAllocator, nullptr);
 
+        ALLOCATION_DESC allocationDesc = {};
+        allocationDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
+
         for (auto& alloc : GenerateBufferAllocations()) {
             ComPtr<ResourceAllocation> allocation;
             EXPECT_EQ(SUCCEEDED(resourceAllocator->CreateResource(
-                          {}, CreateBasicBufferDesc(alloc.size, alloc.alignment),
+                          allocationDesc, CreateBasicBufferDesc(alloc.size, alloc.alignment),
                           D3D12_RESOURCE_STATE_COMMON, nullptr, &allocation)),
                       alloc.succeeds);
         }
@@ -182,10 +185,13 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferSubAllocated) {
         ASSERT_SUCCEEDED(ResourceAllocator::CreateAllocator(newAllocatorDesc, &resourceAllocator));
         ASSERT_NE(resourceAllocator, nullptr);
 
+        ALLOCATION_DESC allocationDesc = {};
+        allocationDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
+
         for (auto& alloc : GenerateBufferAllocations()) {
             ComPtr<ResourceAllocation> allocation;
             EXPECT_EQ(SUCCEEDED(resourceAllocator->CreateResource(
-                          {}, CreateBasicBufferDesc(alloc.size, alloc.alignment),
+                          allocationDesc, CreateBasicBufferDesc(alloc.size, alloc.alignment),
                           D3D12_RESOURCE_STATE_COMMON, nullptr, &allocation)),
                       alloc.succeeds);
         }
@@ -201,10 +207,13 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferSubAllocated) {
         ASSERT_SUCCEEDED(ResourceAllocator::CreateAllocator(newAllocatorDesc, &resourceAllocator));
         ASSERT_NE(resourceAllocator, nullptr);
 
+        ALLOCATION_DESC allocationDesc = {};
+        allocationDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
+
         for (auto& alloc : GenerateBufferAllocations()) {
             ComPtr<ResourceAllocation> allocation;
             EXPECT_EQ(SUCCEEDED(resourceAllocator->CreateResource(
-                          {}, CreateBasicBufferDesc(alloc.size, alloc.alignment),
+                          allocationDesc, CreateBasicBufferDesc(alloc.size, alloc.alignment),
                           D3D12_RESOURCE_STATE_COMMON, nullptr, &allocation)),
                       alloc.succeeds);
         }
@@ -219,10 +228,13 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferSubAllocated) {
         ASSERT_SUCCEEDED(ResourceAllocator::CreateAllocator(newAllocatorDesc, &resourceAllocator));
         ASSERT_NE(resourceAllocator, nullptr);
 
+        ALLOCATION_DESC allocationDesc = {};
+        allocationDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
+
         for (auto& alloc : GenerateBufferAllocations()) {
             ComPtr<ResourceAllocation> allocation;
             EXPECT_EQ(SUCCEEDED(resourceAllocator->CreateResource(
-                          {}, CreateBasicBufferDesc(alloc.size, alloc.alignment),
+                          allocationDesc, CreateBasicBufferDesc(alloc.size, alloc.alignment),
                           D3D12_RESOURCE_STATE_COMMON, nullptr, &allocation)),
                       alloc.succeeds);
         }
@@ -235,11 +247,14 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferManyDeallocateAtEnd) {
         ResourceAllocator::CreateAllocator(CreateBasicAllocatorDesc(), &resourceAllocator));
     ASSERT_NE(resourceAllocator, nullptr);
 
+    ALLOCATION_DESC allocationDesc = {};
+    allocationDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
+
     std::set<ComPtr<ResourceAllocation>> allocs = {};
     for (auto& alloc : GenerateBufferAllocations()) {
         ComPtr<ResourceAllocation> allocation;
         EXPECT_EQ(SUCCEEDED(resourceAllocator->CreateResource(
-                      {}, CreateBasicBufferDesc(alloc.size, alloc.alignment),
+                      allocationDesc, CreateBasicBufferDesc(alloc.size, alloc.alignment),
                       D3D12_RESOURCE_STATE_COMMON, nullptr, &allocation)),
                   alloc.succeeds);
 
@@ -260,27 +275,33 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBuffer) {
 
     // Creating a resource without allocation should still succeed.
     {
-        ASSERT_SUCCEEDED(
-            resourceAllocator->CreateResource({}, CreateBasicBufferDesc(kDefaultBufferSize),
-                                              D3D12_RESOURCE_STATE_COMMON, nullptr, nullptr));
+        ALLOCATION_DESC allocationDesc = {};
+        allocationDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
+
+        ASSERT_SUCCEEDED(resourceAllocator->CreateResource(
+            allocationDesc, CreateBasicBufferDesc(kDefaultBufferSize), D3D12_RESOURCE_STATE_COMMON,
+            nullptr, nullptr));
     }
 
     // Using the min resource heap size should always succeed.
     {
+        ALLOCATION_DESC allocationDesc = {};
+        allocationDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
+
         ComPtr<ResourceAllocation> allocation;
-        ASSERT_SUCCEEDED(
-            resourceAllocator->CreateResource({}, CreateBasicBufferDesc(kDefaultBufferSize),
-                                              D3D12_RESOURCE_STATE_COMMON, nullptr, &allocation));
+        ASSERT_SUCCEEDED(resourceAllocator->CreateResource(
+            allocationDesc, CreateBasicBufferDesc(kDefaultBufferSize), D3D12_RESOURCE_STATE_COMMON,
+            nullptr, &allocation));
         ASSERT_NE(allocation, nullptr);
         ASSERT_NE(allocation->GetResource(), nullptr);
     }
 
     // Mapping the entire buffer should always succeed.
     {
-        ComPtr<ResourceAllocation> allocation;
         ALLOCATION_DESC allocationDesc = {};
         allocationDesc.HeapType = D3D12_HEAP_TYPE_UPLOAD;
 
+        ComPtr<ResourceAllocation> allocation;
         ASSERT_SUCCEEDED(resourceAllocator->CreateResource(
             allocationDesc, CreateBasicBufferDesc(kDefaultBufferSize),
             D3D12_RESOURCE_STATE_GENERIC_READ, nullptr, &allocation));
@@ -373,9 +394,11 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBuffer) {
 
     // Creating a buffer with a name should be always specified.
     {
-        ComPtr<ResourceAllocation> allocation;
         ALLOCATION_DESC allocationDesc = {};
+        allocationDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
         allocationDesc.DebugName = "Buffer";
+
+        ComPtr<ResourceAllocation> allocation;
         ASSERT_SUCCEEDED(resourceAllocator->CreateResource(
             allocationDesc, CreateBasicBufferDesc(kDefaultBufferSize), D3D12_RESOURCE_STATE_COMMON,
             nullptr, &allocation));
@@ -392,9 +415,12 @@ TEST_F(D3D12ResourceAllocatorTests, CreateSmallTexture) {
 
     // DXGI_FORMAT_R8G8B8A8_UNORM
     {
+        ALLOCATION_DESC allocationDesc = {};
+        allocationDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
+
         ComPtr<ResourceAllocation> allocation;
         ASSERT_SUCCEEDED(resourceAllocator->CreateResource(
-            {}, CreateBasicTextureDesc(DXGI_FORMAT_R8G8B8A8_UNORM, 1, 1),
+            allocationDesc, CreateBasicTextureDesc(DXGI_FORMAT_R8G8B8A8_UNORM, 1, 1),
             D3D12_RESOURCE_STATE_GENERIC_READ, nullptr, &allocation));
         ASSERT_NE(allocation, nullptr);
         EXPECT_TRUE(
@@ -411,9 +437,12 @@ TEST_F(D3D12ResourceAllocatorTests, CreateMultisampledTexture) {
 
     // DXGI_FORMAT_R8G8B8A8_UNORM
     {
+        ALLOCATION_DESC allocationDesc = {};
+        allocationDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
+
         ComPtr<ResourceAllocation> allocation;
         ASSERT_SUCCEEDED(resourceAllocator->CreateResource(
-            {}, CreateBasicTextureDesc(DXGI_FORMAT_R8G8B8A8_UNORM, 1, 1, 4),
+            allocationDesc, CreateBasicTextureDesc(DXGI_FORMAT_R8G8B8A8_UNORM, 1, 1, 4),
             D3D12_RESOURCE_STATE_GENERIC_READ, nullptr, &allocation));
         ASSERT_NE(allocation, nullptr);
         EXPECT_TRUE(gpgmm::IsAligned(
@@ -437,10 +466,13 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferImported) {
     ASSERT_FAILED(resourceAllocator->CreateResource(nullptr, &externalAllocation));
     ASSERT_EQ(externalAllocation, nullptr);
 
+    ALLOCATION_DESC allocationDesc = {};
+    allocationDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
+
     // Importing a buffer should always succeed.
     ASSERT_SUCCEEDED(resourceAllocator->CreateResource(
-        {}, CreateBasicBufferDesc(kDefaultBufferSize), D3D12_RESOURCE_STATE_COMMON, nullptr,
-        &externalAllocation));
+        allocationDesc, CreateBasicBufferDesc(kDefaultBufferSize), D3D12_RESOURCE_STATE_COMMON,
+        nullptr, &externalAllocation));
     ASSERT_NE(externalAllocation, nullptr);
 
     ComPtr<ResourceAllocation> internalAllocation;
@@ -476,9 +508,12 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferAlwaysCommitted) {
     ASSERT_SUCCEEDED(ResourceAllocator::CreateAllocator(desc, &resourceAllocator));
     ASSERT_NE(resourceAllocator, nullptr);
 
+    ALLOCATION_DESC allocationDesc = {};
+    allocationDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
+
     ComPtr<ResourceAllocation> allocation;
     ASSERT_SUCCEEDED(
-        resourceAllocator->CreateResource({}, CreateBasicBufferDesc(kDefaultBufferSize),
+        resourceAllocator->CreateResource(allocationDesc, CreateBasicBufferDesc(kDefaultBufferSize),
                                           D3D12_RESOURCE_STATE_COMMON, nullptr, &allocation));
     ASSERT_NE(allocation, nullptr);
     EXPECT_EQ(allocation->GetSize(), kDefaultBufferSize);
@@ -505,6 +540,8 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferNeverAllocate) {
     // Check we can't reuse memory if CreateResource was never called previously.
     ALLOCATION_DESC allocationDesc = {};
     allocationDesc.Flags = ALLOCATION_FLAG_NEVER_ALLOCATE_MEMORY;
+    allocationDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
+
     ComPtr<ResourceAllocation> allocation;
     ASSERT_FAILED(resourceAllocator->CreateResource(
         allocationDesc, CreateBasicBufferDesc(kDefaultBufferSize + 1), D3D12_RESOURCE_STATE_COMMON,
@@ -538,11 +575,11 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferWithin) {
         ResourceAllocator::CreateAllocator(CreateBasicAllocatorDesc(), &resourceAllocator));
     ASSERT_NE(resourceAllocator, nullptr);
 
-    ALLOCATION_DESC desc = {};
-    desc.Flags = ALLOCATION_FLAG_ALLOW_SUBALLOCATE_WITHIN_RESOURCE;
+    ALLOCATION_DESC baseAllocationDesc = {};
+    baseAllocationDesc.Flags = ALLOCATION_FLAG_ALLOW_SUBALLOCATE_WITHIN_RESOURCE;
 
     {
-        ALLOCATION_DESC smallBufferDesc = desc;
+        ALLOCATION_DESC smallBufferDesc = baseAllocationDesc;
         smallBufferDesc.HeapType = D3D12_HEAP_TYPE_UPLOAD;
 
         ComPtr<ResourceAllocation> smallBuffer;
@@ -560,12 +597,12 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferWithin) {
         EXPECT_EQ(resourceAllocator->GetInfo().UsedBlockUsage, smallBuffer->GetSize());
     }
     {
-        ALLOCATION_DESC smallBufferDesc = desc;
-        smallBufferDesc.HeapType = D3D12_HEAP_TYPE_UPLOAD;
+        ALLOCATION_DESC smallBufferWithinDesc = baseAllocationDesc;
+        smallBufferWithinDesc.HeapType = D3D12_HEAP_TYPE_UPLOAD;
 
         ComPtr<ResourceAllocation> smallBuffer;
         ASSERT_SUCCEEDED(resourceAllocator->CreateResource(
-            smallBufferDesc, CreateBasicBufferDesc(4u, 16), D3D12_RESOURCE_STATE_GENERIC_READ,
+            smallBufferWithinDesc, CreateBasicBufferDesc(4u, 16), D3D12_RESOURCE_STATE_GENERIC_READ,
             nullptr, &smallBuffer));
         ASSERT_NE(smallBuffer, nullptr);
         EXPECT_EQ(smallBuffer->GetMethod(), gpgmm::AllocationMethod::kSubAllocatedWithin);
@@ -578,13 +615,13 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferWithin) {
         EXPECT_EQ(resourceAllocator->GetInfo().UsedBlockUsage, smallBuffer->GetSize());
     }
     {
-        ALLOCATION_DESC smallBufferDesc = desc;
-        smallBufferDesc.HeapType = D3D12_HEAP_TYPE_UPLOAD;
+        ALLOCATION_DESC smallBufferWithinDesc = baseAllocationDesc;
+        smallBufferWithinDesc.HeapType = D3D12_HEAP_TYPE_UPLOAD;
 
         ComPtr<ResourceAllocation> smallBuffer;
         ASSERT_SUCCEEDED(resourceAllocator->CreateResource(
-            smallBufferDesc, CreateBasicBufferDesc(4u), D3D12_RESOURCE_STATE_GENERIC_READ, nullptr,
-            &smallBuffer));
+            smallBufferWithinDesc, CreateBasicBufferDesc(4u), D3D12_RESOURCE_STATE_GENERIC_READ,
+            nullptr, &smallBuffer));
         ASSERT_NE(smallBuffer, nullptr);
         EXPECT_EQ(smallBuffer->GetMethod(), gpgmm::AllocationMethod::kSubAllocatedWithin);
         EXPECT_EQ(smallBuffer->GetSize(), 256u);
@@ -596,13 +633,13 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferWithin) {
         EXPECT_EQ(resourceAllocator->GetInfo().UsedBlockUsage, smallBuffer->GetSize());
     }
     {
-        ALLOCATION_DESC smallBufferDesc = desc;
-        smallBufferDesc.HeapType = D3D12_HEAP_TYPE_READBACK;
+        ALLOCATION_DESC smallBufferWithinDesc = baseAllocationDesc;
+        smallBufferWithinDesc.HeapType = D3D12_HEAP_TYPE_READBACK;
 
         ComPtr<ResourceAllocation> smallBuffer;
         ASSERT_SUCCEEDED(resourceAllocator->CreateResource(
-            smallBufferDesc, CreateBasicBufferDesc(4u), D3D12_RESOURCE_STATE_COPY_DEST, nullptr,
-            &smallBuffer));
+            smallBufferWithinDesc, CreateBasicBufferDesc(4u), D3D12_RESOURCE_STATE_COPY_DEST,
+            nullptr, &smallBuffer));
         ASSERT_NE(smallBuffer, nullptr);
         EXPECT_EQ(smallBuffer->GetMethod(), gpgmm::AllocationMethod::kSubAllocatedWithin);
         EXPECT_EQ(smallBuffer->GetSize(), 4u);
@@ -610,13 +647,13 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferWithin) {
         EXPECT_EQ(smallBuffer->GetAlignment(), 4u);
     }
     {
-        ALLOCATION_DESC smallBufferDesc = desc;
-        smallBufferDesc.HeapType = D3D12_HEAP_TYPE_READBACK;
+        ALLOCATION_DESC smallBufferWithinDesc = baseAllocationDesc;
+        smallBufferWithinDesc.HeapType = D3D12_HEAP_TYPE_READBACK;
 
         ComPtr<ResourceAllocation> smallBuffer;
         ASSERT_SUCCEEDED(resourceAllocator->CreateResource(
-            smallBufferDesc, CreateBasicBufferDesc(3u), D3D12_RESOURCE_STATE_COPY_DEST, nullptr,
-            &smallBuffer));
+            smallBufferWithinDesc, CreateBasicBufferDesc(3u), D3D12_RESOURCE_STATE_COPY_DEST,
+            nullptr, &smallBuffer));
         ASSERT_NE(smallBuffer, nullptr);
         EXPECT_EQ(smallBuffer->GetMethod(), gpgmm::AllocationMethod::kSubAllocatedWithin);
         EXPECT_EQ(smallBuffer->GetSize(), 4u);
@@ -631,36 +668,39 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferWithinMany) {
         ResourceAllocator::CreateAllocator(CreateBasicAllocatorDesc(), &resourceAllocator));
     ASSERT_NE(resourceAllocator, nullptr);
 
-    ALLOCATION_DESC desc = {};
-    desc.Flags = ALLOCATION_FLAG_ALLOW_SUBALLOCATE_WITHIN_RESOURCE;
-    desc.HeapType = D3D12_HEAP_TYPE_UPLOAD;
+    ALLOCATION_DESC allocationDesc = {};
+    allocationDesc.Flags = ALLOCATION_FLAG_ALLOW_SUBALLOCATE_WITHIN_RESOURCE;
+    allocationDesc.HeapType = D3D12_HEAP_TYPE_UPLOAD;
 
     const D3D12_RESOURCE_DESC& smallBufferDesc = CreateBasicBufferDesc(4u, 1);
 
     // Create two small buffers that will be byte-aligned.
     ComPtr<ResourceAllocation> smallBufferA;
-    desc.DebugName = GPGMM_GET_VAR_NAME(smallBufferA);
+    allocationDesc.DebugName = GPGMM_GET_VAR_NAME(smallBufferA);
 
-    ASSERT_SUCCEEDED(resourceAllocator->CreateResource(
-        desc, smallBufferDesc, D3D12_RESOURCE_STATE_GENERIC_READ, nullptr, &smallBufferA));
+    ASSERT_SUCCEEDED(resourceAllocator->CreateResource(allocationDesc, smallBufferDesc,
+                                                       D3D12_RESOURCE_STATE_GENERIC_READ, nullptr,
+                                                       &smallBufferA));
     ASSERT_NE(smallBufferA, nullptr);
     EXPECT_EQ(smallBufferA->GetMethod(), gpgmm::AllocationMethod::kSubAllocatedWithin);
     EXPECT_EQ(smallBufferA->GetSize(), smallBufferDesc.Width);
 
     ComPtr<ResourceAllocation> smallBufferB;
-    desc.DebugName = GPGMM_GET_VAR_NAME(smallBufferB);
+    allocationDesc.DebugName = GPGMM_GET_VAR_NAME(smallBufferB);
 
-    ASSERT_SUCCEEDED(resourceAllocator->CreateResource(
-        desc, smallBufferDesc, D3D12_RESOURCE_STATE_GENERIC_READ, nullptr, &smallBufferB));
+    ASSERT_SUCCEEDED(resourceAllocator->CreateResource(allocationDesc, smallBufferDesc,
+                                                       D3D12_RESOURCE_STATE_GENERIC_READ, nullptr,
+                                                       &smallBufferB));
     ASSERT_NE(smallBufferB, nullptr);
     EXPECT_EQ(smallBufferB->GetMethod(), gpgmm::AllocationMethod::kSubAllocatedWithin);
     EXPECT_EQ(smallBufferB->GetSize(), smallBufferDesc.Width);
 
     ComPtr<ResourceAllocation> smallBufferC;
-    desc.DebugName = GPGMM_GET_VAR_NAME(smallBufferC);
+    allocationDesc.DebugName = GPGMM_GET_VAR_NAME(smallBufferC);
 
-    ASSERT_SUCCEEDED(resourceAllocator->CreateResource(
-        desc, smallBufferDesc, D3D12_RESOURCE_STATE_GENERIC_READ, nullptr, &smallBufferC));
+    ASSERT_SUCCEEDED(resourceAllocator->CreateResource(allocationDesc, smallBufferDesc,
+                                                       D3D12_RESOURCE_STATE_GENERIC_READ, nullptr,
+                                                       &smallBufferC));
     ASSERT_NE(smallBufferC, nullptr);
     EXPECT_EQ(smallBufferC->GetMethod(), gpgmm::AllocationMethod::kSubAllocatedWithin);
     EXPECT_EQ(smallBufferC->GetSize(), smallBufferDesc.Width);
@@ -935,6 +975,7 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferGetInfo) {
 
         ALLOCATION_DESC standaloneAllocationDesc = {};
         standaloneAllocationDesc.Flags = ALLOCATION_FLAG_NEVER_SUBALLOCATE_MEMORY;
+        standaloneAllocationDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
 
         ComPtr<ResourceAllocation> firstAllocation;
         ASSERT_SUCCEEDED(resourceAllocator->CreateResource(
@@ -958,6 +999,7 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferGetInfo) {
 
         ALLOCATION_DESC standaloneAllocationDesc = {};
         standaloneAllocationDesc.Flags = ALLOCATION_FLAG_NEVER_SUBALLOCATE_MEMORY;
+        standaloneAllocationDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
 
         ComPtr<ResourceAllocation> firstAllocation;
         ASSERT_SUCCEEDED(resourceAllocator->CreateResource(
@@ -989,11 +1031,14 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferGetInfo) {
             ResourceAllocator::CreateAllocator(CreateBasicAllocatorDesc(), &resourceAllocator));
         ASSERT_NE(resourceAllocator, nullptr);
 
+        ALLOCATION_DESC subAllocationDesc = {};
+        subAllocationDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
+
         constexpr uint64_t kBufferSize = kDefaultBufferSize / 8;
         ComPtr<ResourceAllocation> firstAllocation;
-        ASSERT_SUCCEEDED(resourceAllocator->CreateResource({}, CreateBasicBufferDesc(kBufferSize),
-                                                           D3D12_RESOURCE_STATE_GENERIC_READ,
-                                                           nullptr, &firstAllocation));
+        ASSERT_SUCCEEDED(resourceAllocator->CreateResource(
+            subAllocationDesc, CreateBasicBufferDesc(kBufferSize),
+            D3D12_RESOURCE_STATE_GENERIC_READ, nullptr, &firstAllocation));
         ASSERT_NE(firstAllocation, nullptr);
 
         // Depending on the device, sub-allocation could fail. Since this test relies on a
@@ -1008,9 +1053,9 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferGetInfo) {
         EXPECT_GE(info.UsedBlockUsage, kBufferSize);
 
         ComPtr<ResourceAllocation> secondAllocation;
-        ASSERT_SUCCEEDED(resourceAllocator->CreateResource({}, CreateBasicBufferDesc(kBufferSize),
-                                                           D3D12_RESOURCE_STATE_GENERIC_READ,
-                                                           nullptr, &secondAllocation));
+        ASSERT_SUCCEEDED(resourceAllocator->CreateResource(
+            subAllocationDesc, CreateBasicBufferDesc(kBufferSize),
+            D3D12_RESOURCE_STATE_GENERIC_READ, nullptr, &secondAllocation));
         ASSERT_NE(secondAllocation, nullptr);
         EXPECT_EQ(secondAllocation->GetMethod(), gpgmm::AllocationMethod::kSubAllocated);
 
@@ -1073,6 +1118,7 @@ TEST_F(D3D12ResourceAllocatorTests, CreateTexturePooled) {
     // Only standalone allocations can be pool-allocated.
     ALLOCATION_DESC standaloneAllocationDesc = {};
     standaloneAllocationDesc.Flags = ALLOCATION_FLAG_NEVER_SUBALLOCATE_MEMORY;
+    standaloneAllocationDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
 
     // Create a small texture of size A with it's own resource heap that will be returned to the
     // pool.
@@ -1106,6 +1152,9 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferWithLimitedFragmentation) {
     ALLOCATOR_DESC allocatorDesc = CreateBasicAllocatorDesc();
     allocatorDesc.MemoryFragmentationLimit = 0.0265;  // or 2.65%
 
+    ALLOCATION_DESC baseAllocationDesc = {};
+    baseAllocationDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
+
     // A 1 byte buffer causes 64KB - 1 worth of resource fragmentation.
     // This means a resource heap equal to 64 pages is required to be created, since 64KB - 1B <
     // (64KB * 64)* 2.65%.
@@ -1117,8 +1166,9 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferWithLimitedFragmentation) {
         ASSERT_NE(resourceAllocator, nullptr);
 
         ComPtr<ResourceAllocation> allocation;
-        ASSERT_SUCCEEDED(resourceAllocator->CreateResource(
-            {}, CreateBasicBufferDesc(1), D3D12_RESOURCE_STATE_COMMON, nullptr, &allocation));
+        ASSERT_SUCCEEDED(
+            resourceAllocator->CreateResource(baseAllocationDesc, CreateBasicBufferDesc(1),
+                                              D3D12_RESOURCE_STATE_COMMON, nullptr, &allocation));
 
         EXPECT_EQ(allocation->GetMemory()->GetSize(), 64 * 65536u);
     }
@@ -1129,14 +1179,15 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferWithLimitedFragmentation) {
         ASSERT_SUCCEEDED(ResourceAllocator::CreateAllocator(allocatorDesc, &resourceAllocator));
         ASSERT_NE(resourceAllocator, nullptr);
 
-        ALLOCATION_DESC allocationDesc = {};
-        allocationDesc.Flags |= ALLOCATION_FLAG_NEVER_SUBALLOCATE_MEMORY;
+        ALLOCATION_DESC standaloneAllocationDesc = baseAllocationDesc;
+        standaloneAllocationDesc.Flags |= ALLOCATION_FLAG_NEVER_SUBALLOCATE_MEMORY;
 
         ComPtr<ResourceAllocation> allocation;
-        ASSERT_SUCCEEDED(resourceAllocator->CreateResource(
-            {}, CreateBasicBufferDesc(1), D3D12_RESOURCE_STATE_COMMON, nullptr, &allocation));
+        ASSERT_SUCCEEDED(
+            resourceAllocator->CreateResource(standaloneAllocationDesc, CreateBasicBufferDesc(1),
+                                              D3D12_RESOURCE_STATE_COMMON, nullptr, &allocation));
 
-        EXPECT_EQ(allocation->GetMemory()->GetSize(), 64 * 65536u);
+        EXPECT_EQ(allocation->GetMemory()->GetSize(), 65536u);
     }
 
     // Repeat standalone buffer creation, but using a committed resource.
@@ -1148,8 +1199,9 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferWithLimitedFragmentation) {
         ASSERT_NE(commitedAllocator, nullptr);
 
         ComPtr<ResourceAllocation> allocation;
-        ASSERT_SUCCEEDED(commitedAllocator->CreateResource(
-            {}, CreateBasicBufferDesc(1), D3D12_RESOURCE_STATE_COMMON, nullptr, &allocation));
+        ASSERT_SUCCEEDED(
+            commitedAllocator->CreateResource(baseAllocationDesc, CreateBasicBufferDesc(1),
+                                              D3D12_RESOURCE_STATE_COMMON, nullptr, &allocation));
 
         EXPECT_EQ(allocation->GetMemory()->GetSize(), 65536u);
     }
@@ -1165,6 +1217,7 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferManyPrefetch) {
     constexpr uint64_t kNumOfBuffers = 1000u;
 
     ALLOCATION_DESC allocationDesc = {};
+    allocationDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
     allocationDesc.Flags = ALLOCATION_FLAG_ALWAYS_PREFETCH_MEMORY;
 
     constexpr uint32_t kMinBufferSize = GPGMM_KB_TO_BYTES(64);
@@ -1189,14 +1242,17 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferManyThreaded) {
         ResourceAllocator::CreateAllocator(CreateBasicAllocatorDesc(), &resourceAllocator));
     ASSERT_NE(resourceAllocator, nullptr);
 
+    ALLOCATION_DESC allocationDesc = {};
+    allocationDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
+
     constexpr uint32_t kThreadCount = 64u;
     std::vector<std::thread> threads(kThreadCount);
     for (size_t threadIdx = 0; threadIdx < threads.size(); threadIdx++) {
         threads[threadIdx] = std::thread([&]() {
             ComPtr<ResourceAllocation> allocation;
             ASSERT_SUCCEEDED(resourceAllocator->CreateResource(
-                {}, CreateBasicBufferDesc(kDefaultBufferSize), D3D12_RESOURCE_STATE_COMMON, nullptr,
-                &allocation));
+                allocationDesc, CreateBasicBufferDesc(kDefaultBufferSize),
+                D3D12_RESOURCE_STATE_COMMON, nullptr, &allocation));
             ASSERT_NE(allocation, nullptr);
         });
     }
@@ -1252,13 +1308,14 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferCacheSize) {
     ASSERT_NE(resourceAllocator, nullptr);
 
     // First request is always a cache miss.
-    ALLOCATION_DESC allocationDesc = {};
-    allocationDesc.Flags |= ALLOCATION_FLAG_ALWAYS_CACHE_SIZE;
+    ALLOCATION_DESC baseAllocationDesc = {};
+    baseAllocationDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
+    baseAllocationDesc.Flags |= ALLOCATION_FLAG_ALWAYS_CACHE_SIZE;
 
     {
         ComPtr<ResourceAllocation> allocation;
 
-        ALLOCATION_DESC smallResourceAllocDesc = allocationDesc;
+        ALLOCATION_DESC smallResourceAllocDesc = baseAllocationDesc;
         smallResourceAllocDesc.HeapType = D3D12_HEAP_TYPE_UPLOAD;
         smallResourceAllocDesc.Flags |= ALLOCATION_FLAG_ALLOW_SUBALLOCATE_WITHIN_RESOURCE;
 
@@ -1277,7 +1334,8 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferCacheSize) {
         EXPECT_SIZE_CACHE_MISS(
             resourceAllocator,
             resourceAllocator->CreateResource(
-                allocationDesc, CreateBasicBufferDesc(D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT),
+                baseAllocationDesc,
+                CreateBasicBufferDesc(D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT),
                 D3D12_RESOURCE_STATE_COMMON, nullptr, &allocation));
         ASSERT_NE(allocation, nullptr);
         EXPECT_EQ(allocation->GetSize(),
@@ -1288,7 +1346,7 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferCacheSize) {
         EXPECT_SIZE_CACHE_MISS(
             resourceAllocator,
             resourceAllocator->CreateResource(
-                allocationDesc,
+                baseAllocationDesc,
                 CreateBasicBufferDesc(D3D12_DEFAULT_MSAA_RESOURCE_PLACEMENT_ALIGNMENT),
                 D3D12_RESOURCE_STATE_COMMON, nullptr, &allocation));
         ASSERT_NE(allocation, nullptr);
@@ -1300,7 +1358,7 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferCacheSize) {
     {
         ComPtr<ResourceAllocation> allocation;
 
-        ALLOCATION_DESC smallResourceAllocDesc = allocationDesc;
+        ALLOCATION_DESC smallResourceAllocDesc = baseAllocationDesc;
         smallResourceAllocDesc.HeapType = D3D12_HEAP_TYPE_UPLOAD;
         smallResourceAllocDesc.Flags |= ALLOCATION_FLAG_ALLOW_SUBALLOCATE_WITHIN_RESOURCE;
 
@@ -1315,11 +1373,11 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferCacheSize) {
     }
     {
         ComPtr<ResourceAllocation> allocation;
-        EXPECT_SIZE_CACHE_HIT(
-            resourceAllocator,
-            resourceAllocator->CreateResource(
-                {}, CreateBasicBufferDesc(D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT),
-                D3D12_RESOURCE_STATE_COMMON, nullptr, &allocation));
+        EXPECT_SIZE_CACHE_HIT(resourceAllocator,
+                              resourceAllocator->CreateResource(
+                                  baseAllocationDesc,
+                                  CreateBasicBufferDesc(D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT),
+                                  D3D12_RESOURCE_STATE_COMMON, nullptr, &allocation));
         ASSERT_NE(allocation, nullptr);
         EXPECT_EQ(allocation->GetSize(),
                   static_cast<uint64_t>(D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT));
@@ -1329,7 +1387,8 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferCacheSize) {
         EXPECT_SIZE_CACHE_HIT(
             resourceAllocator,
             resourceAllocator->CreateResource(
-                {}, CreateBasicBufferDesc(D3D12_DEFAULT_MSAA_RESOURCE_PLACEMENT_ALIGNMENT),
+                baseAllocationDesc,
+                CreateBasicBufferDesc(D3D12_DEFAULT_MSAA_RESOURCE_PLACEMENT_ALIGNMENT),
                 D3D12_RESOURCE_STATE_COMMON, nullptr, &allocation));
         ASSERT_NE(allocation, nullptr);
         EXPECT_EQ(allocation->GetSize(),
@@ -1347,6 +1406,8 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferWithPadding) {
     constexpr uint64_t kBufferSize = GPGMM_MB_TO_BYTES(1);
 
     ALLOCATION_DESC allocationDesc = {};
+    allocationDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
+
     ComPtr<ResourceAllocation> allocationWithoutPadding;
     ASSERT_SUCCEEDED(resourceAllocator->CreateResource(
         allocationDesc, CreateBasicBufferDesc(kBufferSize), D3D12_RESOURCE_STATE_GENERIC_READ,
@@ -1373,6 +1434,7 @@ TEST_F(D3D12ResourceAllocatorTests, CreateTextureWithPadding) {
     ASSERT_NE(resourceAllocator, nullptr);
 
     ALLOCATION_DESC allocationDesc = {};
+    allocationDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
 
     ComPtr<ResourceAllocation> allocationWithoutPadding;
     ASSERT_SUCCEEDED(resourceAllocator->CreateResource(


### PR DESCRIPTION
This is because `desc = {}` could zero-initialize them to mean a unexpected default-value. More precisely,
* MinLogLevel assumes corruption-level messages by default.
* Use ALLOCATOR_ALGORITHM_DEFAULT, which internally is set to slab + segmented pool.

Support for a minimum viable implementation #577