### PR TITLE
Do not block destruction of residency manager.

### DIFF
--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
@@ -879,10 +879,10 @@ namespace gpgmm::d3d12 {
             return;
         }
 
-        const bool success = mBudgetNotificationUpdateEvent->UnregisterAndExit();
-        ASSERT(success);
+        if (!mBudgetNotificationUpdateEvent->UnregisterAndExit()) {
+            gpgmm::WarningLog() << "Unable to unregister from budget events.";
+        }
 
-        mBudgetNotificationUpdateEvent->Wait();
         mBudgetNotificationUpdateEvent = nullptr;
     }
 


### PR DESCRIPTION
Fixes potential bug where destruction of residency manager hangs because a background was terminated before able to shutdown. Since the budget event doesn't need to be handled, it can be safely ignored.