### PR TITLE
Add flag HEAP_FLAG_ALWAYS_IN_RESIDENCY.

### DIFF
--- a/include/gpgmm_d3d12.h
+++ b/include/gpgmm_d3d12.h
@@ -134,8 +134,18 @@ namespace gpgmm::d3d12 {
         HEAP_FLAG_NONE = 0x0,
 
         /** \brief Requires the heap to be created in budget.
-         */
+
+        This flags allows the heap to be tracked for residency but not made resident.
+        */
         HEAP_FLAG_ALWAYS_IN_BUDGET = 0x1,
+
+        /** \brief Requires the heap to be tracked for residency.
+
+        This flag is equivelent to calling LockHeap then UnlockHeap after
+        creation. The flag only has effect when the heap's residency status
+        cannot be determined.
+        */
+        HEAP_FLAG_ALWAYS_IN_RESIDENCY = 0x2,
     };
 
     DEFINE_ENUM_FLAG_OPERATORS(HEAP_FLAGS)

--- a/src/gpgmm/d3d12/HeapD3D12.cpp
+++ b/src/gpgmm/d3d12/HeapD3D12.cpp
@@ -122,6 +122,11 @@ namespace gpgmm::d3d12 {
             // residency cache.
             if (heap->mState != RESIDENCY_STATUS_UNKNOWN) {
                 ReturnIfFailed(residencyManager->InsertHeap(heap.get()));
+            } else {
+                if (descriptor.Flags & HEAP_FLAG_ALWAYS_IN_RESIDENCY) {
+                    ReturnIfFailed(residencyManager->LockHeap(heap.get()));
+                    ReturnIfFailed(residencyManager->UnlockHeap(heap.get()));
+                }
             }
         }
 


### PR DESCRIPTION
Allows non-resource heaps to be tracked + resident upon creation.