### PR TITLE
Use ResidencyManager for segment group lookup.

### DIFF
--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
@@ -758,4 +758,9 @@ namespace gpgmm::d3d12 {
         mBudgetNotificationUpdateEvent = nullptr;
     }
 
+    DXGI_MEMORY_SEGMENT_GROUP ResidencyManager::GetMemorySegmentGroup(
+        D3D12_MEMORY_POOL memoryPool) const {
+        return d3d12::GetMemorySegmentGroup(memoryPool, mIsUMA);
+    }
+
 }  // namespace gpgmm::d3d12

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.h
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.h
@@ -35,6 +35,7 @@ namespace gpgmm::d3d12 {
     class Heap;
     class ResidencyList;
     class ResourceAllocator;
+    class ResourceHeapAllocator;
 
     /** \struct RESIDENCY_DESC
      Specify parameters when creating a residency manager.
@@ -223,6 +224,7 @@ namespace gpgmm::d3d12 {
       private:
         friend Heap;
         friend ResourceAllocator;
+        friend ResourceHeapAllocator;
 
         ResidencyManager(const RESIDENCY_DESC& descriptor, std::unique_ptr<Fence> residencyFence);
 
@@ -239,6 +241,8 @@ namespace gpgmm::d3d12 {
 
         friend BudgetUpdateTask;
         HRESULT UpdateMemorySegments();
+
+        DXGI_MEMORY_SEGMENT_GROUP GetMemorySegmentGroup(D3D12_MEMORY_POOL memoryPool) const;
 
         const char* GetTypename() const;
 

--- a/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.cpp
@@ -30,14 +30,12 @@ namespace gpgmm::d3d12 {
                                                  ID3D12Device* device,
                                                  D3D12_HEAP_PROPERTIES heapProperties,
                                                  D3D12_HEAP_FLAGS heapFlags,
-                                                 DXGI_MEMORY_SEGMENT_GROUP memorySegment,
                                                  bool alwaysInBudget)
         : mResidencyManager(residencyManager),
           mDevice(device),
           mHeapProperties(heapProperties),
           mHeapFlags(heapFlags),
-          mAlwaysInBudget(alwaysInBudget),
-          mMemorySegment(memorySegment) {
+          mAlwaysInBudget(alwaysInBudget){
     }
 
     std::unique_ptr<MemoryAllocation> ResourceHeapAllocator::TryAllocateMemory(
@@ -66,7 +64,11 @@ namespace gpgmm::d3d12 {
         resourceHeapDesc.DebugName = "Resource heap";
         resourceHeapDesc.Alignment = request.Alignment;
         resourceHeapDesc.AlwaysInBudget = mAlwaysInBudget;
-        resourceHeapDesc.MemorySegmentGroup = mMemorySegment;
+
+        if (mResidencyManager != nullptr) {
+            resourceHeapDesc.MemorySegmentGroup =
+                mResidencyManager->GetMemorySegmentGroup(mHeapProperties.MemoryPoolPreference);
+        }
 
         Heap* resourceHeap = nullptr;
         if (FAILED(Heap::CreateHeap(

--- a/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.h
@@ -30,7 +30,6 @@ namespace gpgmm::d3d12 {
                               ID3D12Device* device,
                               D3D12_HEAP_PROPERTIES heapProperties,
                               D3D12_HEAP_FLAGS heapFlags,
-                              DXGI_MEMORY_SEGMENT_GROUP memorySegment,
                               bool alwaysInBudget);
         ~ResourceHeapAllocator() override = default;
 
@@ -47,7 +46,6 @@ namespace gpgmm::d3d12 {
         const D3D12_HEAP_PROPERTIES mHeapProperties;
         const D3D12_HEAP_FLAGS mHeapFlags;
         const bool mAlwaysInBudget;
-        const DXGI_MEMORY_SEGMENT_GROUP mMemorySegment;
     };
 
 }  // namespace gpgmm::d3d12


### PR DESCRIPTION
ResidencyManager may not recognize UMA, which means the budget per segment may not match the group specified from the adapter capability.

Also, removes segment lookup for external heaps.