### PR TITLE
Re-do manual heap tracking by moving into ResidencyManager.

### DIFF
--- a/include/gpgmm_d3d12.h
+++ b/include/gpgmm_d3d12.h
@@ -495,6 +495,19 @@ namespace gpgmm::d3d12 {
         virtual HRESULT QueryVideoMemoryInfo(const DXGI_MEMORY_SEGMENT_GROUP& memorySegmentGroup,
                                              DXGI_QUERY_VIDEO_MEMORY_INFO* pVideoMemoryInfoOut) = 0;
 
+        /** \brief  Update the residency status of a heap.
+
+        Allows the application to explicitly MakeResident/Evict without using a residency manager
+        operation. This is useful should the application already perform some residency management
+        but also want to use a residency manager. It is the application developers responsibility to
+        ensure MakeResident/Evict will be called before updating the residency status to
+        CURRENT_RESIDENT/PENDING, respectively.
+
+        @param pHeap  A pointer to the heap being updated.
+        @param state The RESIDENCY_STATUS enum of the new status.
+        */
+        virtual HRESULT SetResidencyState(IHeap * pHeap, const RESIDENCY_STATUS& state) = 0;
+
         /** \brief  Return the current residency manager usage.
 
         \return A RESIDENCY_STATS struct.

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
@@ -950,4 +950,33 @@ namespace gpgmm::d3d12 {
         }
     }
 
+    HRESULT ResidencyManager::SetResidencyState(IHeap* pHeap, const RESIDENCY_STATUS& state) {
+        ReturnIfNullptr(pHeap);
+
+        Heap* heap = static_cast<Heap*>(pHeap);
+        if (heap->GetInfo().IsLocked) {
+            gpgmm::ErrorLog() << "Heap residency cannot be updated because it was locked. "
+                                 "Please unlock the heap before updating the state.";
+            return E_FAIL;
+        }
+
+        if (!heap->GetInfo().IsCachedForResidency) {
+            gpgmm::ErrorLog() << "Heap residency cannot be updated because no residency "
+                                 "manager was specified upon creation. The heap must be created "
+                                 "using a residency manager to update the residency status.";
+            return E_FAIL;
+        }
+
+        const RESIDENCY_STATUS oldState = heap->GetInfo().Status;
+        if (state == RESIDENCY_STATUS_UNKNOWN && oldState != RESIDENCY_STATUS_UNKNOWN) {
+            gpgmm::ErrorLog() << "Heap residency cannot be unknown when previously known by the "
+                                 "residency manager. "
+                                 "Check the status before updating the state.";
+            return E_FAIL;
+        }
+
+        heap->SetResidencyState(state);
+        return S_OK;
+    }
+
 }  // namespace gpgmm::d3d12

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.h
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.h
@@ -60,6 +60,7 @@ namespace gpgmm::d3d12 {
 
         HRESULT QueryVideoMemoryInfo(const DXGI_MEMORY_SEGMENT_GROUP& memorySegmentGroup,
                                      DXGI_QUERY_VIDEO_MEMORY_INFO* pVideoMemoryInfoOut) override;
+        HRESULT SetResidencyState(IHeap* pHeap, const RESIDENCY_STATUS& state) override;
 
         RESIDENCY_STATS GetStats() const override;
 

--- a/src/mvi/gpgmm_d3d12.cpp
+++ b/src/mvi/gpgmm_d3d12.cpp
@@ -197,6 +197,10 @@ namespace gpgmm::d3d12 {
         return S_OK;
     }
 
+    HRESULT ResidencyManager::SetResidencyState(IHeap* pHeap, const RESIDENCY_STATUS& state) {
+        return S_OK;
+    }
+
     RESIDENCY_STATS ResidencyManager::GetStats() const {
         return {0, 0};
     }

--- a/src/mvi/gpgmm_d3d12.h
+++ b/src/mvi/gpgmm_d3d12.h
@@ -120,6 +120,7 @@ namespace gpgmm::d3d12 {
                                           uint64_t* pCurrentReservationOut = nullptr) override;
         HRESULT QueryVideoMemoryInfo(const DXGI_MEMORY_SEGMENT_GROUP& memorySegmentGroup,
                                      DXGI_QUERY_VIDEO_MEMORY_INFO* pVideoMemoryInfoOut) override;
+        HRESULT SetResidencyState(IHeap* pHeap, const RESIDENCY_STATUS& state) override;
         RESIDENCY_STATS GetStats() const override;
 
         // IUnknown interface


### PR DESCRIPTION
Avoids allowing heap objects becoming modifiable outside the residency manager.