### PR TITLE
Move re-capture from unit-test into workflow.

### DIFF
--- a/.github/workflows/win_clang_dbg_x64.yaml
+++ b/.github/workflows/win_clang_dbg_x64.yaml
@@ -149,6 +149,12 @@ jobs:
         cd test
         out\Debug\gpgmm_capture_replay_tests.exe --log-level=DEBUG --gtest_output=json:${{ github.workspace }}\..\test_capture_replay_tests.json 2>&1
 
+    - name: Run gpgmm_capture_replay_tests to re-capture (with patch)
+      shell: cmd
+      run: |
+        cd test
+        out\Debug\gpgmm_capture_replay_tests.exe -log-level=DEBUG --gtest_filter=*Replay/* --capture-mask=0x3 --ignore-caps-mismatch --disable-memory
+
     - name: Regression check end2end tests
       run: |
         python test\scripts\regression_check.py ${{ github.workspace }}\..\baseline_end2end_tests.json ${{ github.workspace }}\..\test_end2end_tests.json

--- a/.github/workflows/win_clang_rel_x64.yaml
+++ b/.github/workflows/win_clang_rel_x64.yaml
@@ -149,6 +149,12 @@ jobs:
         cd test
         out\Release\gpgmm_capture_replay_tests.exe --gtest_output=json:${{ github.workspace }}\..\test_capture_replay_tests.json
 
+    - name: Run gpgmm_capture_replay_tests to re-capture (with patch)
+      shell: cmd
+      run: |
+        cd test
+        out\Release\gpgmm_capture_replay_tests.exe --gtest_filter=*Replay/* --capture-mask=0x3 --ignore-caps-mismatch --disable-memory
+
     - name: Regression check end2end tests
       run: |
         python test\scripts\regression_check.py ${{ github.workspace }}\..\baseline_end2end_tests.json ${{ github.workspace }}\..\test_end2end_tests.json

--- a/src/tests/capture_replay_tests/GPGMMCaptureReplayTests.cpp
+++ b/src/tests/capture_replay_tests/GPGMMCaptureReplayTests.cpp
@@ -85,8 +85,8 @@ GPGMMCaptureReplayTestEnvironment::GPGMMCaptureReplayTestEnvironment(int argc, c
             continue;
         }
 
-        if (strcmp("--same-caps", argv[i]) == 0) {
-            mParams.IsSameCapsRequired = true;
+        if (strcmp("--ignore-caps-mismatch", argv[i]) == 0) {
+            mParams.IsIgnoreCapsMismatchEnabled = true;
             continue;
         }
 
@@ -95,8 +95,13 @@ GPGMMCaptureReplayTestEnvironment::GPGMMCaptureReplayTestEnvironment(int argc, c
             continue;
         }
 
-        if (strcmp("--disable-allocation-playback", argv[i]) == 0) {
-            mParams.IsAllocationPlaybackDisabled = true;
+        if (strcmp("--disable-allocation", argv[i]) == 0) {
+            mParams.IsAllocatorDisabled = true;
+            continue;
+        }
+
+        if (strcmp("--disable-memory", argv[i]) == 0) {
+            mParams.IsMemoryDisabled = true;
             continue;
         }
 
@@ -135,8 +140,8 @@ GPGMMCaptureReplayTestEnvironment::GPGMMCaptureReplayTestEnvironment(int argc, c
                 << " --playback-file: Path to captured file to playback.\n"
                 << " --same-caps: Captured device must be compatible with playback device.\n"
                 << " --profile=[MAXPERF|LOWMEM|CAPTURED|DEFAULT]: Profile to apply.\n"
-                << " --disable-allocation-playback: Disable allocation playback for testing "
-                   "budgets.\n";
+                << " --disable-allocator: Disables allocator playback.\n"
+                << " --disable-memory: Disables playback of memory from capture.\n";
             continue;
         }
     }
@@ -159,16 +164,10 @@ void GPGMMCaptureReplayTestEnvironment::TearDown() {
 void GPGMMCaptureReplayTestEnvironment::PrintCaptureReplaySettings() const {
     gpgmm::InfoLog() << "Playback settings\n"
                         "-----------------\n"
-                     << "Iterations per test: " << mParams.Iterations << "\n"
-                     << "Must use same caps: " << (mParams.IsSameCapsRequired ? "true" : "false")
-                     << "\n"
-                     << "No Allocations: "
-                     << (mParams.IsAllocationPlaybackDisabled ? "true" : "false") << "\n";
+                     << "Iterations per test: " << mParams.Iterations << "\n";
 
     gpgmm::InfoLog() << "Experiment settings\n"
                         "-------------------\n"
-                     << "Disable sub-allocation: "
-                     << (mParams.IsSuballocationDisabled ? "true" : "false") << "\n"
                      << "Profile: " << AllocatorProfileToString(mParams.AllocatorProfile) << "\n";
 }
 
@@ -221,8 +220,8 @@ void CaptureReplayTestWithParams::RunTestLoop(const TestEnviromentParams& forceP
         envParams.CaptureEventMask |= forceParams.CaptureEventMask;
     }
 
-    if (forceParams.IsSameCapsRequired != envParams.IsSameCapsRequired) {
-        envParams.IsSameCapsRequired |= forceParams.IsSameCapsRequired;
+    if (forceParams.IsIgnoreCapsMismatchEnabled != envParams.IsIgnoreCapsMismatchEnabled) {
+        envParams.IsIgnoreCapsMismatchEnabled |= forceParams.IsIgnoreCapsMismatchEnabled;
     }
 
     if (forceParams.Iterations != envParams.Iterations) {

--- a/src/tests/capture_replay_tests/GPGMMCaptureReplayTests.h
+++ b/src/tests/capture_replay_tests/GPGMMCaptureReplayTests.h
@@ -45,11 +45,12 @@ struct TestEnviromentParams {
     uint64_t Iterations = 1;  // Number of test iterations to run.
     int CaptureEventMask = 0;
 
-    bool IsSameCapsRequired = false;  // Caps of test device must match capture caps.
+    bool IsIgnoreCapsMismatchEnabled = false;  // Test device must match capture caps.
     bool IsSuballocationDisabled = false;
     bool IsNeverAllocate = false;
     bool IsPrefetchAllowed = false;
-    bool IsAllocationPlaybackDisabled = false;  // Disables creation of new allocations.
+    bool IsAllocatorDisabled = false;  // Disables creation of new allocations.
+    bool IsMemoryDisabled = false;     // Disables creation of captured heaps.
 
     AllocatorProfile AllocatorProfile =
         AllocatorProfile::ALLOCATOR_PROFILE_CAPTURED;  // Playback uses captured settings.


### PR DESCRIPTION
Runs re-capture as it's own workflow step instead of a GTest instance. This avoids mistakenly overwriting captures. Also,  disables playback when device is incompatible and adds option to disable heap-playback.