### PR TITLE
Remove src folder from public config.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,6 @@ endif()
 # GPGMM's public and common "configs"
 # ###############################################################################
 set(GPGMM_INCLUDE_DIRS
-  "${GPGMM_ROOT_DIR}/src"
   "${GPGMM_INCLUDE_DIR}"
 )
 
@@ -142,7 +141,7 @@ add_library(gpgmm_public_config INTERFACE)
 target_include_directories(gpgmm_public_config INTERFACE "${GPGMM_INCLUDE_DIRS}")
 
 add_library(gpgmm_common_config INTERFACE)
-target_link_libraries(gpgmm_common_config INTERFACE gpgmm_public_config)
+target_include_directories(gpgmm_common_config INTERFACE "${GPGMM_ROOT_DIR}/src")
 
 # Compile definitions for the common config
 if(GPGMM_ALWAYS_ASSERT)

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ cmake --build . --config Debug
 
 1. Copy the DLL into the `$(OutputPath)` folder and configure the VS build:
 2. Highlight project in the **Solution Explorer**, and then select **Project > Properties**.
-3. Under **Configuration Properties > C/C++ > General**, add `gpgmm\src` and `gpgmm\src\include` to **Additional Include Directories**.
+3. Under **Configuration Properties > C/C++ > General**, add `gpgmm\src\include` to **Additional Include Directories**.
 4. Under **Configuration Properties > Linker > Input**, add ``gpgmm.dll.lib`` to **Additional Dependencies**.
 5. Under **Configuration Properties > Linker > General**, add the folder path to `out\Release` to **Additional Library Directories**.
 

--- a/src/fuzzers/BUILD.gn
+++ b/src/fuzzers/BUILD.gn
@@ -48,6 +48,8 @@ if (is_win) {
 
     deps = [ "${gpgmm_root_dir}:gpgmm" ]
 
+    include_dirs = [ "${gpgmm_root_dir}/src" ]
+
     libs = [
       "d3d12.lib",
       "dxgi.lib",

--- a/src/gpgmm/common/BUILD.gn
+++ b/src/gpgmm/common/BUILD.gn
@@ -34,13 +34,11 @@ if (build_with_chromium) {
 ###############################################################################
 
 config("gpgmm_public_config") {
-  include_dirs = [
-    "${gpgmm_root_dir}/src",
-    "${gpgmm_root_dir}/src/include",
-  ]
+  include_dirs = [ "${gpgmm_root_dir}/src/include" ]
 }
 
 config("gpgmm_common_config") {
+  include_dirs = [ "${gpgmm_root_dir}/src" ]
   defines = []
   if (gpgmm_always_assert || is_debug || use_fuzzing_engine) {
     defines += [ "GPGMM_ENABLE_ASSERTS" ]


### PR DESCRIPTION
Public config target only needs to add src/include. The internal/common config target only needs to add src.