### PR TITLE
Do not release all allocator memory by default.

### DIFF
--- a/src/gpgmm/common/MemoryAllocator.h
+++ b/src/gpgmm/common/MemoryAllocator.h
@@ -221,14 +221,14 @@ namespace gpgmm {
 
         /** \brief Return free memory back to the OS.
 
-        @param bytesToRelease Amount of memory to release, in bytes. A kInvalidSize means ALL memory
-        will be released.
+        @param bytesToRelease Amount of memory to release, in bytes. A value of UINT64_MAX
+        releases ALL memory held by the allocator.
 
         \return Amount of memory, in bytes, released. The released size might be smaller then
         bytesToRelease if there was not enough memory or larger if releasable memory doesn't exactly
         total up to the amount.
         */
-        virtual uint64_t ReleaseMemory(uint64_t bytesToRelease = kInvalidSize);
+        virtual uint64_t ReleaseMemory(uint64_t bytesToRelease);
 
         /** \brief Get the fixed-memory sized of the MemoryAllocator.
 

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -485,14 +485,14 @@ namespace gpgmm::d3d12 {
         system. Apps should call ReleaseMemory() when going idle for a period of time since there is
         a brief performance hit when the internal resource heaps get reallocated by the OS.
 
-        @param bytesToRelease Amount of memory to release, in bytes. A kInvalidSize means ALL memory
-        will be released.
+        @param bytesToRelease Amount of memory to release, in bytes. A value of UINT64_MAX
+        releases ALL memory held by the allocator.
 
         \return Amount of memory, in bytes, released. The released size might be smaller then
         bytesToRelease if there was not enough memory or larger if releasable memory doesn't exactly
         total up to the amount.
         */
-        uint64_t ReleaseMemory(uint64_t bytesToRelease = kInvalidSize) override;
+        uint64_t ReleaseMemory(uint64_t bytesToRelease) override;
 
         /** \brief  Return the current allocator usage.
 

--- a/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
+++ b/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
@@ -27,6 +27,7 @@
 using namespace gpgmm::d3d12;
 
 static constexpr uint64_t kDefaultBufferSize = 4ll * 1024ll * 1024ll;  // 4MB
+static constexpr uint64_t kReleaseAllMemory = std::numeric_limits<uint64_t>::max();
 
 #define GPGMM_GET_VAR_NAME(x) (#x)
 
@@ -942,7 +943,7 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferPooled) {
 
     EXPECT_EQ(poolAllocator->GetInfo().FreeMemoryUsage, bufferSize + bufferSize / 2);
 
-    EXPECT_EQ(poolAllocator->ReleaseMemory(), bufferSize + bufferSize / 2);
+    EXPECT_EQ(poolAllocator->ReleaseMemory(kReleaseAllMemory), bufferSize + bufferSize / 2);
 
     EXPECT_EQ(poolAllocator->GetInfo().FreeMemoryUsage, 0u);
 

--- a/src/tests/unittests/BuddyMemoryAllocatorTests.cpp
+++ b/src/tests/unittests/BuddyMemoryAllocatorTests.cpp
@@ -27,6 +27,7 @@ using namespace gpgmm;
 
 static constexpr uint64_t kDefaultMemorySize = 128u;
 static constexpr uint64_t kDefaultMemoryAlignment = 128u;
+static constexpr uint64_t kReleaseAllMemory = std::numeric_limits<uint64_t>::max();
 
 class BuddyMemoryAllocatorTests : public testing::Test {
   public:
@@ -510,7 +511,7 @@ TEST_F(BuddyMemoryAllocatorTests, ReuseFreedHeaps) {
 
     EXPECT_EQ(allocator.GetInfo().UsedMemoryCount, 0u);
 
-    allocator.ReleaseMemory();
+    allocator.ReleaseMemory(kReleaseAllMemory);
 }
 
 // Verify resource heaps that were reused from a pool can be destroyed.
@@ -550,5 +551,5 @@ TEST_F(BuddyMemoryAllocatorTests, DestroyHeaps) {
 
     EXPECT_EQ(allocator.GetInfo().FreeMemoryUsage, kNumOfHeaps * kDefaultMemorySize);
 
-    allocator.ReleaseMemory();
+    allocator.ReleaseMemory(kReleaseAllMemory);
 }

--- a/src/tests/unittests/MemoryAllocatorTests.cpp
+++ b/src/tests/unittests/MemoryAllocatorTests.cpp
@@ -21,6 +21,8 @@
 
 using namespace gpgmm;
 
+static constexpr uint64_t kReleaseAllMemory = std::numeric_limits<uint64_t>::max();
+
 static uint64_t DestructCount = 0;
 static uint64_t ReleaseMemoryCount = 0;
 
@@ -36,7 +38,7 @@ class TestMemoryAllocator final : public DummyMemoryAllocator {
         DestructCount++;
     }
 
-    uint64_t ReleaseMemory(uint64_t bytesToRelease = kInvalidSize) override {
+    uint64_t ReleaseMemory(uint64_t bytesToRelease) override {
         ReleaseMemoryCount++;
         return MemoryAllocator::ReleaseMemory(bytesToRelease);
     }
@@ -56,7 +58,7 @@ TEST_F(MemoryAllocatorTests, SingleAllocator) {
 
     EXPECT_TRUE(parent->GetNextInChain() != nullptr);
 
-    parent->ReleaseMemory();
+    parent->ReleaseMemory(kReleaseAllMemory);
     EXPECT_EQ(ReleaseMemoryCount, 2u);
 
     parent.reset();
@@ -70,7 +72,7 @@ TEST_F(MemoryAllocatorTests, MultipleAllocators) {
 
     EXPECT_TRUE(parent->GetNextInChain() != nullptr);
 
-    parent->ReleaseMemory();
+    parent->ReleaseMemory(kReleaseAllMemory);
     EXPECT_EQ(ReleaseMemoryCount, 3u);
 
     parent.reset();


### PR DESCRIPTION
Removes the default-initialized value to ReleaseMemory, which released all memory held by the allocator. Instead, UINT64_MAX can be defined and passed by the caller.