### PR TITLE
Allow sub-allocated buffers within to use any allocation method.

### DIFF
--- a/src/gpgmm/d3d12/BufferAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/BufferAllocatorD3D12.h
@@ -29,18 +29,13 @@ namespace gpgmm::d3d12 {
                         D3D12_HEAP_PROPERTIES heapProperties,
                         D3D12_HEAP_FLAGS heapFlags,
                         D3D12_RESOURCE_FLAGS resourceFlags,
-                        D3D12_RESOURCE_STATES initialResourceState,
-                        uint64_t bufferSize,
-                        uint64_t bufferAlignment);
+                        D3D12_RESOURCE_STATES initialResourceState);
         ~BufferAllocator() override = default;
 
         // MemoryAllocator interface
         std::unique_ptr<MemoryAllocation> TryAllocateMemory(
             const MemoryAllocationRequest& request) override;
         void DeallocateMemory(std::unique_ptr<MemoryAllocation> allocation) override;
-
-        uint64_t GetMemorySize() const override;
-        uint64_t GetMemoryAlignment() const override;
 
       private:
         ResourceAllocator* const mResourceAllocator;
@@ -49,8 +44,6 @@ namespace gpgmm::d3d12 {
         const D3D12_HEAP_FLAGS mHeapFlags;
         const D3D12_RESOURCE_FLAGS mResourceFlags;
         const D3D12_RESOURCE_STATES mInitialResourceState;
-        const uint64_t mBufferSize;
-        const uint64_t mBufferAlignment;
     };
 
 }  // namespace gpgmm::d3d12

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -612,13 +612,7 @@ namespace gpgmm::d3d12 {
                           ComPtr<ResidencyManager> residencyManager,
                           std::unique_ptr<Caps> caps);
 
-        std::unique_ptr<MemoryAllocator> CreateResourceHeapSubAllocator(
-            const ALLOCATOR_DESC& descriptor,
-            D3D12_HEAP_FLAGS heapFlags,
-            D3D12_HEAP_PROPERTIES heapProperties,
-            uint64_t heapAlignment);
-
-        std::unique_ptr<MemoryAllocator> CreateResourceHeapAllocator(
+        std::unique_ptr<MemoryAllocator> CreateResourceAllocator(
             const ALLOCATOR_DESC& descriptor,
             D3D12_HEAP_FLAGS heapFlags,
             D3D12_HEAP_PROPERTIES heapProperties,
@@ -630,6 +624,22 @@ namespace gpgmm::d3d12 {
             D3D12_HEAP_PROPERTIES heapProperties,
             uint64_t heapAlignment,
             D3D12_RESOURCE_STATES initialResourceState);
+
+        std::unique_ptr<MemoryAllocator> CreatePoolAllocator(
+            ALLOCATOR_ALGORITHM algorithm,
+            uint64_t memorySize,
+            uint64_t memoryAlignment,
+            bool isAlwaysOnDemand,
+            std::unique_ptr<MemoryAllocator> underlyingAllocator);
+
+        std::unique_ptr<MemoryAllocator> CreateSubAllocator(
+            ALLOCATOR_ALGORITHM algorithm,
+            uint64_t memorySize,
+            uint64_t memoryAlignment,
+            double memoryFragmentationLimit,
+            double memoryGrowthFactor,
+            bool isPrefetchAllowed,
+            std::unique_ptr<MemoryAllocator> underlyingAllocator);
 
         HRESULT CreatePlacedResource(Heap* const resourceHeap,
                                      uint64_t resourceOffset,
@@ -672,12 +682,12 @@ namespace gpgmm::d3d12 {
         static constexpr uint64_t kNumOfResourceHeapTypes = 8u;
 
         std::array<std::unique_ptr<MemoryAllocator>, kNumOfResourceHeapTypes>
-            mResourceHeapAllocatorOfType;
+            mDedicatedResourceAllocatorOfType;
         std::array<std::unique_ptr<MemoryAllocator>, kNumOfResourceHeapTypes>
             mResourceAllocatorOfType;
 
         std::array<std::unique_ptr<MemoryAllocator>, kNumOfResourceHeapTypes>
-            mMSAAResourceHeapAllocatorOfType;
+            mMSAADedicatedResourceAllocatorOfType;
         std::array<std::unique_ptr<MemoryAllocator>, kNumOfResourceHeapTypes>
             mMSAAResourceAllocatorOfType;
 


### PR DESCRIPTION
Removes a limitation that sub-allocation within a resource was limited to pooling and slab-allocating from fixed-size 64kb resources. This change allows the SubAllocationAlgorithm and PoolAlgorithm to be honored when using the flag ALLOCATION_FLAG_ALLOW_SUBALLOCATE_WITHIN_RESOURCE.