### PR TITLE
Specify heap properties instead of heap type

### DIFF
--- a/.github/workflows/.patches/dawn.diff
+++ b/.github/workflows/.patches/dawn.diff
@@ -1,4 +1,4 @@
-From 8ef270d881c9f8d91a3acbaa7f8fbc572baa3d57 Mon Sep 17 00:00:00 2001
+From 887577ccf4be7e2b74733c5c10b9051da8c3af38 Mon Sep 17 00:00:00 2001
 From: Bryan Bernhart <bryan.bernhart@intel.com>
 Date: Tue, 15 Feb 2022 17:25:29 -0800
 Subject: [PATCH] Use GPGMM for D3D12 backend.
@@ -14,6 +14,7 @@ Change-Id: I47708462a1d9dd0166120c3a6af93451aae54a07
  src/dawn/native/Device.cpp                    |   1 +
  src/dawn/native/Toggles.cpp                   |   8 ++
  src/dawn/native/Toggles.h                     |   2 +
+ src/dawn/native/d3d12/AdapterD3D12.cpp        |   4 +
  src/dawn/native/d3d12/BufferD3D12.cpp         |  51 ++++----
  src/dawn/native/d3d12/BufferD3D12.h           |   7 +-
  src/dawn/native/d3d12/CommandBufferD3D12.cpp  |   9 +-
@@ -22,7 +23,7 @@ Change-Id: I47708462a1d9dd0166120c3a6af93451aae54a07
  src/dawn/native/d3d12/D3D12Backend.cpp        |  17 ++-
  src/dawn/native/d3d12/DeviceD3D12.cpp         | 114 +++++++++++++++---
  src/dawn/native/d3d12/DeviceD3D12.h           |  20 +--
- .../ShaderVisibleDescriptorAllocatorD3D12.cpp |  79 +++++++-----
+ .../ShaderVisibleDescriptorAllocatorD3D12.cpp |  80 +++++++-----
  .../ShaderVisibleDescriptorAllocatorD3D12.h   |  11 +-
  src/dawn/native/d3d12/StagingBufferD3D12.cpp  |  22 +---
  src/dawn/native/d3d12/StagingBufferD3D12.h    |   4 +-
@@ -31,7 +32,7 @@ Change-Id: I47708462a1d9dd0166120c3a6af93451aae54a07
  src/dawn/native/d3d12/UtilsD3D12.cpp          |  11 ++
  src/dawn/native/d3d12/UtilsD3D12.h            |   2 +
  .../tests/white_box/D3D12ResidencyTests.cpp   |  17 +--
- 26 files changed, 325 insertions(+), 162 deletions(-)
+ 27 files changed, 329 insertions(+), 163 deletions(-)
  create mode 100644 build_overrides/gpgmm.gni
 
 diff --git a/.gitignore b/.gitignore
@@ -189,6 +190,21 @@ index 341db798f..9e760e05b 100644
      SkipValidation,
      VulkanUseD32S8,
      VulkanUseS8,
+diff --git a/src/dawn/native/d3d12/AdapterD3D12.cpp b/src/dawn/native/d3d12/AdapterD3D12.cpp
+index 4ac41348f..8ea7e6272 100644
+--- a/src/dawn/native/d3d12/AdapterD3D12.cpp
++++ b/src/dawn/native/d3d12/AdapterD3D12.cpp
+@@ -363,6 +363,10 @@ MaybeError Adapter::InitializeDebugLayerFilters() {
+         // Even this means that no vertex buffer view has been set in D3D12 backend.
+         // https://crbug.com/dawn/1255
+         D3D12_MESSAGE_ID_COMMAND_LIST_DRAW_VERTEX_BUFFER_NOT_SET,
++        
++        // Dawn doesn't specify the smallest range possible but D3D12 still warns of inefficiencies.
++        D3D12_MESSAGE_ID_MAP_INVALID_NULLRANGE,
++        D3D12_MESSAGE_ID_UNMAP_INVALID_NULLRANGE,
+     };
+ 
+     // Create a retrieval filter with a deny list to suppress messages.
 diff --git a/src/dawn/native/d3d12/BufferD3D12.cpp b/src/dawn/native/d3d12/BufferD3D12.cpp
 index 0488fce6a..6b0dd1627 100644
 --- a/src/dawn/native/d3d12/BufferD3D12.cpp
