### PR TITLE
Remove ResourceAllocation::CreateResourceAllocation.

### DIFF
--- a/src/gpgmm/d3d12/ResourceAllocationD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocationD3D12.cpp
@@ -41,29 +41,6 @@ namespace gpgmm::d3d12 {
 
     }  // namespace
 
-    // static
-    HRESULT ResourceAllocation::CreateResourceAllocation(
-        const RESOURCE_ALLOCATION_DESC& descriptor,
-        ResidencyManager* pResidencyManager,
-        MemoryAllocator* pAllocator,
-        Heap* pResourceHeap,
-        MemoryBlock* pBlock,
-        ComPtr<ID3D12Resource> resource,
-        ResourceAllocation** ppResourceAllocationOut) {
-        std::unique_ptr<ResourceAllocation> resourceAllocation(new ResourceAllocation(
-            descriptor, pResidencyManager, pAllocator, pResourceHeap, pBlock, std::move(resource)));
-
-        if (!descriptor.DebugName.empty()) {
-            ReturnIfFailed(resourceAllocation->SetDebugName(descriptor.DebugName));
-        }
-
-        if (ppResourceAllocationOut != nullptr) {
-            *ppResourceAllocationOut = resourceAllocation.release();
-        }
-
-        return S_OK;
-    }
-
     ResourceAllocation::ResourceAllocation(const RESOURCE_ALLOCATION_DESC& desc,
                                            ResidencyManager* residencyManager,
                                            MemoryAllocator* allocator,

--- a/src/gpgmm/d3d12/ResourceAllocationD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocationD3D12.h
@@ -29,6 +29,7 @@ namespace gpgmm::d3d12 {
     class Heap;
     class ResidencyManager;
     class ResidencyList;
+    class ResourceAllocator;
 
     /** \struct RESOURCE_ALLOCATION_DESC
     Describes a resource allocation.
@@ -93,27 +94,6 @@ namespace gpgmm::d3d12 {
                                                   public DebugObject,
                                                   public IUnknownImpl {
       public:
-        /** \brief Constructs a resource allocation using memory containing one or more resources.
-
-        @param desc A RESOURCE_ALLOCATION_DESC describing the resource allocation.
-        @param pResidencyManager A pointer to ResidencyManager which manages residency for the
-        resource allocation.
-        @param pAllocator A pointer to MemoryAllocator which created the resourceHeap for the
-        resource.
-        @param pResourceHeap A pointer to the Heap used for the resource allocation.
-        @param pBlock A pointer to MemoryBlock which describes the region in Heap being allocated.
-        @param resource A pointer to the ID3D12Resource used for the allocation.
-        @param[out] ppResourceAllocationOut Pointer to a resource allocation that recieves a pointer
-        to the resource allocation.
-        */
-        static HRESULT CreateResourceAllocation(const RESOURCE_ALLOCATION_DESC& desc,
-                                                ResidencyManager* pResidencyManager,
-                                                MemoryAllocator* pAllocator,
-                                                Heap* pResourceHeap,
-                                                MemoryBlock* pBlock,
-                                                ComPtr<ID3D12Resource> resource,
-                                                ResourceAllocation** ppResourceAllocationOut);
-
         ~ResourceAllocation() override;
 
         /** \brief Maps the resource allocation.
@@ -191,6 +171,8 @@ namespace gpgmm::d3d12 {
         Heap* GetMemory() const;
 
       private:
+        friend ResourceAllocator;
+
         ResourceAllocation(const RESOURCE_ALLOCATION_DESC& desc,
                            ResidencyManager* residencyManager,
                            MemoryAllocator* allocator,

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -712,6 +712,10 @@ namespace gpgmm::d3d12 {
         ReturnIfFailed(CreateResourceInternal(allocationDescriptor, resourceDescriptor,
                                               initialResourceState, pClearValue, &allocation));
 
+        if (!allocationDescriptor.DebugName.empty()) {
+            ReturnIfFailed(allocation->SetDebugName(allocationDescriptor.DebugName));
+        }
+
         // Insert a new (debug) allocator layer into the allocation so it can report details used
         // during leak checks. Since we don't want to use it unless we are debugging, we hide it
         // behind a macro.
@@ -884,10 +888,9 @@ namespace gpgmm::d3d12 {
                     allocationDesc.OffsetFromResource = subAllocation.GetOffset();
                     allocationDesc.DebugName = allocationDescriptor.DebugName;
 
-                    ReturnIfFailed(ResourceAllocation::CreateResourceAllocation(
+                    *ppResourceAllocationOut = new ResourceAllocation(
                         allocationDesc, mResidencyManager.Get(), subAllocation.GetAllocator(),
-                        resourceHeap, subAllocation.GetBlock(), std::move(committedResource),
-                        ppResourceAllocationOut));
+                        resourceHeap, subAllocation.GetBlock(), std::move(committedResource));
 
                     return S_OK;
                 }));
@@ -924,10 +927,9 @@ namespace gpgmm::d3d12 {
                     allocationDesc.OffsetFromResource = 0;
                     allocationDesc.DebugName = allocationDescriptor.DebugName;
 
-                    ReturnIfFailed(ResourceAllocation::CreateResourceAllocation(
+                    *ppResourceAllocationOut = new ResourceAllocation(
                         allocationDesc, mResidencyManager.Get(), subAllocation.GetAllocator(),
-                        resourceHeap, subAllocation.GetBlock(), std::move(placedResource),
-                        ppResourceAllocationOut));
+                        resourceHeap, subAllocation.GetBlock(), std::move(placedResource));
 
                     return S_OK;
                 }));
@@ -964,10 +966,9 @@ namespace gpgmm::d3d12 {
                     allocationDesc.OffsetFromResource = 0;
                     allocationDesc.DebugName = allocationDescriptor.DebugName;
 
-                    ReturnIfFailed(ResourceAllocation::CreateResourceAllocation(
+                    *ppResourceAllocationOut = new ResourceAllocation(
                         allocationDesc, mResidencyManager.Get(), allocation.GetAllocator(),
-                        resourceHeap, allocation.GetBlock(), std::move(placedResource),
-                        ppResourceAllocationOut));
+                        resourceHeap, allocation.GetBlock(), std::move(placedResource));
 
                     return S_OK;
                 }));
@@ -1012,9 +1013,9 @@ namespace gpgmm::d3d12 {
         allocationDesc.OffsetFromResource = 0;
         allocationDesc.DebugName = allocationDescriptor.DebugName;
 
-        ReturnIfFailed(ResourceAllocation::CreateResourceAllocation(
-            allocationDesc, mResidencyManager.Get(), this, resourceHeap, nullptr,
-            std::move(committedResource), ppResourceAllocationOut));
+        *ppResourceAllocationOut =
+            new ResourceAllocation(allocationDesc, mResidencyManager.Get(), this, resourceHeap,
+                                   nullptr, std::move(committedResource));
 
         return S_OK;
     }
@@ -1067,9 +1068,8 @@ namespace gpgmm::d3d12 {
         allocationDesc.Method = AllocationMethod::kStandalone;
         allocationDesc.OffsetFromResource = 0;
 
-        ReturnIfFailed(ResourceAllocation::CreateResourceAllocation(
-            allocationDesc, nullptr, this, resourceHeap, nullptr, std::move(resource),
-            ppResourceAllocationOut));
+        *ppResourceAllocationOut = new ResourceAllocation(
+            allocationDesc, nullptr, this, resourceHeap, nullptr, std::move(resource));
 
         return S_OK;
     }


### PR DESCRIPTION
Removes the create allocation public interface. This is because allocation creation is only internally performed by the allocator.

Support for a minimum viable implementation #577