### PR TITLE
Handle nullptr checks for API calls consistently.

### DIFF
--- a/src/gpgmm/d3d12/ErrorD3D12.h
+++ b/src/gpgmm/d3d12/ErrorD3D12.h
@@ -22,6 +22,15 @@
 
 namespace gpgmm::d3d12 {
 
+#define ReturnIfNullptr(expr)                  \
+    {                                          \
+        if (GPGMM_UNLIKELY(expr == nullptr)) { \
+            return E_POINTER;                  \
+        }                                      \
+    }                                          \
+    for (;;)                                   \
+    break
+
 #define ReturnIfFailed(expr)                                           \
     {                                                                  \
         HRESULT hr = expr;                                             \

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
@@ -162,9 +162,8 @@ namespace gpgmm::d3d12 {
     // static
     HRESULT ResidencyManager::CreateResidencyManager(const RESIDENCY_DESC& descriptor,
                                                      IResidencyManager** ppResidencyManagerOut) {
-        if (descriptor.Adapter == nullptr || descriptor.Device == nullptr) {
-            return E_INVALIDARG;
-        }
+        ReturnIfNullptr(descriptor.Adapter);
+        ReturnIfNullptr(descriptor.Device);
 
         std::unique_ptr<Caps> caps;
         {
@@ -311,12 +310,12 @@ namespace gpgmm::d3d12 {
 
     // Increments number of locks on a heap to ensure the heap remains resident.
     HRESULT ResidencyManager::LockHeap(IHeap* pHeap) {
+        ReturnIfNullptr(pHeap);
+
         std::lock_guard<std::mutex> lock(mMutex);
 
         Heap* heap = static_cast<Heap*>(pHeap);
-        if (heap == nullptr) {
-            return E_INVALIDARG;
-        }
+        ASSERT(heap != nullptr);
 
         if (!heap->IsInList() && !heap->IsResidencyLocked()) {
             ComPtr<ID3D12Pageable> pageable;
@@ -351,11 +350,11 @@ namespace gpgmm::d3d12 {
     // Decrements number of locks on a heap. When the number of locks becomes zero, the heap is
     // inserted into the LRU cache and becomes eligible for eviction.
     HRESULT ResidencyManager::UnlockHeap(IHeap* pHeap) {
+        ReturnIfNullptr(pHeap);
+
         std::lock_guard<std::mutex> lock(mMutex);
         Heap* heap = static_cast<Heap*>(pHeap);
-        if (heap == nullptr) {
-            return E_INVALIDARG;
-        }
+        ASSERT(heap != nullptr);
 
         if (!heap->IsResidencyLocked()) {
             return E_FAIL;

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -381,9 +381,7 @@ namespace gpgmm::d3d12 {
     HRESULT ResourceAllocator::CreateResourceAllocator(const ALLOCATOR_DESC& allocatorDescriptor,
                                                        IResourceAllocator** ppResourceAllocatorOut,
                                                        IResidencyManager** ppResidencyManagerOut) {
-        if (allocatorDescriptor.Device == nullptr) {
-            return E_INVALIDARG;
-        }
+        ReturnIfNullptr(allocatorDescriptor.Device);
 
         ComPtr<IResidencyManager> residencyManager;
         if (ppResidencyManagerOut != nullptr) {
@@ -430,9 +428,7 @@ namespace gpgmm::d3d12 {
         const ALLOCATOR_DESC& allocatorDescriptor,
         IResidencyManager* pResidencyManager,
         IResourceAllocator** ppResourceAllocatorOut) {
-        if (allocatorDescriptor.Device == nullptr) {
-            return E_INVALIDARG;
-        }
+        ReturnIfNullptr(allocatorDescriptor.Device);
 
         std::unique_ptr<Caps> caps;
         {
@@ -1234,11 +1230,9 @@ namespace gpgmm::d3d12 {
     HRESULT ResourceAllocator::CreateResource(const ALLOCATION_DESC& allocationDescriptor,
                                               ID3D12Resource* pCommittedResource,
                                               IResourceAllocation** ppResourceAllocationOut) {
-        std::lock_guard<std::mutex> lock(mMutex);
+        ReturnIfNullptr(pCommittedResource);
 
-        if (pCommittedResource == nullptr) {
-            return E_INVALIDARG;
-        }
+        std::lock_guard<std::mutex> lock(mMutex);
 
         ComPtr<ID3D12Resource> resource(pCommittedResource);
 


### PR DESCRIPTION
Returns E_POINTER instead of INVALID_ARG whenever nullptr is specified, but required, to API call.