### PR TITLE
Fix use-after-free with CreateCommittedResourceCallbackContext.

### DIFF
--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -49,7 +49,6 @@ namespace gpgmm::d3d12 {
     class CreateCommittedResourceCallbackContext {
       public:
         CreateCommittedResourceCallbackContext(ID3D12Device* device,
-                                               ComPtr<ID3D12Resource> resource,
                                                D3D12_HEAP_PROPERTIES* heapProperties,
                                                D3D12_HEAP_FLAGS heapFlags,
                                                const D3D12_RESOURCE_DESC* resourceDescriptor,
@@ -66,7 +65,6 @@ namespace gpgmm::d3d12 {
         D3D12_RESOURCE_STATES mInitialResourceState;
         D3D12_HEAP_FLAGS mHeapFlags;
         D3D12_HEAP_PROPERTIES* mHeapProperties;
-        ComPtr<ID3D12Resource> mResource;
         const D3D12_RESOURCE_DESC* mResourceDescriptor;
     };
 

--- a/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
+++ b/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
@@ -889,6 +889,15 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferAlwaysCommitted) {
     ComPtr<IHeap> resourceHeap = allocation->GetMemory();
     ASSERT_NE(resourceHeap, nullptr);
 
+    EXPECT_NE(allocation->GetResource(), nullptr);
+
+    ComPtr<ID3D12Pageable> resourceAsPageable;
+    ASSERT_SUCCEEDED(allocation->GetResource()->QueryInterface(IID_PPV_ARGS(&resourceAsPageable)));
+
+    ComPtr<ID3D12Pageable> implicitHeap;
+    ASSERT_SUCCEEDED(resourceHeap.As(&implicitHeap));
+    EXPECT_EQ(resourceAsPageable, implicitHeap);
+
     ComPtr<ID3D12Heap> heap;
     ASSERT_FAILED(resourceHeap.As(&heap));
 


### PR DESCRIPTION
CreateCommittedResourceCallbackContext wasn't saving-out the resource for the new resource allocation so any accesses would cause corruption.