### PR TITLE
Add device leak checks to missing workflows.

### DIFF
--- a/.github/workflows/win_clang_dbg_x64.yaml
+++ b/.github/workflows/win_clang_dbg_x64.yaml
@@ -61,12 +61,6 @@ jobs:
         cd base
         ninja -C out\Debug
 
-    - name: Run gpgmm_end2end_tests leak tests
-      shell: cmd
-      run: |
-        cd base
-        out\Debug\gpgmm_end2end_tests.exe --gtest_filter=*NoLeak
-
     - name: Run gpgmm_end2end_tests
       shell: cmd
       run: |
@@ -130,6 +124,12 @@ jobs:
         set "DEPOT_TOOLS_WIN_TOOLCHAIN=0"
         cd test
         ninja -C out\Debug
+
+    - name: Run gpgmm_end2end_tests leak tests (with patch)
+      shell: cmd
+      run: |
+        cd test
+        out\Debug\gpgmm_end2end_tests.exe --gtest_filter=*NoLeak --check-device-leaks 2>&1
 
     - name: Run gpgmm_end2end_tests (with patch)
       shell: cmd

--- a/.github/workflows/win_clang_dbg_x86.yaml
+++ b/.github/workflows/win_clang_dbg_x86.yaml
@@ -61,12 +61,6 @@ jobs:
         cd base
         ninja -C out\Debug
 
-    - name: Run gpgmm_end2end_tests leak tests
-      shell: cmd
-      run: |
-        cd base
-        out\Debug\gpgmm_end2end_tests.exe --gtest_filter=*NoLeak
-
     - name: Run gpgmm_end2end_tests
       shell: cmd
       run: |
@@ -130,6 +124,12 @@ jobs:
         set "DEPOT_TOOLS_WIN_TOOLCHAIN=0"
         cd test
         ninja -C out\Debug
+
+    - name: Run gpgmm_end2end_tests leak tests (with patch)
+      shell: cmd
+      run: |
+        cd test
+        out\Debug\gpgmm_end2end_tests.exe --gtest_filter=*NoLeak --check-device-leaks 2>&1
 
     - name: Run gpgmm_end2end_tests (with patch)
       shell: cmd

--- a/.github/workflows/win_clang_rel_x64.yaml
+++ b/.github/workflows/win_clang_rel_x64.yaml
@@ -61,11 +61,6 @@ jobs:
         cd base
         ninja -C out\Release
 
-    - name: Run gpgmm_end2end_tests leak tests
-      shell: cmd
-      run: |
-        cd base
-        out\Release\gpgmm_end2end_tests.exe --gtest_filter=*NoLeak
 
     - name: Run gpgmm_end2end_tests
       shell: cmd
@@ -130,6 +125,12 @@ jobs:
         set "DEPOT_TOOLS_WIN_TOOLCHAIN=0"
         cd test
         ninja -C out\Release
+
+    - name: Run gpgmm_end2end_tests leak tests (with patch)
+      shell: cmd
+      run: |
+        cd test
+        out\Release\gpgmm_end2end_tests.exe --gtest_filter=*NoLeak --check-device-leaks 2>&1
 
     - name: Run gpgmm_end2end_tests (with patch)
       shell: cmd

--- a/.github/workflows/win_clang_rel_x86.yaml
+++ b/.github/workflows/win_clang_rel_x86.yaml
@@ -61,11 +61,6 @@ jobs:
         cd base
         ninja -C out\Release
 
-    - name: Run gpgmm_end2end_tests leak tests
-      shell: cmd
-      run: |
-        cd base
-        out\Release\gpgmm_end2end_tests.exe --gtest_filter=*NoLeak
 
     - name: Run gpgmm_end2end_tests
       shell: cmd
@@ -130,6 +125,12 @@ jobs:
         set "DEPOT_TOOLS_WIN_TOOLCHAIN=0"
         cd test
         ninja -C out\Release
+
+    - name: Run gpgmm_end2end_tests leak tests (with patch)
+      shell: cmd
+      run: |
+        cd test
+        out\Release\gpgmm_end2end_tests.exe --gtest_filter=*NoLeak --check-device-leaks 2>&1
 
     - name: Run gpgmm_end2end_tests (with patch)
       shell: cmd

--- a/.github/workflows/win_msvc_dbg_x64.yaml
+++ b/.github/workflows/win_msvc_dbg_x64.yaml
@@ -80,13 +80,13 @@ jobs:
       shell: cmd
       run: |
         cd test
