### PR TITLE
Abandon attribution of heaps when adapter is cache-coherent UMA.

### DIFF
--- a/src/gpgmm/d3d12/CapsD3D12.cpp
+++ b/src/gpgmm/d3d12/CapsD3D12.cpp
@@ -94,6 +94,7 @@ namespace gpgmm::d3d12 {
         ReturnIfFailed(
             device->CheckFeatureSupport(D3D12_FEATURE_ARCHITECTURE, &arch, sizeof(arch)));
         caps->mIsAdapterUMA = arch.UMA;
+        caps->mIsAdapterCacheCoherentUMA = arch.CacheCoherentUMA;
 
         // D3D12 has no feature to detect support and must be set manually.
         if (adapterDesc.VendorId == kIntel_VkVendor) {
@@ -143,6 +144,10 @@ namespace gpgmm::d3d12 {
 
     bool Caps::IsAdapterUMA() const {
         return mIsAdapterUMA;
+    }
+
+    bool Caps::IsAdapterCacheCoherentUMA() const {
+        return mIsAdapterCacheCoherentUMA;
     }
 
     bool Caps::GetMaxResourceHeapTierSupported() const {

--- a/src/gpgmm/d3d12/CapsD3D12.h
+++ b/src/gpgmm/d3d12/CapsD3D12.h
@@ -41,6 +41,9 @@ namespace gpgmm::d3d12 {
         // Specifies if the adapter uses a Unified Memory Architecture (UMA).
         bool IsAdapterUMA() const;
 
+        // Specifies if the UMA adapter is also cache-coherent.
+        bool IsAdapterCacheCoherentUMA() const;
+
         // Specifies if a texture and buffer can belong in the same heap.
         bool GetMaxResourceHeapTierSupported() const;
 
@@ -53,6 +56,7 @@ namespace gpgmm::d3d12 {
         bool mIsCreateHeapNotResidentSupported = false;
         bool mIsResourceAccessAlwaysCoherent = false;
         bool mIsAdapterUMA = false;
+        bool mIsAdapterCacheCoherentUMA = false;
     };
 
 }  // namespace gpgmm::d3d12

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -315,8 +315,13 @@ namespace gpgmm::d3d12 {
 
         /** \brief Heap type that the resource to be allocated requires.
 
+        It is recommended to not specifiy the heap type, if possible. This enables better resource
+        optimization for UMA adapters by using a single custom-equivelent heap type everywhere. A
+        D3D12_HEAP_TYPE_READBACK is usually the only heap type that benefits from being explicitly
+        specified since most UMA adapters could benefit from write-combined CPU reads.
+
         Optional parameter. If the heap type is not provided, the heap type will be inferred by the
-        parameters used to call CreateResource.
+        adapter properties and the initial resource state.
         */
         D3D12_HEAP_TYPE HeapType;
 

--- a/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
+++ b/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
@@ -430,6 +430,32 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBuffer) {
     }
 }
 
+// Verifies there are no attribution of heaps when UMA + no read-back.
+TEST_F(D3D12ResourceAllocatorTests, CreateBufferUMA) {
+    GPGMM_SKIP_TEST_IF(!mIsUMA);
+
+    ComPtr<ResourceAllocator> resourceAllocator;
+    ASSERT_SUCCEEDED(
+        ResourceAllocator::CreateAllocator(CreateBasicAllocatorDesc(), &resourceAllocator));
+    ASSERT_NE(resourceAllocator, nullptr);
+
+    ASSERT_SUCCEEDED(
+        resourceAllocator->CreateResource({}, CreateBasicBufferDesc(kDefaultBufferSize),
+                                          D3D12_RESOURCE_STATE_COMMON, nullptr, nullptr));
+
+    ASSERT_SUCCEEDED(
+        resourceAllocator->CreateResource({}, CreateBasicBufferDesc(kDefaultBufferSize),
+                                          D3D12_RESOURCE_STATE_GENERIC_READ, nullptr, nullptr));
+
+    EXPECT_EQ(resourceAllocator->GetInfo().FreeMemoryUsage, kDefaultBufferSize);
+
+    ASSERT_SUCCEEDED(
+        resourceAllocator->CreateResource({}, CreateBasicBufferDesc(kDefaultBufferSize),
+                                          D3D12_RESOURCE_STATE_COPY_DEST, nullptr, nullptr));
+
+    EXPECT_EQ(resourceAllocator->GetInfo().FreeMemoryUsage, kDefaultBufferSize * 2);
+}
+
 TEST_F(D3D12ResourceAllocatorTests, CreateSmallTexture) {
     ComPtr<ResourceAllocator> resourceAllocator;
     ASSERT_SUCCEEDED(


### PR DESCRIPTION
It is recommend that ALLOCATION_DESC::HeapType is not specified so a custom-equivalent can be used everywhere except when the CPU intends to read-back or D3D12_HEAP_TYPE_READBACK is specified.