### PR TITLE
Track the residency state for heaps.

### DIFF
--- a/src/gpgmm/d3d12/JSONSerializerD3D12.cpp
+++ b/src/gpgmm/d3d12/JSONSerializerD3D12.cpp
@@ -178,7 +178,8 @@ namespace gpgmm::d3d12 {
     // static
     JSONDict JSONSerializer::Serialize(const HEAP_INFO& info) {
         JSONDict dict;
-        dict.AddItem("IsResident", info.IsResident);
+        dict.AddItem("IsLocked", info.IsLocked);
+        dict.AddItem("Status", info.Status);
         return dict;
     }
 

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -1215,7 +1215,6 @@ namespace gpgmm::d3d12 {
         HEAP_DESC resourceHeapDesc = {};
         resourceHeapDesc.SizeInBytes = resourceInfo.SizeInBytes;
         resourceHeapDesc.Alignment = resourceInfo.Alignment;
-        resourceHeapDesc.Flags |= HEAP_FLAG_NEVER_USE_RESIDENCY;
 
         Heap* resourceHeap = nullptr;
         ReturnIfFailed(Heap::CreateHeap(

--- a/src/include/min/gpgmm_d3d12.cpp
+++ b/src/include/min/gpgmm_d3d12.cpp
@@ -81,7 +81,7 @@ namespace gpgmm::d3d12 {
         ReturnIfFailed(createHeapFn(&pageable));
 
         if (ppHeapOut != nullptr) {
-            *ppHeapOut = new Heap(pageable, descriptor.SizeInBytes, descriptor.Alignment);
+            *ppHeapOut = new Heap(pageable, descriptor, (pResidencyManager == nullptr));
         }
 
         return S_OK;
@@ -99,8 +99,10 @@ namespace gpgmm::d3d12 {
         return {IsResident()};
     }
 
-    Heap::Heap(Microsoft::WRL::ComPtr<ID3D12Pageable> pageable, uint64_t size, uint64_t alignment)
-        : MemoryBase(size, alignment), mPageable(std::move(pageable)) {
+    Heap::Heap(Microsoft::WRL::ComPtr<ID3D12Pageable> pageable,
+               const HEAP_DESC& descriptor,
+               bool isResidencyDisabled)
+        : MemoryBase(descriptor.SizeInBytes, descriptor.Alignment), mPageable(std::move(pageable)) {
     }
 
     // ResidencyList

--- a/src/include/min/gpgmm_d3d12.h
+++ b/src/include/min/gpgmm_d3d12.h
@@ -65,14 +65,20 @@ namespace gpgmm::d3d12 {
         uint64_t mRefCount;
     };
 
+    enum RESIDENCY_STATUS {
+        RESIDENCY_UNKNOWN = 0,
+        PENDING_RESIDENCY = 1,
+        CURRENT_RESIDENT = 2,
+    };
+
     struct HEAP_INFO {
-        bool IsResident;
+        bool IsLocked;
+        RESIDENCY_STATUS Status;
     };
 
     enum HEAPS_FLAGS {
         HEAPS_FLAG_NONE = 0x0,
         HEAP_FLAG_ALWAYS_IN_BUDGET = 0x1,
-        HEAP_FLAG_NEVER_USE_RESIDENCY = 0x2,
     };
 
     DEFINE_ENUM_FLAG_OPERATORS(HEAPS_FLAGS)
@@ -102,7 +108,9 @@ namespace gpgmm::d3d12 {
         HEAP_INFO GetInfo() const;
 
       private:
-        Heap(Microsoft::WRL::ComPtr<ID3D12Pageable> pageable, uint64_t size, uint64_t alignment);
+        Heap(Microsoft::WRL::ComPtr<ID3D12Pageable> pageable,
+             const HEAP_DESC& descriptor,
+             bool isResidencyDisabled);
 
         Microsoft::WRL::ComPtr<ID3D12Pageable> mPageable;
     };


### PR DESCRIPTION
Also, remove HEAP_FLAG_NEVER_USE_RESIDENCY since creating a heap without a residency manager is equivalent.