### PR TITLE
Fix D3D12ResidencyManagerTests.CreateHeap failures on non-UMA.

### DIFF
--- a/src/tests/end2end/D3D12ResidencyManagerTests.cpp
+++ b/src/tests/end2end/D3D12ResidencyManagerTests.cpp
@@ -103,6 +103,9 @@ TEST_F(D3D12ResidencyManagerTests, CreateHeap) {
     heapDesc.Properties = heapProperties;
     heapDesc.SizeInBytes = kHeapSize;
 
+    // Assume tier 1, which all adapters support.
+    heapDesc.Flags |= D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS;
+
     auto createHeapFn = [&](ID3D12Pageable** ppPageableOut) -> HRESULT {
         ComPtr<ID3D12Heap> heap;
         if (FAILED(mDevice->CreateHeap(&heapDesc, IID_PPV_ARGS(&heap)))) {


### PR DESCRIPTION
Assumes tier 1 is used so heap flags are correct.