### PR TITLE
Disable custom heaps when UMA is not supported.

### DIFF
--- a/include/gpgmm_d3d12.h
+++ b/include/gpgmm_d3d12.h
@@ -684,12 +684,13 @@ namespace gpgmm::d3d12 {
         */
         ALLOCATOR_FLAG_ALWAYS_ON_DEMAND = 0x8,
 
-        /** \brief Disables use of D3D12_HEAP_TYPE_CUSTOM.
+        /** \brief Disables using D3D12_HEAP_TYPE_CUSTOM-equivalent upload heap everywhere on UMA
+        GPUs.
 
-        Used to workaround issues when a custom-equivalent heap is not considered equal to
-        the corresponding heap type.
+        Used to workaround issues when custom heaps are not being recongized as expected or driver
+        bugs related to using a single memory pool.
         */
-        ALLOCATOR_FLAG_DISABLE_CUSTOM_HEAPS = 0x10,
+        ALLOCATOR_FLAG_DISABLE_UNIFIED_MEMORY = 0x10,
 
         /** \brief Report leaks of resource allocations.
 
@@ -974,7 +975,7 @@ namespace gpgmm::d3d12 {
         as well as frequent CPU reads would beneifit from D3D12_HEAP_TYPE_READBACK since the CPU
         properties are always write-combined.
 
-        If ALLOCATOR_FLAG_DISABLE_CUSTOM_HEAPS was specified, heap type was
+        If ALLOCATOR_FLAG_DISABLE_UNIFIED_MEMORY was specified, heap type was
         D3D12_HEAP_TYPE_READBACK, or the adapter is not cache-coherent UMA, this flag has no effect.
         */
         ALLOCATION_FLAG_ALWAYS_ATTRIBUTE_HEAPS = 0x20,

--- a/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
+++ b/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
@@ -714,9 +714,9 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferUMA) {
     EXPECT_EQ(resourceAllocator->GetStats().FreeMemoryUsage, kBufferOf4MBAllocationSize * 2);
 }
 
-TEST_F(D3D12ResourceAllocatorTests, CreateBufferDisableCustomHeaps) {
+TEST_F(D3D12ResourceAllocatorTests, CreateBufferDisableUMA) {
     ALLOCATOR_DESC allocatorDesc = CreateBasicAllocatorDesc();
-    allocatorDesc.Flags |= ALLOCATOR_FLAG_DISABLE_CUSTOM_HEAPS;
+    allocatorDesc.Flags |= ALLOCATOR_FLAG_DISABLE_UNIFIED_MEMORY;
 
     ComPtr<IResourceAllocator> resourceAllocator;
     ASSERT_SUCCEEDED(CreateResourceAllocator(allocatorDesc, &resourceAllocator, nullptr));


### PR DESCRIPTION
Prevents resource allocators from creating custom heaps when cache-coherent UMA is not supported.