### PR TITLE
Prevent backend leak detection from not reporting leaks.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,10 +173,6 @@ endif()
 
 if(GPGMM_ENABLE_ALLOCATOR_LEAK_CHECKS)
   target_compile_definitions(gpgmm_common_config INTERFACE "GPGMM_ENABLE_ALLOCATOR_LEAK_CHECKS")
-else()
-  target_compile_definitions(gpgmm_common_config INTERFACE
-    $<$<CONFIG:Debug>:GPGMM_ENABLE_ALLOCATOR_LEAK_CHECKS>
-  )
 endif()
 
 if(GPGMM_DISABLE_SIZE_CACHE)

--- a/build_overrides/gpgmm_features.gni
+++ b/build_overrides/gpgmm_features.gni
@@ -50,7 +50,7 @@ declare_args() {
 
   # Enables checking of allocator leaks.
   # Sets -dGPGMM_ENABLE_ALLOCATOR_LEAK_CHECKS
-  gpgmm_enable_allocator_leak_checks = is_debug
+  gpgmm_enable_allocator_leak_checks = false
 
   # Enables ASSERT on severity functionality.
   # Sets -dGPGMM_ENABLE_ASSERT_ON_WARNING

--- a/src/gpgmm/common/MemoryAllocator.cpp
+++ b/src/gpgmm/common/MemoryAllocator.cpp
@@ -74,6 +74,7 @@ namespace gpgmm {
     }
 
     MemoryAllocator::~MemoryAllocator() {
+#if defined(GPGMM_ENABLE_ALLOCATOR_LEAK_CHECKS)
         // If memory cannot be reused by a (parent) allocator, ensure no used memory leaked.
         if (GetParent() == nullptr) {
             ASSERT(mInfo.UsedBlockUsage == 0u);
@@ -81,6 +82,7 @@ namespace gpgmm {
             ASSERT(mInfo.UsedMemoryCount == 0u);
             ASSERT(mInfo.UsedMemoryUsage == 0u);
         }
+#endif
     }
 
     std::unique_ptr<MemoryAllocation> MemoryAllocator::TryAllocateMemory(

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -83,6 +83,13 @@ namespace gpgmm::d3d12 {
         the corresponding heap type.
         */
         ALLOCATOR_FLAG_DISABLE_CUSTOM_HEAPS = 0x10,
+
+        /** \brief Report leaks of resource allocations.
+
+        Used to track outstanding allocations made with this allocator. When the allocator is about
+        to be released, it will report details on any leaked allocations as log messages.
+        */
+        ALLOCATOR_FLAG_NEVER_LEAK_MEMORY = 0x20,
     };
 
     DEFINE_ENUM_FLAG_OPERATORS(ALLOCATOR_FLAGS)

--- a/src/tests/D3D12Test.cpp
+++ b/src/tests/D3D12Test.cpp
@@ -86,6 +86,9 @@ namespace gpgmm::d3d12 {
             desc.Flags |= ALLOCATOR_FLAG_DISABLE_MEMORY_PREFETCH;
         }
 
+        // Make sure leak detection is always enabled.
+        desc.Flags |= gpgmm::d3d12::ALLOCATOR_FLAG_NEVER_LEAK_MEMORY;
+
         desc.MinLogLevel = GetMessageSeverity(GetLogLevel());
 
         if (IsDumpAllEventsEnabled()) {

--- a/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
+++ b/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
@@ -424,6 +424,20 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBuffer) {
     }
 }
 
+TEST_F(D3D12ResourceAllocatorTests, CreateBufferLeaked) {
+    ComPtr<ResourceAllocator> resourceAllocator;
+    ASSERT_SUCCEEDED(
+        ResourceAllocator::CreateAllocator(CreateBasicAllocatorDesc(), &resourceAllocator));
+    ASSERT_NE(resourceAllocator, nullptr);
+
+    ComPtr<ResourceAllocation> allocation;
+    ASSERT_SUCCEEDED(
+        resourceAllocator->CreateResource({}, CreateBasicBufferDesc(kDefaultBufferSize),
+                                          D3D12_RESOURCE_STATE_COMMON, nullptr, &allocation));
+
+    allocation.Detach();  // leaked!
+}
+
 // Verifies there are no attribution of heaps when UMA + no read-back.
 TEST_F(D3D12ResourceAllocatorTests, CreateBufferUMA) {
     GPGMM_SKIP_TEST_IF(!mIsUMA);


### PR DESCRIPTION
* Moves backend leak detection enabling to ALLOCATOR_FLAG_NEVER_LEAK_MEMORY.
* Moves front-end leak detection checks behind existing build flag, GPGMM_ENABLE_ALLOCATOR_LEAK_CHECKS.
* Disables GPGMM_ENABLE_ALLOCATOR_LEAK_CHECKS by default for GN builds (same as CMake).

This change fixes an issue of front-end checks conflicting with the backend checks since the same build flag was used to enable both and the backend checks could not report leaks first. Since memory leaking can now be checked by front-end tests (via MemoryAllocator::GetInfo), always checking is not needed by default.