### PR TITLE
Enable allocation for any heap type on tier 1 hardware.

### DIFF
--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -689,7 +689,7 @@ namespace gpgmm::d3d12 {
         const bool mUseDetailedTimingEvents;
         const bool mIsCustomHeapsDisabled;
 
-        static constexpr uint64_t kNumOfResourceHeapTypes = 8u;
+        static constexpr uint64_t kNumOfResourceHeapTypes = 12u;
 
         std::array<std::unique_ptr<MemoryAllocator>, kNumOfResourceHeapTypes>
             mDedicatedResourceAllocatorOfType;


### PR DESCRIPTION
Previously, only default heaps could be specified when using tier 1 hardware. This adds the other heap types for allocation.

Also, fixes a validation-check when attempting to use tier 2 hardware on a non-supported adapter.