### PR TITLE
Use native character type for trace name.

### DIFF
--- a/src/gpgmm/common/EventTraceWriter.cpp
+++ b/src/gpgmm/common/EventTraceWriter.cpp
@@ -68,9 +68,9 @@ namespace gpgmm {
         : mTraceFile(kDefaultTraceFile), mPlatformTime(CreatePlatformTime()) {
     }
 
-    void EventTraceWriter::SetConfiguration(const std::string& traceFile,
+    void EventTraceWriter::SetConfiguration(const char* traceFile,
                                             const TraceEventPhase& ignoreMask) {
-        mTraceFile = (traceFile.empty()) ? mTraceFile : traceFile;
+        mTraceFile = (traceFile == nullptr) ? mTraceFile : std::string(traceFile);
         mIgnoreMask = ignoreMask;
     }
 

--- a/src/gpgmm/common/EventTraceWriter.h
+++ b/src/gpgmm/common/EventTraceWriter.h
@@ -32,7 +32,7 @@ namespace gpgmm {
         EventTraceWriter();
         ~EventTraceWriter();
 
-        void SetConfiguration(const std::string& traceFile, const TraceEventPhase& ignoreMask);
+        void SetConfiguration(const char* traceFile, const TraceEventPhase& ignoreMask);
 
         void EnqueueTraceEvent(std::shared_ptr<EventTraceWriter> writer,
                                char phase,

--- a/src/gpgmm/common/TraceEvent.cpp
+++ b/src/gpgmm/common/TraceEvent.cpp
@@ -33,7 +33,7 @@ namespace gpgmm {
         return gEventTrace.get();
     }
 
-    void StartupEventTrace(const std::string& traceFile, const TraceEventPhase& ignoreMask) {
+    void StartupEventTrace(const char* traceFile, const TraceEventPhase& ignoreMask) {
 #if defined(GPGMM_DISABLE_TRACING)
         gpgmm::WarningLog()
             << "Event tracing enabled but unable to record due to GPGMM_DISABLE_TRACING.";

--- a/src/gpgmm/common/TraceEvent.h
+++ b/src/gpgmm/common/TraceEvent.h
@@ -175,7 +175,7 @@ namespace gpgmm {
     class EventTraceWriter;
     class PlatformTime;
 
-    void StartupEventTrace(const std::string& traceFile,
+    void StartupEventTrace(const char* traceFile,
                            const TraceEventPhase& ignoreMask);
 
     void FlushEventTraceToDisk();

--- a/src/gpgmm/d3d12/EventRecordD3D12.h
+++ b/src/gpgmm/d3d12/EventRecordD3D12.h
@@ -18,8 +18,6 @@
 #include "gpgmm/d3d12/d3d12_platform.h"
 #include "gpgmm/utils/EnumFlags.h"
 
-#include <string>
-
 namespace gpgmm::d3d12 {
 
     /** \enum EVENT_RECORD_FLAGS
@@ -109,7 +107,7 @@ namespace gpgmm::d3d12 {
 
         Optional parameter. By default, a trace file is created for you.
         */
-        std::string TraceFile;
+        const char* TraceFile;
     };
 
 }  // namespace gpgmm::d3d12

--- a/src/include/min/gpgmm_d3d12.h
+++ b/src/include/min/gpgmm_d3d12.h
@@ -53,7 +53,6 @@
 #endif
 
 #include <functional>
-#include <string>
 
 #include "gpgmm.h"
 
@@ -154,7 +153,7 @@ namespace gpgmm::d3d12 {
         D3D12_MESSAGE_SEVERITY MinMessageLevel;
         EVENT_RECORD_SCOPE EventScope;
         bool UseDetailedTimingEvents;
-        std::string TraceFile;
+        const char* TraceFile;
     };
 
     enum RESIDENCY_FLAGS {

--- a/src/tests/capture_replay_tests/D3D12EventTraceReplay.cpp
+++ b/src/tests/capture_replay_tests/D3D12EventTraceReplay.cpp
@@ -323,7 +323,7 @@ class D3D12EventTraceReplay : public D3D12TestBase, public CaptureReplayTestWith
                         if (envParams.CaptureEventMask != 0) {
                             residencyDesc.RecordOptions.Flags |=
                                 static_cast<EVENT_RECORD_FLAGS>(envParams.CaptureEventMask);
-                            residencyDesc.RecordOptions.TraceFile = traceFile.path;
+                            residencyDesc.RecordOptions.TraceFile = traceFile.path.c_str();
                             residencyDesc.RecordOptions.MinMessageLevel =
                                 GetMessageSeverity(GetLogLevel());
 
@@ -408,7 +408,7 @@ class D3D12EventTraceReplay : public D3D12TestBase, public CaptureReplayTestWith
                         if (envParams.CaptureEventMask != 0) {
                             allocatorDesc.RecordOptions.Flags |=
                                 static_cast<EVENT_RECORD_FLAGS>(envParams.CaptureEventMask);
-                            allocatorDesc.RecordOptions.TraceFile = traceFile.path;
+                            allocatorDesc.RecordOptions.TraceFile = traceFile.path.c_str();
                             allocatorDesc.RecordOptions.MinMessageLevel =
                                 GetMessageSeverity(GetLogLevel());
 


### PR DESCRIPTION
Replaces requiring std::string in the public interface.