### PR TITLE
Map D3D12_HEAP_TYPE_CUSTOM heap types.

### DIFF
--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -828,7 +828,7 @@ namespace gpgmm::d3d12 {
 
         // If the heap type was not specified, infer it using the initial resource state.
         D3D12_HEAP_TYPE heapType = allocationDescriptor.HeapType;
-        if (heapType == 0) {
+        if (heapType == 0 || heapType == D3D12_HEAP_TYPE_CUSTOM) {
             ReturnIfFailed(GetHeapType(initialResourceState, &heapType));
         }
 

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -336,13 +336,14 @@ namespace gpgmm::d3d12 {
 
         /** \brief Heap type that the resource to be allocated requires.
 
-        It is recommended to not specifiy the heap type, if possible. This enables better resource
-        optimization for UMA adapters by using a single custom-equivelent heap type everywhere. A
-        D3D12_HEAP_TYPE_READBACK is usually the only heap type that benefits from being explicitly
-        specified since most UMA adapters could benefit from write-combined CPU reads.
+        It is recommended to not specifiy the heap type or equivelently specify
+        D3D12_HEAP_TYPE_CUSTOM, if possible. This enables better resource optimization for UMA
+        adapters by using a single custom-equivelent heap type everywhere. D3D12_HEAP_TYPE_READBACK
+        is usually the only heap type that benefits from being explicitly specified since UMA
+        adapters benefit from write-combined CPU reads.
 
-        Optional parameter. If the heap type is not provided, the heap type will be inferred by the
-        adapter properties and the initial resource state.
+        Optional parameter. If the heap type is not provided or D3D12_HEAP_TYPE_CUSTOM, the heap
+        type will be inferred by using adapter properties and the initial resource state.
         */
         D3D12_HEAP_TYPE HeapType;
 

--- a/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
+++ b/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
@@ -480,7 +480,7 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferDisableCustomHeaps) {
         ALLOCATION_DESC allocationDesc = {};
         allocationDesc.HeapType = D3D12_HEAP_TYPE_CUSTOM;
 
-        ASSERT_FAILED(resourceAllocator->CreateResource(
+        ASSERT_SUCCEEDED(resourceAllocator->CreateResource(
             allocationDesc, CreateBasicBufferDesc(kDefaultBufferSize),
             D3D12_RESOURCE_STATE_COPY_DEST, nullptr, nullptr));
     }


### PR DESCRIPTION
Allows 0 or D3D12_HEAP_TYPE_CUSTOM to be specified as heap type.