### PR TITLE
Validate descriptor for residency and allocator.

### DIFF
--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -388,6 +388,16 @@ namespace gpgmm::d3d12 {
             caps.reset(ptr);
         }
 
+        if (allocatorDescriptor.ResourceHeapTier != caps->GetMaxResourceHeapTierSupported()) {
+            gpgmm::WarningLog()
+                << "Resource heap tier does not match capabilities of the adapter "
+                   "(ResourceHeapTier:"
+                << allocatorDescriptor.ResourceHeapTier << " vs "
+                << caps->GetMaxResourceHeapTierSupported()
+                << "). This is probably not what the developer intended. Please use "
+                   "CheckFeatureSupport instead.";
+        }
+
         ALLOCATOR_DESC newDescriptor = allocatorDescriptor;
         newDescriptor.MemoryGrowthFactor = (allocatorDescriptor.MemoryGrowthFactor >= 1.0)
                                                ? allocatorDescriptor.MemoryGrowthFactor

--- a/src/tests/end2end/D3D12ResidencyManagerTests.cpp
+++ b/src/tests/end2end/D3D12ResidencyManagerTests.cpp
@@ -185,6 +185,29 @@ TEST_F(D3D12ResidencyManagerTests, CreateResidencyList) {
 }
 
 TEST_F(D3D12ResidencyManagerTests, CreateResidencyManager) {
+    // Create residency without adapter must always fail.
+    {
+        RESIDENCY_DESC residencyDesc = CreateBasicResidencyDesc(kDefaultBudget);
+        residencyDesc.Adapter = nullptr;
+
+        ASSERT_FAILED(ResidencyManager::CreateResidencyManager(residencyDesc, nullptr));
+    }
+
+    // Create residency without device must always fail.
+    {
+        RESIDENCY_DESC residencyDesc = CreateBasicResidencyDesc(kDefaultBudget);
+        residencyDesc.Device = nullptr;
+
+        ASSERT_FAILED(ResidencyManager::CreateResidencyManager(residencyDesc, nullptr));
+    }
+
+    // Create residency alone.
+    {
+        ComPtr<ResidencyManager> residencyManager;
+        ASSERT_SUCCEEDED(ResidencyManager::CreateResidencyManager(
+            CreateBasicResidencyDesc(kDefaultBudget), nullptr));
+    }
+
     // Create allocator with residency support, together.
     {
         ComPtr<ResidencyManager> residencyManager;


### PR DESCRIPTION
Adds warnings when allocator/residency mismatches capabilities of the adapter/device.