### PR TITLE
Disable thread write tests for 32-bit builds.

### DIFF
--- a/src/gpgmm/utils/Compiler.h
+++ b/src/gpgmm/utils/Compiler.h
@@ -29,6 +29,17 @@
 //  Both GPGMM_UNUSED_FUNC and GPGMM_DECLARE_UNUSED may be necessary, e.g. to suppress clang's
 //  unneeded-internal-declaration warning.
 
+// For 32-bit detection. Copied from vulkan_core.h.
+#ifndef GPGMM_COMPILER_IS_64_BIT
+#    if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__)) || \
+        defined(_M_X64) || defined(__ia64) || defined(_M_IA64) || defined(__aarch64__) ||       \
+        defined(__powerpc64__)
+#        define GPGMM_COMPILER_IS_64_BIT 1
+#    else
+#        define GPGMM_COMPILER_IS_64_BIT 0
+#    endif
+#endif
+
 // Clang and GCC, check for __clang__ too to catch clang-cl masquarading as MSVC
 #if defined(__GNUC__) || defined(__clang__)
 #    if defined(__clang__)

--- a/src/tests/unittests/EventTraceWriterTests.cpp
+++ b/src/tests/unittests/EventTraceWriterTests.cpp
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gtest/gtest.h>
-
 #include "gpgmm/common/TraceEvent.h"
+#include "tests/GPGMMTest.h"
 
 #include <thread>
 #include <vector>
@@ -35,6 +34,11 @@ class EventTraceWriterTests : public testing::Test {
 };
 
 TEST_F(EventTraceWriterTests, SingleThreadWrites) {
+    // TODO: Figure out why win_clang_[rel|dbg]_x86 builder fails.
+#ifndef GPGMM_COMPILER_IS_64_BIT
+    GPGMM_SKIP_TEST_IF(true);
+#endif
+
     constexpr uint32_t kEventCount = 64u;
     for (size_t i = 0; i < kEventCount; i++) {
         TRACE_EVENT_INSTANT0(TraceEventCategory::kDefault, "InstantEvent");
@@ -45,6 +49,11 @@ TEST_F(EventTraceWriterTests, SingleThreadWrites) {
 }
 
 TEST_F(EventTraceWriterTests, MultiThreadWrites) {
+    // TODO: Figure out why win_clang_[rel|dbg]_x86 builder fails.
+#ifndef GPGMM_COMPILER_IS_64_BIT
+    GPGMM_SKIP_TEST_IF(true);
+#endif
+
     constexpr uint32_t kThreadCount = 64u;
     std::vector<std::thread> threads(kThreadCount);
     for (size_t threadIdx = 0; threadIdx < threads.size(); threadIdx++) {


### PR DESCRIPTION
Need to figure out why x86 builders don't work with thread writer tests. Example, https://github.com/intel/GPGMM/actions/runs/3988723505/jobs/6840256571.