@@ -725,7 +741,7 @@ index 99b03e396..b1cf46fd0 100644
      static constexpr uint32_t kMaxSamplerDescriptorsPerBindGroup = 3 * kMaxSamplersPerShaderStage;
      static constexpr uint32_t kMaxViewDescriptorsPerBindGroup =
 diff --git a/src/dawn/native/d3d12/ShaderVisibleDescriptorAllocatorD3D12.cpp b/src/dawn/native/d3d12/ShaderVisibleDescriptorAllocatorD3D12.cpp
-index fe99a63ac..e169435f9 100644
+index fe99a63ac..1ecd21da3 100644
 --- a/src/dawn/native/d3d12/ShaderVisibleDescriptorAllocatorD3D12.cpp
 +++ b/src/dawn/native/d3d12/ShaderVisibleDescriptorAllocatorD3D12.cpp
 @@ -93,7 +93,8 @@ ShaderVisibleDescriptorAllocator::ShaderVisibleDescriptorAllocator(
@@ -763,7 +779,7 @@ index fe99a63ac..e169435f9 100644
 +    heapDesc.SizeInBytes = mSizeIncrement * descriptorCount;
 +
 +    heapDesc.DebugName = "Shader visible heap";
-+    heapDesc.MemorySegment = gpgmm::d3d12::RESIDENCY_SEGMENT_LOCAL;
++    heapDesc.MemorySegmentGroup = DXGI_MEMORY_SEGMENT_GROUP_LOCAL;
 +
 +    auto createHeapFn = [&](ID3D12Pageable** ppPageableOut) -> HRESULT {
 +        ComPtr<ID3D12DescriptorHeap> d3d12DescriptorHeap;
@@ -836,15 +852,16 @@ index fe99a63ac..e169435f9 100644
  }
  
  bool ShaderVisibleDescriptorAllocator::IsAllocationStillValid(
-@@ -244,12 +259,18 @@ bool ShaderVisibleDescriptorAllocator::IsAllocationStillValid(
+@@ -243,13 +258,18 @@ bool ShaderVisibleDescriptorAllocator::IsAllocationStillValid(
+             allocation.GetHeapSerial() == mHeapSerial);
  }
  
- ShaderVisibleDescriptorHeap::ShaderVisibleDescriptorHeap(
+-ShaderVisibleDescriptorHeap::ShaderVisibleDescriptorHeap(
 -    ComPtr<ID3D12DescriptorHeap> d3d12DescriptorHeap,
 -    uint64_t size)
 -    : Pageable(d3d12DescriptorHeap, MemorySegment::Local, size),
 -      mD3d12DescriptorHeap(std::move(d3d12DescriptorHeap)) {}
-+    ComPtr<gpgmm::d3d12::Heap> descriptorHeap)
++ShaderVisibleDescriptorHeap::ShaderVisibleDescriptorHeap(ComPtr<gpgmm::d3d12::Heap> descriptorHeap)
 +    : mDescriptorHeap(std::move(descriptorHeap)) {}
  
  ID3D12DescriptorHeap* ShaderVisibleDescriptorHeap::GetD3D12DescriptorHeap() const {

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Residency also works for non-resources too:
 ```cpp
 gpgmm::d3d12::HEAP_DESC shaderVisibleHeap = {};
 shaderVisibleHeap.SizeInBytes = kHeapSize;
-shaderVisibleHeap.MemorySegment = gpgmm::d3d12::RESIDENCY_SEGMENT_LOCAL;
+shaderVisibleHeap.MemorySegmentGroup = DXGI_MEMORY_SEGMENT_GROUP_LOCAL;
 
 ComPtr<gpgmm::d3d12::Heap> descriptorHeap;
 gpgmm::d3d12::Heap::CreateHeap(shaderVisibleHeap, residencyManager,

--- a/src/fuzzers/D3D12ResidencyManagerFuzzer.cpp
+++ b/src/fuzzers/D3D12ResidencyManagerFuzzer.cpp
@@ -80,9 +80,11 @@ extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv) {
     gpgmm::d3d12::ALLOCATION_DESC allocationDesc = {};
     allocationDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
 
-    const DXGI_MEMORY_SEGMENT_GROUP bufferMemorySegment =
-        gpgmm::d3d12::GetDefaultMemorySegmentGroup(residencyDesc.Device.Get(),
-                                                   allocationDesc.HeapType, residencyDesc.IsUMA);
+    D3D12_HEAP_PROPERTIES heapProperties =
+        residencyDesc.Device->GetCustomHeapProperties(0, allocationDesc.HeapType);
+
+    const DXGI_MEMORY_SEGMENT_GROUP bufferMemorySegment = gpgmm::d3d12::GetMemorySegmentGroup(
+        heapProperties.MemoryPoolPreference, residencyDesc.IsUMA);
 
     constexpr uint64_t kBufferMemorySize = GPGMM_MB_TO_BYTES(1);
     const D3D12_RESOURCE_DESC bufferDesc = CreateBufferDesc(kBufferMemorySize);

--- a/src/gpgmm/d3d12/BufferAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/BufferAllocatorD3D12.cpp
@@ -23,14 +23,14 @@
 namespace gpgmm::d3d12 {
 
     BufferAllocator::BufferAllocator(ResourceAllocator* resourceAllocator,
-                                     D3D12_HEAP_TYPE heapType,
+                                     D3D12_HEAP_PROPERTIES heapProperties,
                                      D3D12_HEAP_FLAGS heapFlags,
                                      D3D12_RESOURCE_FLAGS resourceFlags,
                                      D3D12_RESOURCE_STATES initialResourceState,
                                      uint64_t bufferSize,
                                      uint64_t bufferAlignment)
         : mResourceAllocator(resourceAllocator),
-          mHeapType(heapType),
+          mHeapProperties(heapProperties),
           mHeapFlags(heapFlags),
           mResourceFlags(resourceFlags),
           mInitialResourceState(initialResourceState),
@@ -69,7 +69,7 @@ namespace gpgmm::d3d12 {
         // Optimized clear is not supported for buffers.
         Heap* resourceHeap = nullptr;
         if (FAILED(mResourceAllocator->CreateCommittedResource(
-                mHeapType, mHeapFlags, info, &resourceDescriptor,
+                mHeapProperties, mHeapFlags, info, &resourceDescriptor,
                 /*pOptimizedClearValue*/ nullptr, mInitialResourceState, /*resourceOut*/ nullptr,
                 &resourceHeap))) {
             return {};

--- a/src/gpgmm/d3d12/BufferAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/BufferAllocatorD3D12.h
@@ -26,7 +26,7 @@ namespace gpgmm::d3d12 {
     class BufferAllocator : public MemoryAllocator {
       public:
         BufferAllocator(ResourceAllocator* resourceAllocator,
-                        D3D12_HEAP_TYPE heapType,
+                        D3D12_HEAP_PROPERTIES heapProperties,
                         D3D12_HEAP_FLAGS heapFlags,
                         D3D12_RESOURCE_FLAGS resourceFlags,
                         D3D12_RESOURCE_STATES initialResourceState,
@@ -45,7 +45,7 @@ namespace gpgmm::d3d12 {
       private:
         ResourceAllocator* const mResourceAllocator;
 
-        const D3D12_HEAP_TYPE mHeapType;
+        const D3D12_HEAP_PROPERTIES mHeapProperties;
         const D3D12_HEAP_FLAGS mHeapFlags;
         const D3D12_RESOURCE_FLAGS mResourceFlags;
         const D3D12_RESOURCE_STATES mInitialResourceState;

--- a/src/gpgmm/d3d12/HeapD3D12.h
+++ b/src/gpgmm/d3d12/HeapD3D12.h
@@ -31,18 +31,6 @@ namespace gpgmm::d3d12 {
     class ResidencyManager;
     class ResourceAllocator;
 
-    /** \enum RESIDENCY_SEGMENT
-    Specifies which type of segment the heap belongs to.
-
-    RESIDENCY_SEGMENT is equivelent to DXGI_MEMORY_SEGMENT_GROUP but also has
-    RESIDENCY_SEGMENT_UNKNOWN.
-    */
-    enum RESIDENCY_SEGMENT {
-        RESIDENCY_SEGMENT_UNKNOWN = 0,
-        RESIDENCY_SEGMENT_LOCAL = 1,
-        RESIDENCY_SEGMENT_NON_LOCAL = 2,
-    };
-
     /** \struct HEAP_INFO
     Additional information about the heap.
     */
@@ -68,12 +56,6 @@ namespace gpgmm::d3d12 {
         */
         uint64_t Alignment;
 
-        /** \brief Specifies the type of heap.
-
-        When resident, heaps reside in a particular video segment.
-        */
-        D3D12_HEAP_TYPE HeapType;
-
         /** \brief Requires the heap to be created in budget.
          */
         bool AlwaysInBudget;
@@ -88,7 +70,7 @@ namespace gpgmm::d3d12 {
 
         Allows any heap to specify a segment which does not have a attributed heap type.
         */
-        RESIDENCY_SEGMENT MemorySegment;
+        DXGI_MEMORY_SEGMENT_GROUP MemorySegmentGroup;
 
         /** \brief Debug name associated with the heap.
          */

--- a/src/gpgmm/d3d12/JSONSerializerD3D12.cpp
+++ b/src/gpgmm/d3d12/JSONSerializerD3D12.cpp
@@ -164,10 +164,9 @@ namespace gpgmm::d3d12 {
         JSONDict dict;
         dict.AddItem("SizeInBytes", desc.SizeInBytes);
         dict.AddItem("Alignment", desc.Alignment);
-        dict.AddItem("HeapType", desc.HeapType);
         dict.AddItem("AlwaysInBudget", desc.AlwaysInBudget);
         dict.AddItem("IsExternal", desc.IsExternal);
-        dict.AddItem("MemorySegment", desc.MemorySegment);
+        dict.AddItem("MemorySegmentGroup", desc.MemorySegmentGroup);
         dict.AddItem("DebugName", desc.DebugName);
         return dict;
     }

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
@@ -766,9 +766,4 @@ namespace gpgmm::d3d12 {
         mBudgetNotificationUpdateEvent = nullptr;
     }
 
-    DXGI_MEMORY_SEGMENT_GROUP ResidencyManager::GetMemorySegmentGroup(
-        D3D12_HEAP_TYPE heapType) const {
-        return GetDefaultMemorySegmentGroup(mDevice.Get(), heapType, mIsUMA);
-    }
-
 }  // namespace gpgmm::d3d12

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.h
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.h
@@ -237,8 +237,6 @@ namespace gpgmm::d3d12 {
 
         HRESULT InsertHeapInternal(Heap* heap);
 
-        DXGI_MEMORY_SEGMENT_GROUP GetMemorySegmentGroup(D3D12_HEAP_TYPE heapType) const;
-
         friend BudgetUpdateTask;
         HRESULT UpdateMemorySegment(const DXGI_MEMORY_SEGMENT_GROUP& memorySegmentGroup);
 

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -542,23 +542,24 @@ namespace gpgmm::d3d12 {
                           ComPtr<ResidencyManager> residencyManager,
                           std::unique_ptr<Caps> caps);
 
-        std::unique_ptr<MemoryAllocator> CreateResourceSubAllocator(
+        std::unique_ptr<MemoryAllocator> CreateResourceHeapSubAllocator(
             const ALLOCATOR_DESC& descriptor,
             D3D12_HEAP_FLAGS heapFlags,
-            D3D12_HEAP_TYPE heapType,
+            D3D12_HEAP_PROPERTIES heapProperties,
             uint64_t heapAlignment);
 
         std::unique_ptr<MemoryAllocator> CreateResourceHeapAllocator(
             const ALLOCATOR_DESC& descriptor,
             D3D12_HEAP_FLAGS heapFlags,
-            D3D12_HEAP_TYPE heapType,
+            D3D12_HEAP_PROPERTIES heapProperties,
             uint64_t heapAlignment);
 
         std::unique_ptr<MemoryAllocator> CreateSmallBufferAllocator(
             const ALLOCATOR_DESC& descriptor,
             D3D12_HEAP_FLAGS heapFlags,
-            D3D12_HEAP_TYPE heapType,
-            uint64_t heapAlignment);
+            D3D12_HEAP_PROPERTIES heapProperties,
+            uint64_t heapAlignment,
+            D3D12_RESOURCE_STATES initialResourceState);
 
         HRESULT CreatePlacedResource(Heap* const resourceHeap,
                                      uint64_t resourceOffset,
@@ -567,7 +568,7 @@ namespace gpgmm::d3d12 {
                                      D3D12_RESOURCE_STATES initialResourceState,
                                      ID3D12Resource** placedResourceOut);
 
-        HRESULT CreateCommittedResource(D3D12_HEAP_TYPE heapType,
+        HRESULT CreateCommittedResource(D3D12_HEAP_PROPERTIES heapProperties,
                                         D3D12_HEAP_FLAGS heapFlags,
                                         const D3D12_RESOURCE_ALLOCATION_INFO& info,
                                         const D3D12_RESOURCE_DESC* resourceDescriptor,

--- a/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.h
@@ -28,8 +28,9 @@ namespace gpgmm::d3d12 {
       public:
         ResourceHeapAllocator(ResidencyManager* residencyManager,
                               ID3D12Device* device,
-                              D3D12_HEAP_TYPE heapType,
+                              D3D12_HEAP_PROPERTIES heapProperties,
                               D3D12_HEAP_FLAGS heapFlags,
+                              DXGI_MEMORY_SEGMENT_GROUP memorySegment,
                               bool alwaysInBudget);
         ~ResourceHeapAllocator() override = default;
 
@@ -43,9 +44,10 @@ namespace gpgmm::d3d12 {
       private:
         ResidencyManager* const mResidencyManager;
         ID3D12Device* const mDevice;
-        const D3D12_HEAP_TYPE mHeapType;
+        const D3D12_HEAP_PROPERTIES mHeapProperties;
         const D3D12_HEAP_FLAGS mHeapFlags;
         const bool mAlwaysInBudget;
+        const DXGI_MEMORY_SEGMENT_GROUP mMemorySegment;
     };
 
 }  // namespace gpgmm::d3d12

--- a/src/gpgmm/d3d12/UtilsD3D12.cpp
+++ b/src/gpgmm/d3d12/UtilsD3D12.cpp
@@ -437,16 +437,12 @@ namespace gpgmm::d3d12 {
         return object->SetName(TCharToWString(name.c_str()).c_str());
     }
 
-    DXGI_MEMORY_SEGMENT_GROUP GetDefaultMemorySegmentGroup(ID3D12Device* device,
-                                                           D3D12_HEAP_TYPE heapType,
-                                                           bool isUMA) {
+    DXGI_MEMORY_SEGMENT_GROUP GetMemorySegmentGroup(D3D12_MEMORY_POOL memoryPool, bool isUMA) {
         if (isUMA) {
             return DXGI_MEMORY_SEGMENT_GROUP_LOCAL;
         }
 
-        D3D12_HEAP_PROPERTIES heapProperties = device->GetCustomHeapProperties(0, heapType);
-
-        if (heapProperties.MemoryPoolPreference == D3D12_MEMORY_POOL_L1) {
+        if (memoryPool == D3D12_MEMORY_POOL_L1) {
             return DXGI_MEMORY_SEGMENT_GROUP_LOCAL;
         }
 

--- a/src/gpgmm/d3d12/UtilsD3D12.h
+++ b/src/gpgmm/d3d12/UtilsD3D12.h
@@ -26,9 +26,7 @@ namespace gpgmm::d3d12 {
     bool IsDepthFormat(DXGI_FORMAT format);
     bool IsAllowedToUseSmallAlignment(const D3D12_RESOURCE_DESC& Desc);
     HRESULT SetDebugObjectName(ID3D12Object* object, const std::string& name);
-    DXGI_MEMORY_SEGMENT_GROUP GetDefaultMemorySegmentGroup(ID3D12Device* device,
-                                                           D3D12_HEAP_TYPE heapType,
-                                                           bool isUMA);
+    DXGI_MEMORY_SEGMENT_GROUP GetMemorySegmentGroup(D3D12_MEMORY_POOL memoryPool, bool isUMA);
 
 }  // namespace gpgmm::d3d12
 

--- a/src/tests/end2end/D3D12ResidencyManagerTests.cpp
+++ b/src/tests/end2end/D3D12ResidencyManagerTests.cpp
@@ -114,7 +114,7 @@ TEST_F(D3D12ResidencyManagerTests, CreateHeap) {
 
     HEAP_DESC resourceHeapDesc = {};
     resourceHeapDesc.SizeInBytes = kHeapSize;
-    resourceHeapDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
+    resourceHeapDesc.MemorySegmentGroup = DXGI_MEMORY_SEGMENT_GROUP_LOCAL;
 
     ASSERT_SUCCEEDED(
         Heap::CreateHeap(resourceHeapDesc, residencyManager.Get(), createHeapFn, nullptr));
@@ -248,8 +248,11 @@ TEST_F(D3D12ResidencyManagerTests, OverBudget) {
     ALLOCATION_DESC bufferAllocationDesc = {};
     bufferAllocationDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
 
+    D3D12_HEAP_PROPERTIES heapProperties =
+        mDevice->GetCustomHeapProperties(0, bufferAllocationDesc.HeapType);
+
     const DXGI_MEMORY_SEGMENT_GROUP bufferMemorySegment =
-        GetDefaultMemorySegmentGroup(mDevice.Get(), bufferAllocationDesc.HeapType, mIsUMA);
+        GetMemorySegmentGroup(heapProperties.MemoryPoolPreference, mIsUMA);
     const uint64_t memoryUnderBudget = GetBudgetLeft(residencyManager.Get(), bufferMemorySegment);
 
     // Keep allocating until we reach the budget.
@@ -310,8 +313,11 @@ TEST_F(D3D12ResidencyManagerTests, OverBudgetUsingBudgetNotifications) {
     ALLOCATION_DESC bufferAllocationDesc = {};
     bufferAllocationDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
 
+    D3D12_HEAP_PROPERTIES heapProperties =
+        mDevice->GetCustomHeapProperties(0, bufferAllocationDesc.HeapType);
+
     const DXGI_MEMORY_SEGMENT_GROUP bufferMemorySegment =
-        GetDefaultMemorySegmentGroup(mDevice.Get(), bufferAllocationDesc.HeapType, mIsUMA);
+        GetMemorySegmentGroup(heapProperties.MemoryPoolPreference, mIsUMA);
 
     const uint64_t memoryUnderBudget = GetBudgetLeft(residencyManager.Get(), bufferMemorySegment);
 
@@ -354,8 +360,11 @@ TEST_F(D3D12ResidencyManagerTests, OverBudgetWithGrowth) {
     ALLOCATION_DESC bufferAllocationDesc = {};
     bufferAllocationDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
 
+    D3D12_HEAP_PROPERTIES heapProperties =
+        mDevice->GetCustomHeapProperties(0, bufferAllocationDesc.HeapType);
+
     const DXGI_MEMORY_SEGMENT_GROUP bufferMemorySegment =
-        GetDefaultMemorySegmentGroup(mDevice.Get(), bufferAllocationDesc.HeapType, mIsUMA);
+        GetMemorySegmentGroup(heapProperties.MemoryPoolPreference, mIsUMA);
     const uint64_t memoryUnderBudget = GetBudgetLeft(residencyManager.Get(), bufferMemorySegment);
 
     while (resourceAllocator->GetInfo().UsedMemoryUsage + kBufferMemorySize < memoryUnderBudget) {


### PR DESCRIPTION
Replaces HEAP_DESC::ResidencySegment with HEAP_DESC::MemorySegmentGroup, which is determined directly from the heap properties instead of indirectly by heap type.