### PR TITLE
Release leaked D3D allocations during testing.

### DIFF
--- a/src/gpgmm/d3d12/DebugResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/DebugResourceAllocatorD3D12.cpp
@@ -55,6 +55,16 @@ namespace gpgmm::d3d12 {
         }
     }
 
+    void DebugResourceAllocator::ReleaseLiveAllocationsForTesting() {
+        std::lock_guard<std::mutex> lock(mMutex);
+        for (auto allocationEntry : mLiveAllocations) {
+            allocationEntry->GetValue().GetAllocator()->DeallocateMemory(
+                std::unique_ptr<MemoryAllocation>(allocationEntry->GetValue().GetAllocation()));
+        }
+
+        mLiveAllocations.clear();
+    }
+
     void DebugResourceAllocator::AddLiveAllocation(ResourceAllocation* allocation) {
         std::lock_guard<std::mutex> lock(mMutex);
 

--- a/src/gpgmm/d3d12/DebugResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/DebugResourceAllocatorD3D12.h
@@ -22,28 +22,16 @@ namespace gpgmm::d3d12 {
 
     class ResourceAllocation;
 
-    /** \brief DebugResourceAllocator tracks "live" allocations so they can be reported if leaked.
-
-    A "live" allocation means the allocation was created (allocated) but not released
-    (de-allocated).
-
-    Use `gpgmm_enable_allocator_leak_checks = true` to always report for leaks.
-    */
+    // DebugResourceAllocator tracks "live" allocations so they can be reported if leaked.
+    // A "live" allocation means the allocation was created (allocated) but not released
+    // (de-allocated).
     class DebugResourceAllocator final : public MemoryAllocator {
       public:
         DebugResourceAllocator() = default;
 
-        /** \brief Add a "live" allocation.
-
-        @param allocation A pointer to a ResourceAllocation to track.
-        */
         void AddLiveAllocation(ResourceAllocation* allocation);
-
-        /** \brief Report "live" allocations.
-
-        Dumps outstanding or "live" allocations.
-        */
         void ReportLiveAllocations() const;
+        void ReleaseLiveAllocationsForTesting();
 
       private:
         void DeallocateMemory(std::unique_ptr<MemoryAllocation> allocation) override;

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -780,9 +780,12 @@ namespace gpgmm::d3d12 {
     ResourceAllocator::~ResourceAllocator() {
         GPGMM_TRACE_EVENT_OBJECT_DESTROY(this);
 
-        // Give the debug allocator the first chance to report leaks.
+        // Give the debug allocator the first chance to report allocation leaks.
+        // If allocation leak exists, report then release them immediately to prevent another leak
+        // check from re-reporting the leaked allocation.
         if (mDebugAllocator) {
             mDebugAllocator->ReportLiveAllocations();
+            mDebugAllocator->ReleaseLiveAllocationsForTesting();
         }
 
         // Destroy allocators in the reverse order they were created so we can record delete events


### PR DESCRIPTION
Fixes bug where CRT leak checker re-reports purposely leaked D3D allocations.