### PR TITLE
Fix event-based budget test when using real non-UMA adapter.

### DIFF
--- a/src/tests/end2end/D3D12ResidencyManagerTests.cpp
+++ b/src/tests/end2end/D3D12ResidencyManagerTests.cpp
@@ -294,8 +294,8 @@ TEST_F(D3D12ResidencyManagerTests, OverBudget) {
     }
 }
 
-// Keeps allocating until it goes over the OS limited budget.
-TEST_F(D3D12ResidencyManagerTests, OverBudgetUsingBudgetNotifications) {
+// Keeps allocating until it goes over the OS provided budget.
+TEST_F(D3D12ResidencyManagerTests, OverBudgetAsync) {
     constexpr uint64_t kBudgetIsDeterminedByOS = 0;
     RESIDENCY_DESC residencyDesc = CreateBasicResidencyDesc(kBudgetIsDeterminedByOS);
     residencyDesc.Flags ^= RESIDENCY_FLAG_NEVER_UPDATE_BUDGET_ON_WORKER_THREAD;
@@ -321,9 +321,11 @@ TEST_F(D3D12ResidencyManagerTests, OverBudgetUsingBudgetNotifications) {
 
     const uint64_t memoryUnderBudget = GetBudgetLeft(residencyManager.Get(), bufferMemorySegment);
 
-    // Keep allocating until we reach the budget.
+    // Keep allocating until we reach the budget. Should a budget change occur, we must also
+    // terminate the loop since we cannot guarantee all allocations will be created resident.
     std::vector<ComPtr<ResourceAllocation>> allocations = {};
-    while (resourceAllocator->GetInfo().UsedMemoryUsage + kBufferMemorySize < memoryUnderBudget) {
+    while (resourceAllocator->GetInfo().UsedMemoryUsage + kBufferMemorySize < memoryUnderBudget &&
+           GetBudgetLeft(residencyManager.Get(), bufferMemorySegment) >= kBufferMemorySize) {
         ComPtr<ResourceAllocation> allocation;
         ASSERT_SUCCEEDED(resourceAllocator->CreateResource(
             bufferAllocationDesc, bufferDesc, D3D12_RESOURCE_STATE_COMMON, nullptr, &allocation));


### PR DESCRIPTION
Actual driver could change budget causing the test to fail. This fix stops allocating when there is no more current budget left instead of continuing allocating until the initial budget was filled.