### PR TITLE
Minor refactor to prepare for release.

### DIFF
--- a/src/gpgmm/common/BuddyBlockAllocator.h
+++ b/src/gpgmm/common/BuddyBlockAllocator.h
@@ -49,6 +49,7 @@ namespace gpgmm {
         uint64_t ComputeTotalNumOfFreeBlocksForTesting() const;
 
       private:
+        // ObjectBase interface
         const char* GetTypename() const override;
 
         uint32_t ComputeLevelFromBlockSize(uint64_t blockSize) const;

--- a/src/gpgmm/common/BuddyMemoryAllocator.h
+++ b/src/gpgmm/common/BuddyMemoryAllocator.h
@@ -52,6 +52,7 @@ namespace gpgmm {
         MemoryAllocatorStats GetStats() const override;
 
       private:
+        // ObjectBase interface
         const char* GetTypename() const override;
 
         uint64_t GetMemoryIndex(uint64_t offset) const;

--- a/src/gpgmm/common/ConditionalMemoryAllocator.h
+++ b/src/gpgmm/common/ConditionalMemoryAllocator.h
@@ -40,6 +40,7 @@ namespace gpgmm {
         MemoryAllocator* GetSecondAllocatorForTesting() const;
 
       private:
+        // ObjectBase interface
         const char* GetTypename() const override;
 
         std::unique_ptr<MemoryAllocator> mFirstAllocator;

--- a/src/gpgmm/common/DedicatedMemoryAllocator.h
+++ b/src/gpgmm/common/DedicatedMemoryAllocator.h
@@ -36,6 +36,7 @@ namespace gpgmm {
         MemoryAllocatorStats GetStats() const override;
 
       private:
+        // ObjectBase interface
         const char* GetTypename() const override;
     };
 

--- a/src/gpgmm/common/Memory.h
+++ b/src/gpgmm/common/Memory.h
@@ -37,6 +37,7 @@ namespace gpgmm {
         bool RemoveSubAllocationRef();
 
       private:
+        // ObjectBase interface
         const char* GetTypename() const override;
 
         RefCounted mSubAllocationRefs;

--- a/src/gpgmm/common/PooledMemoryAllocator.h
+++ b/src/gpgmm/common/PooledMemoryAllocator.h
@@ -38,6 +38,7 @@ namespace gpgmm {
         uint64_t GetMemoryAlignment() const override;
 
       private:
+        // ObjectBase interface
         const char* GetTypename() const override;
 
         std::unique_ptr<MemoryPoolBase> mPool;

--- a/src/gpgmm/common/SegmentedMemoryAllocator.h
+++ b/src/gpgmm/common/SegmentedMemoryAllocator.h
@@ -48,6 +48,7 @@ namespace gpgmm {
         uint64_t GetSegmentSizeForTesting() const;
 
       private:
+        // ObjectBase interface
         const char* GetTypename() const override;
 
         MemorySegment* GetOrCreateFreeSegment(uint64_t memorySize);

--- a/src/gpgmm/common/SlabBlockAllocator.h
+++ b/src/gpgmm/common/SlabBlockAllocator.h
@@ -53,6 +53,7 @@ namespace gpgmm {
         uint64_t GetBlockCount() const;
 
       private:
+        // ObjectBase interface
         const char* GetTypename() const override;
 
         struct BlockList {

--- a/src/gpgmm/common/SlabMemoryAllocator.h
+++ b/src/gpgmm/common/SlabMemoryAllocator.h
@@ -62,6 +62,7 @@ namespace gpgmm {
         MemoryAllocatorStats GetStats() const override;
 
       private:
+        // ObjectBase interface
         const char* GetTypename() const override;
 
         uint64_t ComputeSlabSize(uint64_t requestSize,
@@ -130,6 +131,7 @@ namespace gpgmm {
         uint64_t GetMemorySize() const override;
 
       private:
+        // ObjectBase interface
         const char* GetTypename() const override;
 
         class SlabAllocatorCacheEntry : public NonCopyable {

--- a/src/gpgmm/d3d12/DebugResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/DebugResourceAllocatorD3D12.h
@@ -34,9 +34,10 @@ namespace gpgmm::d3d12 {
         void ReleaseLiveAllocationsForTesting();
 
       private:
-        void DeallocateMemory(std::unique_ptr<MemoryAllocation> allocation) override;
-
+        // ObjectBase interface
         const char* GetTypename() const override;
+
+        void DeallocateMemory(std::unique_ptr<MemoryAllocation> allocation) override;
 
         class ResourceAllocationEntry {
           public:

--- a/src/gpgmm/d3d12/HeapD3D12.h
+++ b/src/gpgmm/d3d12/HeapD3D12.h
@@ -59,8 +59,10 @@ namespace gpgmm::d3d12 {
              const HEAP_DESC& descriptor,
              bool isResidencyDisabled);
 
-        HRESULT SetDebugNameImpl(LPCWSTR name) override;
+        // ObjectBase interface
         const char* GetTypename() const override;
+
+        HRESULT SetDebugNameImpl(LPCWSTR name) override;
         DXGI_MEMORY_SEGMENT_GROUP GetMemorySegmentGroup() const;
 
         // The residency manager must know the last fence value that any portion of the pageable was

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -1255,7 +1255,7 @@ namespace gpgmm::d3d12 {
                              (allocationDescriptor.Flags & ALLOCATION_FLAG_DISABLE_RESIDENCY)
                                  ? nullptr
                                  : mResidencyManager.Get(),
-                             ImportResourceCallbackContext::CreateHeap,
+                             ImportResourceCallbackContext::GetHeap,
                              &importResourceCallbackContext, &resourceHeap));
 
         const uint64_t& allocationSize = resourceInfo.SizeInBytes;
@@ -1481,12 +1481,9 @@ namespace gpgmm::d3d12 {
     }
 
     // static
-    HRESULT ImportResourceCallbackContext::CreateHeap(void* pContext,
+    HRESULT ImportResourceCallbackContext::GetHeap(void* pContext,
                                                       ID3D12Pageable** ppPageableOut) {
-        ImportResourceCallbackContext* importResourceCallbackContext =
-            static_cast<ImportResourceCallbackContext*>(pContext);
-
-        return importResourceCallbackContext->GetHeap(ppPageableOut);
+        return static_cast<ImportResourceCallbackContext*>(pContext)->GetHeap(ppPageableOut);
     }
 
     HRESULT ImportResourceCallbackContext::GetHeap(ID3D12Pageable** ppPageableOut) {

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -38,7 +38,7 @@ namespace gpgmm::d3d12 {
     class ImportResourceCallbackContext {
       public:
         ImportResourceCallbackContext(ComPtr<ID3D12Resource> resource);
-        static HRESULT CreateHeap(void* pContext, ID3D12Pageable** ppPageableOut);
+        static HRESULT GetHeap(void* pContext, ID3D12Pageable** ppPageableOut);
 
       private:
         HRESULT GetHeap(ID3D12Pageable** ppPageableOut);
@@ -101,11 +101,12 @@ namespace gpgmm::d3d12 {
 
         DEFINE_IUNKNOWNIMPL_OVERRIDES()
 
-        const char* GetTypename() const override;
-
       private:
         friend BufferAllocator;
         friend ResourceAllocation;
+
+        // ObjectBase interface
+        const char* GetTypename() const override;
 
         HRESULT CreateResourceInternal(const ALLOCATION_DESC& allocationDescriptor,
                                        const D3D12_RESOURCE_DESC& resourceDescriptor,

--- a/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.cpp
@@ -26,6 +26,8 @@
 
 namespace gpgmm::d3d12 {
 
+    static const wchar_t* kResourceHeapDebugName = L"GPGMM Resource Heap";
+
     ResourceHeapAllocator::ResourceHeapAllocator(ResidencyManager* residencyManager,
                                                  ID3D12Device* device,
                                                  D3D12_HEAP_PROPERTIES heapProperties,
@@ -51,8 +53,8 @@ namespace gpgmm::d3d12 {
         // alignment to avoid wasting bytes.
         // https://docs.microsoft.com/en-us/windows/win32/api/d3d12/ns-d3d12-d3d12_HEAP_INFO
         resourceHeapDesc.SizeInBytes = AlignTo(request.SizeInBytes, request.Alignment);
-        resourceHeapDesc.Alignment = request.Alignment;        
-        resourceHeapDesc.DebugName = L"Resource heap";
+        resourceHeapDesc.Alignment = request.Alignment;
+        resourceHeapDesc.DebugName = kResourceHeapDebugName;
 
         const bool isResidencyEnabled = (mResidencyManager != nullptr);
         resourceHeapDesc.Flags |= GetHeapFlags(mHeapFlags, isResidencyEnabled);

--- a/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.h
@@ -50,6 +50,7 @@ namespace gpgmm::d3d12 {
         void DeallocateMemory(std::unique_ptr<MemoryAllocation> allocation) override;
 
       private:
+        // ObjectBase interface
         const char* GetTypename() const override;
 
         ResidencyManager* const mResidencyManager;


### PR DESCRIPTION
* Move GetTypename scope to private.
* Move resource heap name into static section.
* Rename ImportResourceCallbackContext::CreateHeap to ImportResourceCallbackContext::GetHeap.
* Nothing gets created during import so the method name should reflect that.