### PR TITLE
Improve residency usage for RESIDENCY_INFO.

### DIFF
--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.h
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.h
@@ -158,13 +158,13 @@ namespace gpgmm::d3d12 {
     Additional information about the residency manager.
     */
     struct RESIDENCY_INFO {
-        /** \brief Amount of memory, in bytes, made resident.
+        /** \brief Amount of memory, in bytes, currently resident.
          */
-        uint64_t ResidentMemoryUsage;
+        uint64_t CurrentMemoryUsage;
 
-        /** \brief Number of heaps, made resident.
+        /** \brief Number of heaps, currently resident.
          */
-        uint64_t ResidentMemoryCount;
+        uint64_t CurrentMemoryCount;
     };
 
     class BudgetUpdateEvent;

--- a/src/include/min/gpgmm_d3d12.h
+++ b/src/include/min/gpgmm_d3d12.h
@@ -169,8 +169,8 @@ namespace gpgmm::d3d12 {
     };
 
     struct RESIDENCY_INFO {
-        uint64_t ResidentMemoryUsage;
-        uint64_t ResidentMemoryCount;
+        uint64_t CurrentMemoryUsage;
+        uint64_t CurrentMemoryCount;
     };
 
     class ResidencyManager final : public IUnknownImpl {

--- a/src/tests/end2end/D3D12ResidencyManagerTests.cpp
+++ b/src/tests/end2end/D3D12ResidencyManagerTests.cpp
@@ -137,8 +137,8 @@ TEST_F(D3D12ResidencyManagerTests, CreateResourceHeap) {
         Heap::CreateHeap(resourceHeapDesc, residencyManager.Get(), createHeapFn, &resourceHeap));
     ASSERT_NE(resourceHeap, nullptr);
 
-    EXPECT_EQ(residencyManager->GetInfo().ResidentMemoryUsage, kHeapSize);
-    EXPECT_EQ(residencyManager->GetInfo().ResidentMemoryCount, 1u);
+    EXPECT_EQ(residencyManager->GetInfo().CurrentMemoryUsage, kHeapSize);
+    EXPECT_EQ(residencyManager->GetInfo().CurrentMemoryCount, 1u);
 
     ComPtr<ID3D12Heap> heap;
     resourceHeap.As(&heap);
@@ -152,13 +152,13 @@ TEST_F(D3D12ResidencyManagerTests, CreateResourceHeap) {
     EXPECT_EQ(resourceHeap->GetInfo().Status, gpgmm::d3d12::CURRENT_RESIDENT);
     EXPECT_EQ(resourceHeap->GetInfo().IsLocked, true);
 
-    EXPECT_EQ(residencyManager->GetInfo().ResidentMemoryUsage, kHeapSize);
-    EXPECT_EQ(residencyManager->GetInfo().ResidentMemoryCount, 1u);
+    EXPECT_EQ(residencyManager->GetInfo().CurrentMemoryUsage, kHeapSize);
+    EXPECT_EQ(residencyManager->GetInfo().CurrentMemoryCount, 1u);
 
     ASSERT_SUCCEEDED(residencyManager->UnlockHeap(resourceHeap.Get()));
 
-    EXPECT_EQ(residencyManager->GetInfo().ResidentMemoryUsage, kHeapSize);
-    EXPECT_EQ(residencyManager->GetInfo().ResidentMemoryCount, 1u);
+    EXPECT_EQ(residencyManager->GetInfo().CurrentMemoryUsage, kHeapSize);
+    EXPECT_EQ(residencyManager->GetInfo().CurrentMemoryCount, 1u);
     EXPECT_EQ(resourceHeap->GetInfo().IsLocked, false);
 
     ASSERT_FAILED(residencyManager->UnlockHeap(resourceHeap.Get()));  // Not locked


### PR DESCRIPTION
* Renames field in RESIDENCY_INFO.
* Doesn't report cached heaps, not made resident, in usage.