### PR TITLE
Fix D3D12_HEAP_FLAG_CREATE_NOT_RESIDENT from being never supported.

### DIFF
--- a/src/gpgmm/d3d12/CapsD3D12.cpp
+++ b/src/gpgmm/d3d12/CapsD3D12.cpp
@@ -60,7 +60,8 @@ namespace gpgmm::d3d12 {
         *createHeapNotResidencySupported = false;
 
         // Only Windows 10 Build 20348 and later support creating non-resident heaps.
-#ifdef D3D12_FEATURE_D3D12_OPTIONS7
+        // ID3D12Device8 is required to be defined in Windows 10 Build 20348 or newer builds.
+#ifdef __ID3D12Device8_FWD_DEFINED__
         D3D12_FEATURE_DATA_D3D12_OPTIONS7 options7 = {};
         if (SUCCEEDED(device->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS7, &options7,
                                                   sizeof(options7)))) {

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
@@ -919,9 +919,12 @@ namespace gpgmm::d3d12 {
         gpgmm::DebugLog() << GetMemorySegmentName(segmentGroup, IsUMA()) << " GPU memory segment:";
         gpgmm::DebugLog() << "\tBudget: " << GPGMM_BYTES_TO_MB(info->Budget) << " MBs ("
                           << GPGMM_BYTES_TO_MB(info->CurrentUsage) << " used).";
-        gpgmm::DebugLog() << "\tReserved: " << GPGMM_BYTES_TO_MB(info->CurrentReservation)
-                          << " MBs (" << GPGMM_BYTES_TO_MB(info->AvailableForReservation)
-                          << " available).";
+
+        if (info->CurrentReservation == 0) {
+            gpgmm::DebugLog() << "\tReserved: " << GPGMM_BYTES_TO_MB(info->CurrentReservation)
+                              << " MBs (" << GPGMM_BYTES_TO_MB(info->AvailableForReservation)
+                              << " available).";
+        }
     }
 
 }  // namespace gpgmm::d3d12

--- a/src/gpgmm/d3d12/d3d12_platform.h
+++ b/src/gpgmm/d3d12/d3d12_platform.h
@@ -24,9 +24,7 @@
 // D3D12.h versions.
 // Only once ALL builds upgrade to the newer D3D12.h version, can these defines be safely
 // removed.
-#ifndef D3D12_FEATURE_D3D12_OPTIONS7
-#    define D3D12_HEAP_FLAG_CREATE_NOT_RESIDENT static_cast<D3D12_HEAP_FLAGS>(0x800)
-#endif
+#define D3D12_HEAP_FLAG_CREATE_NOT_RESIDENT static_cast<D3D12_HEAP_FLAGS>(0x800)
 
 using Microsoft::WRL::ComPtr;
 


### PR DESCRIPTION
D3D12_HEAP_FLAG_CREATE_NOT_RESIDENT was never being set because the required type couldn't be detected by the pre-processor.  This fix removes the guards and just assumes the newer D3D12.h, with the required types, always exists. If the version of D3D12.h is too old, it may not build, however.