-        out\Debug\gpgmm_end2end_tests.exe --gtest_filter=*NoLeak 2>&1
+        out\Debug\gpgmm_end2end_tests.exe --gtest_filter=*NoLeak --check-device-leaks 2>&1
 
     - name: Run gpgmm_end2end_tests (with patch)
       shell: cmd
       run: |
         cd test
-        out\Debug\gpgmm_end2end_tests.exe --gtest_filter=-*NoLeak 2>&1
+        out\Debug\gpgmm_end2end_tests.exe --gtest_filter=-*NoLeak --check-device-leaks 2>&1
 
     - name: Run gpgmm_unittests (with patch)
       shell: cmd
@@ -98,4 +98,4 @@ jobs:
       shell: cmd
       run: |
         cd test
-        out\Debug\gpgmm_capture_replay_tests.exe --log-level=DEBUG 2>&1
+        out\Debug\gpgmm_capture_replay_tests.exe --log-level=DEBUG --check-device-leaks 2>&1

--- a/.github/workflows/win_msvc_dbg_x64_cmake.yaml
+++ b/.github/workflows/win_msvc_dbg_x64_cmake.yaml
@@ -76,13 +76,13 @@ jobs:
       shell: cmd
       run: |
         cd test
-        bin\Debug\gpgmm_end2end_tests.exe --gtest_filter=*NoLeak 2>&1
+        bin\Debug\gpgmm_end2end_tests.exe --gtest_filter=*NoLeak --check-device-leaks 2>&1
 
     - name: Run gpgmm_end2end_tests (with patch)
       shell: cmd
       run: |
         cd test
-        bin\Debug\gpgmm_end2end_tests.exe --gtest_filter=-*NoLeak 2>&1
+        bin\Debug\gpgmm_end2end_tests.exe --gtest_filter=-*NoLeak --check-device-leaks 2>&1
 
     - name: Run gpgmm_unittests (with patch)
       shell: cmd
@@ -94,4 +94,4 @@ jobs:
       shell: cmd
       run: |
         cd test
-        bin\Debug\gpgmm_capture_replay_tests.exe --log-level=DEBUG 2>&1
+        bin\Debug\gpgmm_capture_replay_tests.exe --log-level=DEBUG --check-device-leaks 2>&1

--- a/.github/workflows/win_msvc_rel_x64.yaml
+++ b/.github/workflows/win_msvc_rel_x64.yaml
@@ -80,13 +80,13 @@ jobs:
       shell: cmd
       run: |
         cd test
-        out\Release\gpgmm_end2end_tests.exe --gtest_filter=*NoLeak --check-device-leaks
+        out\Release\gpgmm_end2end_tests.exe --gtest_filter=*NoLeak --check-device-leaks 2>&1
 
     - name: Run gpgmm_end2end_tests (with patch)
       shell: cmd
       run: |
         cd test
-        out\Release\gpgmm_end2end_tests.exe --gtest_filter=-*NoLeak --check-device-leaks
+        out\Release\gpgmm_end2end_tests.exe --gtest_filter=-*NoLeak --check-device-leaks 2>&1
 
     - name: Run gpgmm_unittests (with patch)
       shell: cmd
@@ -98,4 +98,4 @@ jobs:
       shell: cmd
       run: |
         cd test
-        out\Release\gpgmm_capture_replay_tests.exe --check-device-leaks
+        out\Release\gpgmm_capture_replay_tests.exe --check-device-leaks 2>&1

--- a/.github/workflows/win_msvc_rel_x64_cmake.yaml
+++ b/.github/workflows/win_msvc_rel_x64_cmake.yaml
@@ -72,11 +72,17 @@ jobs:
         cd test
         cmake --build . --config Release
 
+    - name: Run gpgmm_end2end_tests leak tests (with patch)
+      shell: cmd
+      run: |
+        cd test
+        bin\Release\gpgmm_end2end_tests.exe --gtest_filter=*NoLeak --check-device-leaks 2>&1
+
     - name: Run gpgmm_end2end_tests (with patch)
       shell: cmd
       run: |
         cd test
-        bin\Release\gpgmm_end2end_tests.exe 2>&1
+        bin\Release\gpgmm_end2end_tests.exe --gtest_filter=-*NoLeak --check-device-leaks 2>&1
 
     - name: Run gpgmm_unittests (with patch)
       shell: cmd
@@ -88,4 +94,4 @@ jobs:
       shell: cmd
       run: |
         cd test
-        bin\Release\gpgmm_capture_replay_tests.exe
+        bin\Release\gpgmm_capture_replay_tests.exe --check-device-leaks 2>&1


### PR DESCRIPTION
* Adds `--check-device-leaks` where missing.
* Adds stderr redirect where missing.
* Fixes end2end re-testing base branch.