### PR TITLE
Fix replay failures due to wrong creation-snapshot sequence by ResourceAllocator.

### DIFF
--- a/src/gpgmm/d3d12/JSONSerializerD3D12.cpp
+++ b/src/gpgmm/d3d12/JSONSerializerD3D12.cpp
@@ -40,9 +40,12 @@ namespace gpgmm::d3d12 {
         dict.AddItem("Flags", desc.Flags);
         dict.AddItem("RecordOptions", Serialize(desc.RecordOptions));
         dict.AddItem("ResourceHeapTier", desc.ResourceHeapTier);
+        dict.AddItem("SubAllocationAlgorithm", desc.SubAllocationAlgorithm);
+        dict.AddItem("PoolAlgorithm", desc.PoolAlgorithm);
         dict.AddItem("PreferredResourceHeapSize", desc.PreferredResourceHeapSize);
         dict.AddItem("MaxResourceHeapSize", desc.MaxResourceHeapSize);
         dict.AddItem("MemoryFragmentationLimit", desc.MemoryFragmentationLimit);
+        dict.AddItem("MemoryGrowthFactor", desc.MemoryGrowthFactor);
         return dict;
     }
 
@@ -166,7 +169,9 @@ namespace gpgmm::d3d12 {
         dict.AddItem("Alignment", desc.Alignment);
         dict.AddItem("Flags", desc.Flags);
         dict.AddItem("MemorySegmentGroup", desc.MemorySegmentGroup);
-        dict.AddItem("DebugName", desc.DebugName);
+        if (!desc.DebugName.empty()) {
+            dict.AddItem("DebugName", desc.DebugName);
+        }
         return dict;
     }
 
@@ -247,7 +252,10 @@ namespace gpgmm::d3d12 {
     JSONDict JSONSerializer::Serialize(const RESIDENCY_DESC& desc) {
         JSONDict dict;
         dict.AddItem("IsUMA", desc.IsUMA);
+        dict.AddItem("Flags", desc.Flags);
+        dict.AddItem("RecordOptions", Serialize(desc.RecordOptions));
         dict.AddItem("MaxPctOfVideoMemoryToBudget", desc.MaxPctOfVideoMemoryToBudget);
+        dict.AddItem("MinPctOfBudgetToReserve", desc.MinPctOfBudgetToReserve);
         dict.AddItem("MaxBudgetInBytes", desc.MaxBudgetInBytes);
         dict.AddItem("EvictSizeInBytes", desc.EvictSizeInBytes);
         dict.AddItem("InitialFenceValue", desc.InitialFenceValue);

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -472,11 +472,13 @@ namespace gpgmm::d3d12 {
                                    "management was not enabled.";
         }
 
-        GPGMM_TRACE_EVENT_OBJECT_SNAPSHOT(*ppResourceAllocatorOut, newDescriptor);
+        std::unique_ptr<ResourceAllocator> resourceAllocator = std::unique_ptr<ResourceAllocator>(
+            new ResourceAllocator(newDescriptor, pResidencyManager, std::move(caps)));
+
+        GPGMM_TRACE_EVENT_OBJECT_SNAPSHOT(resourceAllocator.get(), newDescriptor);
 
         if (ppResourceAllocatorOut != nullptr) {
-            *ppResourceAllocatorOut =
-                new ResourceAllocator(newDescriptor, pResidencyManager, std::move(caps));
+            *ppResourceAllocatorOut = resourceAllocator.release();
         }
 
         return S_OK;

--- a/src/tests/capture_replay_tests/D3D12EventTraceReplay.cpp
+++ b/src/tests/capture_replay_tests/D3D12EventTraceReplay.cpp
@@ -311,7 +311,7 @@ class D3D12EventTraceReplay : public D3D12TestBase, public CaptureReplayTestWith
                         RESIDENCY_DESC residencyDesc = {};
                         residencyDesc.Device = mDevice;
                         residencyDesc.Adapter = mAdapter;
-                        residencyDesc.IsUMA = snapshot["IsUMA"].asBool();
+                        residencyDesc.IsUMA = mIsUMA;
                         residencyDesc.MaxPctOfVideoMemoryToBudget =
                             snapshot["MaxPctOfVideoMemoryToBudget"].asFloat();
                         residencyDesc.MaxBudgetInBytes = snapshot["MaxBudgetInBytes"].asUInt64();


### PR DESCRIPTION
Also, adds a duplicate run of the capture-replay tests to avoid future regressions and fixes missing fields not being captured.