### PR TITLE
Use separate DEPS for Dawn integration.

### DIFF
--- a/.github/workflows/win_dawn_dbg.yaml
+++ b/.github/workflows/win_dawn_dbg.yaml
@@ -39,6 +39,7 @@ jobs:
         set "PATH=%CD%\..\depot_tools;%PATH%"
         set "DEPOT_TOOLS_WIN_TOOLCHAIN=0"
         cd base
+        copy scripts\dawn.deps DEPS
         copy scripts\dawn.gclient .gclient
         gclient sync
 
@@ -81,6 +82,7 @@ jobs:
         set "PATH=%CD%\..\depot_tools;%PATH%"
         set "DEPOT_TOOLS_WIN_TOOLCHAIN=0"
         cd test
+        copy scripts\dawn.deps DEPS
         copy scripts\dawn.gclient .gclient
         gclient sync
 

--- a/.github/workflows/win_dawn_rel.yaml
+++ b/.github/workflows/win_dawn_rel.yaml
@@ -5,14 +5,14 @@ on:
     branches: main
     paths:
       - 'src/**'
-      - 'DEPS'
+      - 'scripts/dawn.deps'
       - '.github/workflows/.patches/dawn.diff'
 
   pull_request:
     branches: main
     paths:
       - 'src/**'
-      - 'DEPS'
+      - 'scripts/dawn.deps'
       - '.github/workflows/.patches/dawn.diff'
 
 jobs:
@@ -51,6 +51,7 @@ jobs:
         set "PATH=%CD%\..\depot_tools;%PATH%"
         set "DEPOT_TOOLS_WIN_TOOLCHAIN=0"
         cd base
+        copy scripts\dawn.deps DEPS
         copy scripts\dawn.gclient .gclient
         gclient sync
 
@@ -93,6 +94,7 @@ jobs:
         set "PATH=%CD%\..\depot_tools;%PATH%"
         set "DEPOT_TOOLS_WIN_TOOLCHAIN=0"
         cd test
+        copy scripts\dawn.deps DEPS
         copy scripts\dawn.gclient .gclient
         gclient sync
 

