### PR TITLE
Make ALLOCATOR_DESC::Adapter optional.

### DIFF
--- a/include/gpgmm_d3d12.h
+++ b/include/gpgmm_d3d12.h
@@ -779,7 +779,11 @@ namespace gpgmm::d3d12 {
 
         /** \brief Specifies the adapter used by this allocator.
 
-        Required parameter. Use EnumAdapters to get the adapter.
+        The adapter is used to detect for additional device capabilities (by GPU vendor).
+        If the adapter is left unspecified, the capabiltities will not be detected and disabled by
+        CheckFeatureSupport.
+
+        Optional parameter. Use EnumAdapters to get the adapter.
         */
         Microsoft::WRL::ComPtr<IDXGIAdapter> Adapter;
 

--- a/src/mvi/gpgmm_d3d12.cpp
+++ b/src/mvi/gpgmm_d3d12.cpp
@@ -293,7 +293,7 @@ namespace gpgmm::d3d12 {
     HRESULT ResourceAllocator::CreateResourceAllocator(const ALLOCATOR_DESC& allocatorDescriptor,
                                                        IResourceAllocator** ppResourceAllocatorOut,
                                                        IResidencyManager** ppResidencyManagerOut) {
-        if (allocatorDescriptor.Device == nullptr || allocatorDescriptor.Adapter == nullptr) {
+        if (allocatorDescriptor.Device == nullptr) {
             return E_INVALIDARG;
         }
 

--- a/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
+++ b/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
@@ -117,14 +117,15 @@ TEST_F(D3D12ResourceAllocatorTests, CreateResourceAllocator) {
         EXPECT_EQ(resourceAllocator, nullptr);
     }
 
-    // Creating an allocator without an adapter should always fail.
+    // Creating an allocator without the adapter should always succeed.
+    // Should output warning messages that some capabilities were not detected.
     {
         ALLOCATOR_DESC desc = CreateBasicAllocatorDesc();
         desc.Adapter = nullptr;
 
         ComPtr<IResourceAllocator> resourceAllocator;
-        EXPECT_FAILED(CreateResourceAllocator(desc, &resourceAllocator, nullptr));
-        EXPECT_EQ(resourceAllocator, nullptr);
+        EXPECT_SUCCEEDED(CreateResourceAllocator(desc, &resourceAllocator, nullptr));
+        EXPECT_NE(resourceAllocator, nullptr);
     }
 
     // Creating a new allocator using the defaults should always succeed.


### PR DESCRIPTION
Allows use of the resource allocator without DXGIAdapter. This is useful in cases where residency isn't (yet) enabled.