### PR TITLE
Use native wide character type for debug name.

### DIFF
--- a/src/gpgmm/d3d12/DebugObjectD3D12.cpp
+++ b/src/gpgmm/d3d12/DebugObjectD3D12.cpp
@@ -14,15 +14,21 @@
 
 #include "gpgmm/d3d12/DebugObjectD3D12.h"
 
+#include "gpgmm/utils/WindowsUtils.h"
+
 namespace gpgmm::d3d12 {
 
-    const std::string& DebugObject::GetDebugName() const {
-        return mDebugName;
+    LPCWSTR DebugObject::GetDebugName() const {
+        return mDebugName.c_str();
     }
 
-    HRESULT DebugObject::SetDebugName(const std::string& name) {
-        mDebugName = name;
-        return SetDebugNameImpl(name);
+    HRESULT DebugObject::SetDebugName(LPCWSTR Name) {
+        if (Name == nullptr) {
+            return S_FALSE;
+        }
+        // Store a copy of the name because D3D12 oddly doesn't have a ID3D12Object::GetName.
+        mDebugName = TCharToWString(Name);
+        return SetDebugNameImpl(Name);
     }
 
 }  // namespace gpgmm::d3d12

--- a/src/gpgmm/d3d12/DebugObjectD3D12.h
+++ b/src/gpgmm/d3d12/DebugObjectD3D12.h
@@ -37,22 +37,24 @@ namespace gpgmm::d3d12 {
 
         /** \brief Get the debug name.
 
-        \return A string that contains the debug name associated with the debug object.
+        \return A NULL-terminated UNICODE string that contains the name to associate with the debug
+        object.
         */
-        const std::string& GetDebugName() const;
+        LPCWSTR GetDebugName() const;
 
         /** \brief Associate a debug name.
 
-        @param name A string that contains the debug name to associate with the debug object.
+        @param Name A NULL-terminated UNICODE string that contains the name to associate with the
+        debug object.
         */
-        HRESULT SetDebugName(const std::string& name);
+        HRESULT SetDebugName(LPCWSTR Name);
 
       protected:
         // Derived classes should override to associate the name with the containing ID3D12Object.
-        virtual HRESULT SetDebugNameImpl(const std::string& name) = 0;
+        virtual HRESULT SetDebugNameImpl(LPCWSTR name) = 0;
 
       private:
-        std::string mDebugName;
+        std::wstring mDebugName;
     };
 
 }  // namespace gpgmm::d3d12

--- a/src/gpgmm/d3d12/HeapD3D12.cpp
+++ b/src/gpgmm/d3d12/HeapD3D12.cpp
@@ -173,7 +173,7 @@ namespace gpgmm::d3d12 {
         return {IsResidencyLocked(), mState};
     }
 
-    HRESULT Heap::SetDebugNameImpl(const std::string& name) {
+    HRESULT Heap::SetDebugNameImpl(LPCWSTR name) {
         return SetDebugObjectName(mPageable.Get(), name);
     }
 

--- a/src/gpgmm/d3d12/HeapD3D12.h
+++ b/src/gpgmm/d3d12/HeapD3D12.h
@@ -115,7 +115,7 @@ namespace gpgmm::d3d12 {
 
         /** \brief Debug name associated with the heap.
          */
-        std::string DebugName;
+        LPCWSTR DebugName;
     };
 
     /** \brief Callback function used to create a ID3D12Pageable.
@@ -197,7 +197,7 @@ namespace gpgmm::d3d12 {
              const HEAP_DESC& descriptor,
              bool isResidencyDisabled);
 
-        HRESULT SetDebugNameImpl(const std::string& name) override;
+        HRESULT SetDebugNameImpl(LPCWSTR name) override;
         const char* GetTypename() const override;
         DXGI_MEMORY_SEGMENT_GROUP GetMemorySegmentGroup() const;
 

--- a/src/gpgmm/d3d12/JSONSerializerD3D12.cpp
+++ b/src/gpgmm/d3d12/JSONSerializerD3D12.cpp
@@ -21,6 +21,7 @@
 #include "gpgmm/d3d12/ResourceAllocationD3D12.h"
 #include "gpgmm/d3d12/ResourceAllocatorD3D12.h"
 #include "gpgmm/d3d12/UtilsD3D12.h"
+#include "gpgmm/utils/WindowsUtils.h"
 
 namespace gpgmm::d3d12 {
 
@@ -169,8 +170,8 @@ namespace gpgmm::d3d12 {
         dict.AddItem("Alignment", desc.Alignment);
         dict.AddItem("Flags", desc.Flags);
         dict.AddItem("MemorySegmentGroup", desc.MemorySegmentGroup);
-        if (!desc.DebugName.empty()) {
-            dict.AddItem("DebugName", desc.DebugName);
+        if (desc.DebugName != nullptr) {
+            dict.AddItem("DebugName", WCharToUTF8(desc.DebugName));
         }
         return dict;
     }
@@ -190,8 +191,8 @@ namespace gpgmm::d3d12 {
         dict.AddItem("HeapOffset", desc.HeapOffset);
         dict.AddItem("OffsetFromResource", desc.OffsetFromResource);
         dict.AddItem("Method", desc.Method);
-        if (!desc.DebugName.empty()) {
-            dict.AddItem("DebugName", desc.DebugName);
+        if (desc.DebugName != nullptr) {
+            dict.AddItem("DebugName", WCharToUTF8(desc.DebugName));
         }
         return dict;
     }

--- a/src/gpgmm/d3d12/ResourceAllocationD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocationD3D12.cpp
@@ -152,9 +152,9 @@ namespace gpgmm::d3d12 {
         mAllocator = allocator;
     }
 
-    HRESULT ResourceAllocation::SetDebugNameImpl(const std::string& name) {
+    HRESULT ResourceAllocation::SetDebugNameImpl(LPCWSTR name) {
         // D3D name is set per resource.
-        if (!GetDebugName().empty() && GetMethod() == AllocationMethod::kSubAllocatedWithin) {
+        if (GetDebugName() != nullptr && GetMethod() == AllocationMethod::kSubAllocatedWithin) {
             return S_FALSE;
         }
 

--- a/src/gpgmm/d3d12/ResourceAllocationD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocationD3D12.h
@@ -60,7 +60,7 @@ namespace gpgmm::d3d12 {
 
         /** \brief Debug name associated with the resource allocation.
          */
-        std::string DebugName;
+        LPCWSTR DebugName;
     };
 
     /** \struct RESOURCE_ALLOCATION_INFO
@@ -177,7 +177,7 @@ namespace gpgmm::d3d12 {
         friend DebugResourceAllocator;
         void SetDebugAllocator(MemoryAllocator* allocator);
 
-        HRESULT SetDebugNameImpl(const std::string& name) override;
+        HRESULT SetDebugNameImpl(LPCWSTR name) override;
 
         void DeleteThis() override;
 

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -854,14 +854,11 @@ namespace gpgmm::d3d12 {
         ReturnIfFailed(CreateResourceInternal(allocationDescriptor, resourceDescriptor,
                                               initialResourceState, pClearValue, &allocation));
 
-        if (!allocationDescriptor.DebugName.empty()) {
-            ReturnIfFailed(allocation->SetDebugName(allocationDescriptor.DebugName));
-        }
-
         // Insert a new (debug) allocator layer into the allocation so it can report details used
         // during leak checks. Since we don't want to use it unless we are debugging, we hide it
         // behind a macro.
         if (mDebugAllocator) {
+            ReturnIfFailed(allocation->SetDebugName(allocationDescriptor.DebugName));
             mDebugAllocator->AddLiveAllocation(allocation.Get());
         }
 
@@ -1299,7 +1296,7 @@ namespace gpgmm::d3d12 {
 
         HEAP_DESC resourceHeapDesc = {};
         resourceHeapDesc.SizeInBytes = info.SizeInBytes;
-        resourceHeapDesc.DebugName = "Resource heap (committed)";
+        resourceHeapDesc.DebugName = L"Resource heap (committed)";
         resourceHeapDesc.Alignment = info.Alignment;
         resourceHeapDesc.Flags |=
             (mIsHeapAlwaysCreatedInBudget) ? HEAP_FLAG_ALWAYS_IN_BUDGET : HEAPS_FLAG_NONE;

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -430,7 +430,7 @@ namespace gpgmm::d3d12 {
 
         Optional parameter. By default, no name is associated.
         */
-        std::string DebugName;
+        LPCWSTR DebugName;
     };
 
     /** \struct FEATURE_DATA_RESOURCE_ALLOCATION_SUPPORT

--- a/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.cpp
@@ -61,7 +61,7 @@ namespace gpgmm::d3d12 {
 
         HEAP_DESC resourceHeapDesc = {};
         resourceHeapDesc.SizeInBytes = heapSize;
-        resourceHeapDesc.DebugName = "Resource heap";
+        resourceHeapDesc.DebugName = L"Resource heap";
         resourceHeapDesc.Alignment = request.Alignment;
         resourceHeapDesc.Flags |= (mAlwaysInBudget) ? HEAP_FLAG_ALWAYS_IN_BUDGET : HEAPS_FLAG_NONE;
 

--- a/src/gpgmm/d3d12/UtilsD3D12.cpp
+++ b/src/gpgmm/d3d12/UtilsD3D12.cpp
@@ -427,14 +427,14 @@ namespace gpgmm::d3d12 {
         return GetTileCount(resourceDescriptor, tile) <= 16;
     }
 
-    HRESULT SetDebugObjectName(ID3D12Object* object, const std::string& name) {
+    HRESULT SetDebugObjectName(ID3D12Object* object, LPCWSTR name) {
         if (object == nullptr) {
             return E_POINTER;
         }
-        if (name.empty()) {
+        if (name == nullptr) {
             return S_FALSE;
         }
-        return object->SetName(TCharToWString(name.c_str()).c_str());
+        return object->SetName(name);
     }
 
     DXGI_MEMORY_SEGMENT_GROUP GetMemorySegmentGroup(D3D12_MEMORY_POOL memoryPool, bool isUMA) {

--- a/src/gpgmm/d3d12/UtilsD3D12.h
+++ b/src/gpgmm/d3d12/UtilsD3D12.h
@@ -25,7 +25,7 @@ namespace gpgmm::d3d12 {
     LogSeverity GetLogSeverity(D3D12_MESSAGE_SEVERITY messageSeverity);
     bool IsDepthFormat(DXGI_FORMAT format);
     bool IsAllowedToUseSmallAlignment(const D3D12_RESOURCE_DESC& Desc);
-    HRESULT SetDebugObjectName(ID3D12Object* object, const std::string& name);
+    HRESULT SetDebugObjectName(ID3D12Object* object, LPCWSTR name);
     DXGI_MEMORY_SEGMENT_GROUP GetMemorySegmentGroup(D3D12_MEMORY_POOL memoryPool, bool isUMA);
     const char* GetMemorySegmentName(DXGI_MEMORY_SEGMENT_GROUP memorySegmentGroup, bool isUMA);
 

--- a/src/include/min/gpgmm_d3d12.h
+++ b/src/include/min/gpgmm_d3d12.h
@@ -88,7 +88,7 @@ namespace gpgmm::d3d12 {
         uint64_t Alignment;
         HEAPS_FLAGS Flags;
         DXGI_MEMORY_SEGMENT_GROUP MemorySegmentGroup;
-        std::string DebugName;
+        LPCWSTR DebugName;
     };
 
     using CreateHeapFn = std::function<HRESULT(ID3D12Pageable** ppPageableOut)>;
@@ -205,7 +205,7 @@ namespace gpgmm::d3d12 {
         uint64_t HeapOffset;
         uint64_t OffsetFromResource;
         AllocationMethod Method;
-        std::string DebugName;
+        LPCWSTR DebugName;
     };
 
     struct RESOURCE_ALLOCATION_INFO {
@@ -294,7 +294,7 @@ namespace gpgmm::d3d12 {
         D3D12_HEAP_TYPE HeapType;
         D3D12_HEAP_FLAGS ExtraRequiredHeapFlags;
         uint64_t RequireResourceHeapPadding;
-        std::string DebugName;
+        LPCWSTR DebugName;
     };
 
     enum ALLOCATOR_FEATURE {

--- a/src/tests/D3D12Test.h
+++ b/src/tests/D3D12Test.h
@@ -27,6 +27,8 @@
 #define EXPECT_FAILED(expr) EXPECT_TRUE(FAILED(expr))
 #define EXPECT_SUCCEEDED(expr) EXPECT_TRUE(SUCCEEDED(expr))
 
+#define EXPECT_EQUAL_WSTR(wstr1, wstr2) EXPECT_FALSE(wcscmp(wstr1, wstr2))
+
 namespace gpgmm::d3d12 {
 
     struct ALLOCATOR_DESC;

--- a/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
+++ b/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
@@ -30,7 +30,7 @@ using namespace gpgmm::d3d12;
 static constexpr uint64_t kBufferOf4MBAllocationSize = GPGMM_MB_TO_BYTES(4);
 static constexpr uint64_t kReleaseAllMemory = std::numeric_limits<uint64_t>::max();
 
-#define GPGMM_GET_VAR_NAME(x) (#x)
+#define GPGMM_GET_VAR_NAME(x) (L#x)
 
 #define EXPECT_SIZE_CACHE_HIT(allocator, statement)                \
     do {                                                           \
@@ -623,14 +623,14 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBuffer) {
     {
         ALLOCATION_DESC allocationDesc = {};
         allocationDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
-        allocationDesc.DebugName = "Buffer";
+        allocationDesc.DebugName = L"Buffer";
 
         ComPtr<ResourceAllocation> allocation;
         ASSERT_SUCCEEDED(resourceAllocator->CreateResource(
             allocationDesc, CreateBasicBufferDesc(kBufferOf4MBAllocationSize), D3D12_RESOURCE_STATE_COMMON,
             nullptr, &allocation));
         ASSERT_NE(allocation, nullptr);
-        EXPECT_EQ(allocation->GetDebugName(), allocationDesc.DebugName);
+        EXPECT_EQUAL_WSTR(allocation->GetDebugName(), allocationDesc.DebugName);
     }
 
     // Creating a buffer without a heap type should be inferred based on the resource state.


### PR DESCRIPTION
Replaces using std::string with the same type used by D3D12. This is to remove requiring <string> in the public interface.