### PR TITLE
Allow a custom refcount types.

### DIFF
--- a/src/gpgmm/d3d12/IUnknownImplD3D12.cpp
+++ b/src/gpgmm/d3d12/IUnknownImplD3D12.cpp
@@ -15,7 +15,7 @@
 #include "gpgmm/d3d12/IUnknownImplD3D12.h"
 
 namespace gpgmm::d3d12 {
-    IUnknownImpl::IUnknownImpl() : mRefs(1) {
+    IUnknownImpl::IUnknownImpl() : mRefCount(1) {
     }
 
     HRESULT IUnknownImpl::QueryInterface(REFIID riid, void** ppvObject) {
@@ -29,7 +29,7 @@ namespace gpgmm::d3d12 {
         if (riid == IID_IUnknown) {
             // Increment reference and return pointer.
             *ppvObject = this;
-            mRefs.Ref();
+            mRefCount.Ref();
             return S_OK;
         }
 
@@ -37,12 +37,12 @@ namespace gpgmm::d3d12 {
     }
 
     ULONG IUnknownImpl::AddRef() {
-        mRefs.Ref();
-        return mRefs.GetRefCount();
+        mRefCount.Ref();
+        return mRefCount.GetRefCount();
     }
 
     ULONG IUnknownImpl::Release() {
-        const ULONG refCount = mRefs.Unref() ? 0 : mRefs.GetRefCount();
+        const ULONG refCount = mRefCount.Unref() ? 0 : mRefCount.GetRefCount();
         if (refCount == 0) {
             DeleteThis();
         }

--- a/src/gpgmm/d3d12/IUnknownImplD3D12.h
+++ b/src/gpgmm/d3d12/IUnknownImplD3D12.h
@@ -17,8 +17,15 @@
 
 #include "gpgmm/d3d12/d3d12_platform.h"
 #include "gpgmm/utils/NonCopyable.h"
-#include "gpgmm/utils/RefCount.h"
 #include "include/gpgmm_export.h"
+
+#ifndef GPGMM_REFCOUNT_TYPE
+#    include "gpgmm/utils/RefCount.h"
+/** \brief Defines the atomic-type to use for ref-counting the COM object.
+    \param type
+*/ 
+#    define GPGMM_REFCOUNT_TYPE RefCounted
+#endif
 
 namespace gpgmm::d3d12 {
 
@@ -41,7 +48,7 @@ namespace gpgmm::d3d12 {
         virtual void DeleteThis();
 
       private:
-        RefCounted mRefs;  // Maintains the COM ref-count of this object.
+        GPGMM_REFCOUNT_TYPE mRefCount;  // Maintains the COM ref-count of this object.
     };
 
 }  // namespace gpgmm::d3d12


### PR DESCRIPTION
Adds GPGMM_REFCOUNT_TYPE to allow a user-provided refcount type to be used instead of GPGMM always providing one.