--- a/scripts/dawn.deps
+++ b/scripts/dawn.deps
@@ -1,0 +1,280 @@
+# DEPS for Dawn testing integration.
+# This DEPS was separated to allow GPGMM to use a different (usually newer) version of
+# buildtools. A different version of buildtools could break Dawn (or any of it's dependencies).
+# To use, copy this to .\DEPS then run `gclient sync`. Then use `roll-dep --roll-to <commit>`,
+# where commit corresponds to Dawn DEPS, to sync/update any dependency.
+use_relative_paths = True
+
+gclient_gn_args_file = 'build/config/gclient_args.gni'
+gclient_gn_args = [
+  'checkout_dawn',
+  'checkout_webnn',
+  'build_with_chromium',
+  'generate_location_tags',
+]
+
+vars = {
+  'chromium_git': 'https://chromium.googlesource.com',
+  'dawn_git': 'https://dawn.googlesource.com',
+  'github_git': 'https://github.com',
+
+  'gpgmm_standalone': True,
+  'build_with_chromium': False,
+
+  # Checkout and download Dawn by default. This can be disabled with custom_vars.
+  'checkout_dawn': False,
+
+  # Checkout and download WebNN by default. This can be disabled with custom_vars.
+  'checkout_webnn': False,
+
+  # Required by Chromium's //testing to generate directory->tags mapping used by ResultDB.
+  'generate_location_tags': False,
+
+  # GN CIPD package version.
+  'gpgmm_gn_version': 'git_revision:bd99dbf98cbdefe18a4128189665c5761263bcfb',
+}
+
+deps = {
+  # Dependencies required to test integrations
+  # Note: rolling Dawn also may require vulkan-deps to be rolled below.
+  # TODO(gpgmm): Consider linking vulkan-deps to Dawn like Tint.
+  # TODO(gpgmm): WebNN hard codes builds to third_party/dawn and should be fixed if the
+  # build errors are related to Dawn version mismatches.
+  'third_party/dawn': {
+    'url': '{dawn_git}/dawn.git@be4c9f48aaef9f2144a654a847b76a6a0050ec5b',
+    'condition': 'checkout_dawn or checkout_webnn',
+  },
+
+  'third_party/webnn_native': {
+    'url': '{github_git}/webmachinelearning/webnn-native.git@9add656df0e715aa9cf1d28536c132dd6506f784',
+    'condition': 'checkout_webnn',
+  },
+
+  # Dependencies required to use GN/Clang in standalone
+  'build': {
+    'url': '{chromium_git}/chromium/src/build@f14f6d206b9a0c81a0fefba487bcba0d90ddb5fe',
+    'condition': 'gpgmm_standalone',
+  },
+  'buildtools': {
+    'url': '{chromium_git}/chromium/src/buildtools@fe57e98eeb2172d7517f6dec1072ca641a019893',
+    'condition': 'gpgmm_standalone',
+  },
+  'buildtools/clang_format/script': {
+    'url': '{chromium_git}/external/github.com/llvm/llvm-project/clang/tools/clang-format.git@99803d74e35962f63a775f29477882afd4d57d94',
+    'condition': 'gpgmm_standalone',
+  },
+
+  'buildtools/linux64': {
+    'packages': [{
+      'package': 'gn/gn/linux-amd64',
+      'version': Var('gpgmm_gn_version'),
+    }],
+    'dep_type': 'cipd',
+    'condition': 'gpgmm_standalone and host_os == "linux"',
+  },
+  'buildtools/mac': {
+    'packages': [{
+      'package': 'gn/gn/mac-${{arch}}',
+      'version': Var('gpgmm_gn_version'),
+    }],
+    'dep_type': 'cipd',
+    'condition': 'gpgmm_standalone and host_os == "mac"',
+  },
+  'buildtools/win': {
+    'packages': [{
+      'package': 'gn/gn/windows-amd64',
+      'version': Var('gpgmm_gn_version'),
+    }],
+    'dep_type': 'cipd',
+    'condition': 'gpgmm_standalone and host_os == "win"',
+  },
+
+  'buildtools/third_party/libc++/trunk': {
+    'url': '{chromium_git}/external/github.com/llvm/llvm-project/libcxx.git@eb79671bfbedd77b747d01dee8c0479ff1693f88',
+    'condition': 'gpgmm_standalone',
+  },
+  'buildtools/third_party/libc++abi/trunk': {
+    'url': '{chromium_git}/external/github.com/llvm/llvm-project/libcxxabi.git@b954e3e65634a9e2f7b595598a30c455f5f2eb26',
+    'condition': 'gpgmm_standalone',
+  },
+  'tools/clang': {
+    'url': '{chromium_git}/chromium/src/tools/clang@3d8d88e8bb600789ba3e798f38ff314521aac524',
+    'condition': 'gpgmm_standalone',
+  },
+  'tools/clang/dsymutil': {
+    'packages': [
+      {
+        'package': 'chromium/llvm-build-tools/dsymutil',
+        'version': 'M56jPzDv1620Rnm__jTMYS62Zi8rxHVq7yw0qeBFEgkC',
+      }
+    ],
+    'condition': 'checkout_mac or checkout_ios',
+    'dep_type': 'cipd',
+  },
+
+  # Testing, GTest and GMock
+  'testing': {
+    'url': '{chromium_git}/chromium/src/testing@615c217a08c05b1e3c31aee46bfde6f191689696',
+    'condition': 'gpgmm_standalone',
+  },
+  'third_party/googletest': {
+    'url': '{chromium_git}/external/github.com/google/googletest@c29315dda476f195298ab8da180e564478649b9e',
+    'condition': 'gpgmm_standalone',
+  },
+  'third_party/vulkan-deps': {
+    'url': '{chromium_git}/vulkan-deps@c5f01bfc31ec5b7165eebf9f241890744edc7789',
+    'condition': 'gpgmm_standalone',
+  },
+  # Dependency of //testing
+  'third_party/catapult': {
+    'url': '{chromium_git}/catapult.git@861067db62eda94b3c144afd46fae5903e9e11f0',
+    'condition': 'gpgmm_standalone',
+  },
+  'third_party/jsoncpp/source': {
+    'url': '{chromium_git}/external/github.com/open-source-parsers/jsoncpp@8190e061bc2d95da37479a638aa2c9e483e58ec6',
+    'condition': 'gpgmm_standalone',
+  },
+  # Fuzzing
+  'third_party/libFuzzer/src': {
+    'url': '{chromium_git}/chromium/llvm-project/compiler-rt/lib/fuzzer.git@debe7d2d1982e540fbd6bd78604bf001753f9e74',
+    'condition': 'gpgmm_standalone',
+  },
+  'third_party/google_benchmark/src': {
+    'url': '{chromium_git}/external/github.com/google/benchmark.git@e991355c02b93fe17713efe04cbc2e278e00fdbd',
+    'condition': 'gpgmm_standalone',
+  },
+}
+
+hooks = [
+  # Pull the compilers and system libraries for hermetic builds
+  {
+    'name': 'sysroot_x86',
+    'pattern': '.',
+    'condition': 'checkout_linux and ((checkout_x86 or checkout_x64) and gpgmm_standalone)',
+    'action': ['python3', 'build/linux/sysroot_scripts/install-sysroot.py',
+               '--arch=x86'],
+  },
+  {
+    'name': 'sysroot_x64',
+    'pattern': '.',
+    'condition': 'checkout_linux and (checkout_x64 and gpgmm_standalone)',
+    'action': ['python3', 'build/linux/sysroot_scripts/install-sysroot.py',
+               '--arch=x64'],
+  },
+  {
+    # Update the Mac toolchain if possible, this makes builders use "hermetic XCode" which is
+    # is more consistent (only changes when rolling build/) and is cached.
+    'name': 'mac_toolchain',
+    'pattern': '.',
+    'condition': 'checkout_mac',
+    'action': ['python3', 'build/mac_toolchain.py'],
+  },
+  {
+    # Update the Windows toolchain if necessary. Must run before 'clang' below.
+    'name': 'win_toolchain',
+    'pattern': '.',
+    'condition': 'checkout_win and gpgmm_standalone',
+    'action': ['python3', 'build/vs_toolchain.py', 'update', '--force'],
+  },
+  {
+    # Note: On Win, this should run after win_toolchain, as it may use it.
+    'name': 'clang',
+    'pattern': '.',
+    'action': ['python3', 'tools/clang/scripts/update.py'],
+    'condition': 'gpgmm_standalone',
+  },
+  {
+    # Pull rc binaries using checked-in hashes.
+    'name': 'rc_win',
+    'pattern': '.',
+    'condition': 'checkout_win and (host_os == "win" and gpgmm_standalone)',
+    'action': [ 'download_from_google_storage',
+                '--no_resume',
+                '--no_auth',
+                '--bucket', 'chromium-browser-clang/rc',
+                '-s', 'build/toolchain/win/rc/win/rc.exe.sha1',
+    ],
+  },
+  # Pull clang-format binaries using checked-in hashes.
+  {
+    'name': 'clang_format_win',
+    'pattern': '.',
+    'condition': 'host_os == "win"',
+    'action': [ 'download_from_google_storage',
+                '--no_resume',
+                '--no_auth',
+                '--bucket', 'chromium-clang-format',
+                '-s', 'buildtools/win/clang-format.exe.sha1',
+    ],
+  },
+  {
+    'name': 'clang_format_mac',
+    'pattern': '.',
+    'condition': 'host_os == "mac"',
+    'action': [ 'download_from_google_storage',
+                '--no_resume',
+                '--no_auth',
+                '--bucket', 'chromium-clang-format',
+                '-s', 'buildtools/mac/clang-format.sha1',
+    ],
+  },
+  {
+    'name': 'clang_format_linux',
+    'pattern': '.',
+    'condition': 'host_os == "linux"',
+    'action': [ 'download_from_google_storage',
+                '--no_resume',
+                '--no_auth',
+                '--bucket', 'chromium-clang-format',
+                '-s', 'buildtools/linux64/clang-format.sha1',
+    ],
+  },
+  # Update build/util/LASTCHANGE.
+  {
+    'name': 'lastchange',
+    'pattern': '.',
+    'condition': 'gpgmm_standalone',
+    'action': ['python3', 'build/util/lastchange.py',
+               '-o', 'build/util/LASTCHANGE'],
+  },
+  # Apply Dawn integration patch.
+  # Patch can be removed should GPGMM be merged into upstream.
+  # Removes un-tracked files from previous apply.
+  {
+    'name': 'apply_dawn_patch_1',
+    'pattern': '.',
+    'condition': 'checkout_dawn',
+    'action': [ 'git', '-C', './third_party/dawn/',
+                'clean', '-f', '-x',
+    ],
+  },
+  # Removes un-staged changes from previous apply.
+  {
+    'name': 'apply_dawn_patch_2',
+    'pattern': '.',
+    'condition': 'checkout_dawn',
+    'action': [ 'git', '-C', './third_party/dawn/',
+                'checkout', '.',
+    ],
+  },
+  {
+    'name': 'apply_dawn_patch_3',
+    'pattern': '.',
+    'condition': 'checkout_dawn',
+    'action': [ 'git', '-C', './third_party/dawn/',
+                'apply', '--ignore-space-change', '--ignore-whitespace',
+                '../../.github/workflows/.patches/dawn.diff',
+    ],
+  },
+]
+
+recursedeps = [
+  # vulkan-deps provides vulkan-headers, spirv-tools, and gslang
+  'third_party/vulkan-deps',
+
+  # Dawn and Tint's revision are linked
+  'third_party/dawn',
+
+  # WebNN and DirectML revision are linked
+  'third_party/webnn_native',
+]


### PR DESCRIPTION
Sharing the same DEPS with Dawn means the buildtools version could mismatch (usually due to a newer version) and would fail to build the Dawn integration until issues are fixed in Dawn.

This change prevents this by having a specific DEPS for Dawn with its own buildtool versions in sync with upstream.