### PR TITLE
Allow manual heap status tracking.

### DIFF
--- a/include/gpgmm_d3d12.h
+++ b/include/gpgmm_d3d12.h
@@ -201,6 +201,16 @@ namespace gpgmm::d3d12 {
         \return A HEAP_INFO struct containing the information.
         */
         virtual HEAP_INFO GetInfo() const = 0;
+
+        /** \brief Specify the residency status of the heap.
+
+        Allows applications to explicitly call MakeResident/Evict on a heap without using a
+        residency manager. Use cautiously, updating the residency status to be in a mismatched state
+        could led to errors.
+
+        @param newStatus The new RESIDENCY_STATUS the heap should be in.
+        */
+        virtual HRESULT SetResidencyState(RESIDENCY_STATUS newStatus) = 0;
     };
 
     /** \brief  Create a heap managed by GPGMM.

--- a/src/gpgmm/d3d12/HeapD3D12.cpp
+++ b/src/gpgmm/d3d12/HeapD3D12.cpp
@@ -221,8 +221,9 @@ namespace gpgmm::d3d12 {
         return Unknown::Release();
     }
 
-    void Heap::SetResidencyState(RESIDENCY_STATUS newStatus) {
+    HRESULT Heap::SetResidencyState(RESIDENCY_STATUS newStatus) {
         mState = newStatus;
+        return S_OK;
     }
 
     LPCWSTR Heap::GetDebugName() const {

--- a/src/gpgmm/d3d12/HeapD3D12.h
+++ b/src/gpgmm/d3d12/HeapD3D12.h
@@ -42,6 +42,7 @@ namespace gpgmm::d3d12 {
 
         // IHeap interface
         HEAP_INFO GetInfo() const override;
+        HRESULT SetResidencyState(RESIDENCY_STATUS newStatus) override;
 
         // IUnknown interface
         HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject) override;
@@ -70,8 +71,6 @@ namespace gpgmm::d3d12 {
         // least until that fence has completed.
         uint64_t GetLastUsedFenceValue() const;
         void SetLastUsedFenceValue(uint64_t fenceValue);
-
-        void SetResidencyState(RESIDENCY_STATUS newStatus);
 
         bool IsResidencyLocked() const;
 

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
@@ -322,7 +322,7 @@ namespace gpgmm::d3d12 {
             ReturnIfFailed(heap->QueryInterface(IID_PPV_ARGS(&pageable)));
             ReturnIfFailed(MakeResident(heap->GetMemorySegmentGroup(), heap->GetSize(), 1,
                                         pageable.GetAddressOf()));
-            heap->SetResidencyState(RESIDENCY_STATUS_CURRENT_RESIDENT);
+            ReturnIfFailed(heap->SetResidencyState(RESIDENCY_STATUS_CURRENT_RESIDENT));
 
             // Untracked heaps, created not resident, are not already attributed toward residency
             // usage because they are not in the residency cache.
@@ -655,7 +655,7 @@ namespace gpgmm::d3d12 {
             ReturnIfFailed(mResidencyFence->WaitFor(lastUsedFenceValue));
 
             heap->RemoveFromList();
-            heap->SetResidencyState(RESIDENCY_STATUS_PENDING_RESIDENCY);
+            ReturnIfFailed(heap->SetResidencyState(RESIDENCY_STATUS_PENDING_RESIDENCY));
 
             bytesEvicted += heap->GetSize();
 
@@ -786,7 +786,7 @@ namespace gpgmm::d3d12 {
         // Once MakeResident succeeds, we must assume the heaps are resident since D3D12 provides
         // no way of knowing for certain.
         for (Heap* heap : heapsToMakeResident) {
-            heap->SetResidencyState(RESIDENCY_STATUS_CURRENT_RESIDENT);
+            ReturnIfFailed(heap->SetResidencyState(RESIDENCY_STATUS_CURRENT_RESIDENT));
         }
 
         GPGMM_TRACE_EVENT_METRIC(

--- a/src/mvi/gpgmm_d3d12.cpp
+++ b/src/mvi/gpgmm_d3d12.cpp
@@ -98,6 +98,10 @@ namespace gpgmm::d3d12 {
         return {GetSize(), GetAlignment(), false, false, RESIDENCY_STATUS_UNKNOWN};
     }
 
+    HRESULT Heap::SetResidencyState(RESIDENCY_STATUS newStatus) {
+        return E_NOTIMPL;
+    }
+
     HRESULT STDMETHODCALLTYPE Heap::QueryInterface(REFIID riid, void** ppvObject) {
         return mPageable->QueryInterface(riid, ppvObject);
     }

--- a/src/mvi/gpgmm_d3d12.h
+++ b/src/mvi/gpgmm_d3d12.h
@@ -70,6 +70,7 @@ namespace gpgmm::d3d12 {
 
         // IHeap interface
         HEAP_INFO GetInfo() const override;
+        HRESULT SetResidencyState(RESIDENCY_STATUS newStatus) override;
 
         // IUnknown interface
         HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject) override;


### PR DESCRIPTION
Exposes IHeap::SetResidencyState to allow more manual heap state tracking.