### PR TITLE
Do not track created non-resource heaps in residency cache by default.

### DIFF
--- a/src/tests/D3D12Test.h
+++ b/src/tests/D3D12Test.h
@@ -30,6 +30,7 @@
 namespace gpgmm::d3d12 {
 
     struct ALLOCATOR_DESC;
+    class Caps;
     class ResourceAllocator;
     class ResourceAllocation;
 
@@ -59,9 +60,7 @@ namespace gpgmm::d3d12 {
       protected:
         ComPtr<IDXGIAdapter3> mAdapter;
         ComPtr<ID3D12Device> mDevice;
-
-        bool mIsUMA = false;
-        D3D12_RESOURCE_HEAP_TIER mResourceHeapTier = D3D12_RESOURCE_HEAP_TIER_1;
+        std::unique_ptr<Caps> mCaps;
     };
 
 }  // namespace gpgmm::d3d12

--- a/src/tests/capture_replay_tests/D3D12EventTraceReplay.cpp
+++ b/src/tests/capture_replay_tests/D3D12EventTraceReplay.cpp
@@ -17,6 +17,7 @@
 
 #include "gpgmm/common/SizeClass.h"
 #include "gpgmm/common/TraceEventPhase.h"
+#include "gpgmm/d3d12/CapsD3D12.h"
 #include "gpgmm/d3d12/ErrorD3D12.h"
 #include "gpgmm/d3d12/UtilsD3D12.h"
 #include "gpgmm/utils/Log.h"
@@ -300,18 +301,19 @@ class D3D12EventTraceReplay : public D3D12TestBase, public CaptureReplayTestWith
                         ASSERT_FALSE(snapshot.empty());
 
                         if (GetLogLevel() <= gpgmm::LogSeverity::Warning &&
-                            mIsUMA != snapshot["IsUMA"].asBool() && iterationIndex == 0) {
+                            mCaps->IsAdapterUMA() != snapshot["IsUMA"].asBool() &&
+                            iterationIndex == 0) {
                             gpgmm::WarningLog()
                                 << "Capture device does not match playback device (IsUMA: " +
                                        std::to_string(snapshot["IsUMA"].asBool()) + " vs " +
-                                       std::to_string(mIsUMA) + ").";
+                                       std::to_string(mCaps->IsAdapterUMA()) + ").";
                             GPGMM_SKIP_TEST_IF(!envParams.IsIgnoreCapsMismatchEnabled);
                         }
 
                         RESIDENCY_DESC residencyDesc = {};
                         residencyDesc.Device = mDevice;
                         residencyDesc.Adapter = mAdapter;
-                        residencyDesc.IsUMA = mIsUMA;
+                        residencyDesc.IsUMA = mCaps->IsAdapterUMA();
                         residencyDesc.MaxPctOfVideoMemoryToBudget =
                             snapshot["MaxPctOfVideoMemoryToBudget"].asFloat();
                         residencyDesc.MaxBudgetInBytes = snapshot["MaxBudgetInBytes"].asUInt64();
@@ -494,8 +496,8 @@ class D3D12EventTraceReplay : public D3D12TestBase, public CaptureReplayTestWith
                         HEAP_DESC resourceHeapDesc = {};
                         resourceHeapDesc.SizeInBytes = args["Heap"]["SizeInBytes"].asUInt64();
                         resourceHeapDesc.Alignment = args["Heap"]["Alignment"].asUInt64();
-                        resourceHeapDesc.MemorySegmentGroup =
-                            GetMemorySegmentGroup(heapProperties.MemoryPoolPreference, mIsUMA);
+                        resourceHeapDesc.MemorySegmentGroup = GetMemorySegmentGroup(
+                            heapProperties.MemoryPoolPreference, mCaps->IsAdapterUMA());
 
                         ResidencyManager* residencyManager =
                             createdResidencyManagerToID[currentResidencyID].Get();

--- a/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
+++ b/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
@@ -15,6 +15,7 @@
 #include "gpgmm/common/SizeClass.h"
 #include "gpgmm/common/TraceEvent.h"
 #include "gpgmm/d3d12/BackendD3D12.h"
+#include "gpgmm/d3d12/CapsD3D12.h"
 #include "gpgmm/d3d12/ErrorD3D12.h"
 #include "gpgmm/utils/Math.h"
 #include "tests/D3D12Test.h"
@@ -671,7 +672,7 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferLeaked) {
 
 // Verifies there are no attribution of heaps when UMA + no read-back.
 TEST_F(D3D12ResourceAllocatorTests, CreateBufferUMA) {
-    GPGMM_SKIP_TEST_IF(!mIsUMA);
+    GPGMM_SKIP_TEST_IF(!mCaps->IsAdapterUMA());
 
     ComPtr<ResourceAllocator> resourceAllocator;
     ASSERT_SUCCEEDED(


### PR DESCRIPTION
Ensures MakeResident is always called reguardless of heap type. Also, fixes incorrect residency usage when locking non-resource heap types.