### PR TITLE
Add cmake build export targets.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,9 @@ add_library(gpgmm_public_config INTERFACE)
 target_include_directories(gpgmm_public_config INTERFACE "${GPGMM_INCLUDE_DIRS}")
 
 add_library(gpgmm_common_config INTERFACE)
-target_include_directories(gpgmm_common_config INTERFACE "${GPGMM_ROOT_DIR}/src")
+target_include_directories(gpgmm_common_config INTERFACE $<BUILD_INTERFACE:${GPGMM_ROOT_DIR}/src>)
+
+install(TARGETS gpgmm_common_config EXPORT gpgmmTargets)
 
 # Compile definitions for the common config
 if(GPGMM_ALWAYS_ASSERT)
@@ -217,8 +219,4 @@ endif()
 # ###############################################################################
 # Install GPGMM
 # ###############################################################################
-install(TARGETS gpgmm
-  RUNTIME DESTINATION bin
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
-)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/install.cmake)

--- a/cmake/gpgmmConfig.cmake.in
+++ b/cmake/gpgmmConfig.cmake.in
@@ -1,0 +1,17 @@
+# Copyright 2022 The GPGMM Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@PACKAGE_INIT@
+
+include ( "${CMAKE_CURRENT_LIST_DIR}/gpgmmTargets.cmake" )

--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -1,0 +1,59 @@
+# Copyright 2022 The GPGMM Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Provide the configure_package_config_file function below. 
+include(CMakePackageConfigHelpers)
+
+install(TARGETS gpgmm
+    EXPORT gpgmmTargets
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+)
+
+# vulkan-headers must be rolled to export gpgmm.
+# TODO: Remove check after rolling vulkan-headers.
+if(GPGMM_ENABLE_VK)
+    message(WARNING "GPGMM_ENABLE_VK is not supported for install.cmake" )
+    return()
+endif()
+
+# Configure then config input file with the targets to be exported.
+install(EXPORT gpgmmTargets
+    DESTINATION lib/cmake/gpgmm
+    FILE gpgmmTargets.cmake
+)
+
+# Generate the config output file that includes the exports.
+configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/gpgmmConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/gpgmmConfig.cmake"
+    INSTALL_DESTINATION "lib/cmake/gpgmm"
+    NO_CHECK_REQUIRED_COMPONENTS_MACRO
+)
+
+# Provide a relocatable configuration file for gpgmm.
+install(
+    FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/gpgmmConfig.cmake
+    DESTINATION
+        lib/cmake/gpgmm
+)
+
+# Allow any parent project to build with the exported target.
+export(EXPORT gpgmmTargets
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/gpgmmTargets.cmake"
+)
+
+export(PACKAGE gpgmm)

--- a/src/gpgmm/CMakeLists.txt
+++ b/src/gpgmm/CMakeLists.txt
@@ -132,7 +132,7 @@ if (GPGMM_ENABLE_VK)
 
 endif()
 
-target_include_directories(gpgmm PUBLIC ${GPGMM_INCLUDE_DIRS})
+target_include_directories(gpgmm PUBLIC $<BUILD_INTERFACE:${GPGMM_INCLUDE_DIRS}>)
 
 ################################################################################
 # Build subdirectories

--- a/src/gpgmm/common/CMakeLists.txt
+++ b/src/gpgmm/common/CMakeLists.txt
@@ -59,3 +59,5 @@ target_sources(gpgmm_common PRIVATE
 )
 
 target_link_libraries(gpgmm_common PRIVATE gpgmm_common_config)
+
+install(TARGETS gpgmm_common EXPORT gpgmmTargets)

--- a/src/gpgmm/utils/CMakeLists.txt
+++ b/src/gpgmm/utils/CMakeLists.txt
@@ -49,3 +49,5 @@ if (WIN32)
 endif()
 
 target_link_libraries(gpgmm_utils PRIVATE gpgmm_common_config)
+
+install(TARGETS gpgmm_utils EXPORT gpgmmTargets)


### PR DESCRIPTION
Fixes build failure when parent CMake project exports a target that depends on GPGMM. Since GPGMM doesn't export such target, it would fail.

#386