### PR TITLE
Do not continue failing tests in workflow.

### DIFF
--- a/.github/workflows/win_clang_dawn_dbg.yaml
+++ b/.github/workflows/win_clang_dawn_dbg.yaml
@@ -107,7 +107,7 @@ jobs:
       continue-on-error: true
       run: |
         cd test
-        out\Debug\dawn_end2end_tests.exe --backend=d3d12 --exclusive-device-type-preference=discrete,integrated,cpu --enable-backend-validation=partial --gtest_output=json:${{ github.workspace }}\..\test_end2end_tests.json || true
+        out\Debug\dawn_end2end_tests.exe --backend=d3d12 --exclusive-device-type-preference=discrete,integrated,cpu --enable-backend-validation=partial --gtest_output=json:${{ github.workspace }}\..\test_end2end_tests.json
 
     - name: Regression check end2end tests
       run: |

--- a/.github/workflows/win_clang_dawn_rel.yaml
+++ b/.github/workflows/win_clang_dawn_rel.yaml
@@ -119,7 +119,7 @@ jobs:
       continue-on-error: true
       run: |
         cd test
-        out\Release\dawn_end2end_tests.exe --backend=d3d12 --exclusive-device-type-preference=discrete,integrated,cpu --enable-backend-validation=partial --gtest_output=json:${{ github.workspace }}\..\test_end2end_tests.json || true
+        out\Release\dawn_end2end_tests.exe --backend=d3d12 --exclusive-device-type-preference=discrete,integrated,cpu --enable-backend-validation=partial --gtest_output=json:${{ github.workspace }}\..\test_end2end_tests.json
 
     - name: Regression check end2end tests
       run: |

--- a/.github/workflows/win_clang_rel_x64.yaml
+++ b/.github/workflows/win_clang_rel_x64.yaml
@@ -135,13 +135,13 @@ jobs:
       shell: cmd
       run: |
         cd test
-        out\Release\gpgmm_end2end_tests.exe --gtest_filter=-*NoLeak --gtest_output=json:${{ github.workspace }}\..\test_end2end_tests.json || true
+        out\Release\gpgmm_end2end_tests.exe --gtest_filter=-*NoLeak --gtest_output=json:${{ github.workspace }}\..\test_end2end_tests.json
 
     - name: Run gpgmm_unittests (with patch)
       shell: cmd
       run: |
         cd test
-        out\Release\gpgmm_unittests.exe --gtest_output=json:${{ github.workspace }}\..\test_unittests.json || true
+        out\Release\gpgmm_unittests.exe --gtest_output=json:${{ github.workspace }}\..\test_unittests.json
 
     - name: Run gpgmm_capture_replay_tests (with patch)
       shell: cmd


### PR DESCRIPTION
Tests with `|| true` in command cannot fail with error-code returned. This change removes the unnecessary condition from the command so the test fails fast.