### PR TITLE
Refactor base object type and memory blocks.

### DIFF
--- a/src/gpgmm/common/DedicatedMemoryAllocator.cpp
+++ b/src/gpgmm/common/DedicatedMemoryAllocator.cpp
@@ -14,6 +14,7 @@
 
 #include "gpgmm/common/DedicatedMemoryAllocator.h"
 
+#include "gpgmm/common/MemoryBlock.h"
 #include "gpgmm/common/TraceEvent.h"
 
 namespace gpgmm {

--- a/src/gpgmm/common/JSONSerializer.cpp
+++ b/src/gpgmm/common/JSONSerializer.cpp
@@ -14,7 +14,6 @@
 
 #include "gpgmm/common/JSONSerializer.h"
 
-#include "gpgmm/common/Allocator.h"
 #include "gpgmm/common/EventMessage.h"
 #include "gpgmm/common/MemoryAllocator.h"
 #include "gpgmm/common/MemoryPool.h"

--- a/src/gpgmm/common/Memory.cpp
+++ b/src/gpgmm/common/Memory.cpp
@@ -53,4 +53,8 @@ namespace gpgmm {
         return mSubAllocationRefs.Unref();
     }
 
+    const char* MemoryBase::GetTypename() const {
+        return "Memory";
+    }
+
 }  // namespace gpgmm

--- a/src/gpgmm/common/Memory.h
+++ b/src/gpgmm/common/Memory.h
@@ -15,6 +15,7 @@
 #ifndef GPGMM_COMMON_MEMORY_H_
 #define GPGMM_COMMON_MEMORY_H_
 
+#include "gpgmm/common/Object.h"
 #include "gpgmm/utils/RefCount.h"
 
 namespace gpgmm {
@@ -25,7 +26,7 @@ namespace gpgmm {
 
     When memory is sub-allocated, it will have a non-zero refcount.
     */
-    class MemoryBase {
+    class MemoryBase : public ObjectBase {
       public:
         /** \brief Constructs a memory object of the specified size and alignment.
 
@@ -33,7 +34,7 @@ namespace gpgmm {
         @param alignment Alignment, in bytes, of the memory object.
         */
         explicit MemoryBase(uint64_t size, uint64_t alignment);
-        virtual ~MemoryBase();
+        virtual ~MemoryBase() override;
 
         /** \brief Return the size of the memory object.
 
@@ -68,6 +69,8 @@ namespace gpgmm {
         bool RemoveSubAllocationRef();
 
       private:
+        const char* GetTypename() const override;
+
         RefCounted mSubAllocationRefs;
 
         const uint64_t mSize;

--- a/src/gpgmm/common/MemoryAllocation.cpp
+++ b/src/gpgmm/common/MemoryAllocation.cpp
@@ -15,10 +15,9 @@
 
 #include "gpgmm/common/MemoryAllocation.h"
 
-#include "gpgmm/common/BlockAllocator.h"
 #include "gpgmm/common/Memory.h"
+#include "gpgmm/common/MemoryBlock.h"
 #include "gpgmm/utils/Assert.h"
-#include "gpgmm/utils/Limits.h"
 
 namespace gpgmm {
 

--- a/src/gpgmm/common/MemoryAllocator.h
+++ b/src/gpgmm/common/MemoryAllocator.h
@@ -165,6 +165,8 @@ namespace gpgmm {
         uint64_t AvailableForAllocation;
     };
 
+    class BlockAllocator;
+
     /** \brief MemoryAllocator services a fixed or variable sized MemoryAllocationRequest.
 
     Internally, MemoryAllocator sub-allocates existing memory objects into smaller chucks
@@ -178,7 +180,7 @@ namespace gpgmm {
     MemoryAllocator to sub-allocate from larger blocks provided by the second-order MemoryAllocator
     and so on.
     */
-    class MemoryAllocator : public AllocatorBase, public LinkNode<MemoryAllocator> {
+    class MemoryAllocator : public ObjectBase, public LinkNode<MemoryAllocator> {
       public:
         /** \brief Constructs a standalone MemoryAllocator.
 

--- a/src/gpgmm/common/MemoryBlock.h
+++ b/src/gpgmm/common/MemoryBlock.h
@@ -12,18 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GPGMM_COMMON_ALLOCATOR_H_
-#define GPGMM_COMMON_ALLOCATOR_H_
+#ifndef GPGMM_COMMON_MEMORYBLOCK_H_
+#define GPGMM_COMMON_MEMORYBLOCK_H_
+
+#include "gpgmm/utils/Limits.h"
 
 namespace gpgmm {
 
-    class AllocatorBase {
-      public:
-        AllocatorBase() = default;
-        virtual ~AllocatorBase() = default;
-        virtual const char* GetTypename() const = 0;
+    struct MemoryBlock {
+        uint64_t Offset = kInvalidOffset;
+        uint64_t Size = kInvalidSize;
     };
 
 }  // namespace gpgmm
 
-#endif  // GPGMM_COMMON_ALLOCATOR_H_
+#endif  // GPGMM_COMMON_MEMORYBLOCK_H_

--- a/src/gpgmm/common/Object.h
+++ b/src/gpgmm/common/Object.h
@@ -12,23 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GPGMM_COMMON_BLOCKALLOCATOR_H_
-#define GPGMM_COMMON_BLOCKALLOCATOR_H_
-
-#include "gpgmm/common/MemoryBlock.h"
-#include "gpgmm/common/Object.h"
+#ifndef GPGMM_COMMON_OBJECT_H_
+#define GPGMM_COMMON_OBJECT_H_
 
 namespace gpgmm {
 
-    // Allocates a sub-range [offset, offset + size) in usually a byte-addressable range.
-    class BlockAllocator : public ObjectBase {
+    class ObjectBase {
       public:
-        ~BlockAllocator() override = default;
-
-        virtual MemoryBlock* TryAllocateBlock(uint64_t requestSize, uint64_t alignment) = 0;
-        virtual void DeallocateBlock(MemoryBlock* block) = 0;
+        ObjectBase() = default;
+        virtual ~ObjectBase() = default;
+        virtual const char* GetTypename() const = 0;
     };
 
 }  // namespace gpgmm
 
-#endif  // GPGMM_COMMON_BLOCKALLOCATOR_H_
+#endif  // GPGMM_COMMON_OBJECT_H_

--- a/src/gpgmm/d3d12/HeapD3D12.h
+++ b/src/gpgmm/d3d12/HeapD3D12.h
@@ -164,7 +164,7 @@ namespace gpgmm::d3d12 {
              bool isExternal);
 
         HRESULT SetDebugNameImpl(const std::string& name) override;
-        const char* GetTypename() const;
+        const char* GetTypename() const override;
         DXGI_MEMORY_SEGMENT_GROUP GetMemorySegmentGroup() const;
 
         // The residency manager must know the last fence value that any portion of the pageable was


### PR DESCRIPTION
Renames Allocator interface and moves memory block into separate interface to avoid requiring  block allocator.