### PR TITLE
Move CRT leak checks into gtest flag.

### DIFF
--- a/.github/workflows/win_clang_dbg_x64.yaml
+++ b/.github/workflows/win_clang_dbg_x64.yaml
@@ -125,7 +125,13 @@ jobs:
         cd test
         ninja -C out\Debug
 
-    - name: Run gpgmm_end2end_tests leak tests (with patch)
+    - name: Run gpgmm_end2end_tests runtime leak checks (with patch)
+      shell: cmd
+      run: |
+        cd test
+        out\Debug\gpgmm_end2end_tests.exe --no-leaks 2>&1
+
+    - name: Run gpgmm_end2end_tests no leak tests (with patch)
       shell: cmd
       run: |
         cd test

--- a/.github/workflows/win_clang_dbg_x86.yaml
+++ b/.github/workflows/win_clang_dbg_x86.yaml
@@ -125,7 +125,13 @@ jobs:
         cd test
         ninja -C out\Debug
 
-    - name: Run gpgmm_end2end_tests leak tests (with patch)
+    - name: Run gpgmm_end2end_tests runtime leak checks (with patch)
+      shell: cmd
+      run: |
+        cd test
+        out\Debug\gpgmm_end2end_tests.exe --no-leaks 2>&1
+
+    - name: Run gpgmm_end2end_tests no leak tests (with patch)
       shell: cmd
       run: |
         cd test

--- a/.github/workflows/win_clang_rel_x64.yaml
+++ b/.github/workflows/win_clang_rel_x64.yaml
@@ -126,7 +126,13 @@ jobs:
         cd test
         ninja -C out\Release
 
-    - name: Run gpgmm_end2end_tests leak tests (with patch)
+    - name: Run gpgmm_end2end_tests runtime leak checks (with patch)
+      shell: cmd
+      run: |
+        cd test
+        out\Release\gpgmm_end2end_tests.exe --no-leaks 2>&1
+
+    - name: Run gpgmm_end2end_tests no leak tests (with patch)
       shell: cmd
       run: |
         cd test

--- a/.github/workflows/win_clang_rel_x86.yaml
+++ b/.github/workflows/win_clang_rel_x86.yaml
@@ -126,7 +126,13 @@ jobs:
         cd test
         ninja -C out\Release
 
-    - name: Run gpgmm_end2end_tests leak tests (with patch)
+    - name: Run gpgmm_end2end_tests runtime leak checks (with patch)
+      shell: cmd
+      run: |
+        cd test
+        out\Release\gpgmm_end2end_tests.exe --no-leaks 2>&1
+
+    - name: Run gpgmm_end2end_tests no leak tests (with patch)
       shell: cmd
       run: |
         cd test

--- a/.github/workflows/win_msvc_dbg_x64.yaml
+++ b/.github/workflows/win_msvc_dbg_x64.yaml
@@ -76,7 +76,13 @@ jobs:
         cd test
         ninja -C out\Debug
 
-    - name: Run gpgmm_end2end_tests leak tests (with patch)
+    - name: Run gpgmm_end2end_tests runtime leak checks (with patch)
+      shell: cmd
+      run: |
+        cd test
+        out\Debug\gpgmm_end2end_tests.exe --no-leaks 2>&1
+
+    - name: Run gpgmm_end2end_tests no leak tests (with patch)
       shell: cmd
       run: |
         cd test

--- a/.github/workflows/win_msvc_dbg_x64_cmake.yaml
+++ b/.github/workflows/win_msvc_dbg_x64_cmake.yaml
@@ -72,7 +72,13 @@ jobs:
         cd test
         cmake --build . --config Debug
 
-    - name: Run gpgmm_end2end_tests leak tests (with patch)
+    - name: Run gpgmm_end2end_tests runtime leak checks (with patch)
+      shell: cmd
+      run: |
+        cd test
+        bin\Debug\gpgmm_end2end_tests.exe --no-leaks 2>&1
+
+    - name: Run gpgmm_end2end_tests no leak tests (with patch)
       shell: cmd
       run: |
         cd test

--- a/.github/workflows/win_msvc_rel_x64.yaml
+++ b/.github/workflows/win_msvc_rel_x64.yaml
@@ -76,7 +76,13 @@ jobs:
         cd test
         ninja -C out\Release
 
-    - name: Run gpgmm_end2end_tests leak tests (with patch)
+    - name: Run gpgmm_end2end_tests runtime leak checks (with patch)
+      shell: cmd
+      run: |
+        cd test
+        out\Release\gpgmm_end2end_tests.exe --no-leaks 2>&1
+
+    - name: Run gpgmm_end2end_tests no leak tests (with patch)
       shell: cmd
       run: |
         cd test

--- a/.github/workflows/win_msvc_rel_x64_cmake.yaml
+++ b/.github/workflows/win_msvc_rel_x64_cmake.yaml
@@ -72,7 +72,13 @@ jobs:
         cd test
         cmake --build . --config Release
 
-    - name: Run gpgmm_end2end_tests leak tests (with patch)
+    - name: Run gpgmm_end2end_tests runtime leak checks (with patch)
+      shell: cmd
+      run: |
+        cd test
+        bin\Release\gpgmm_end2end_tests.exe --no-leaks 2>&1
+
+    - name: Run gpgmm_end2end_tests no leak tests (with patch)
       shell: cmd
       run: |
         cd test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,6 @@ option_if_not_defined(GPGMM_ENABLE_DEVICE_LEAK_CHECKS "Enables checking of devic
 option_if_not_defined(GPGMM_ENABLE_ALLOCATOR_LEAK_CHECKS "Enables checking of allocator leaks" OFF)
 option_if_not_defined(GPGMM_ENABLE_ASSERT_ON_WARNING "Enables ASSERT on severity functionality" OFF)
 option_if_not_defined(GPGMM_DISABLE_SIZE_CACHE "Enables warming of caches with common resource sizes" OFF)
-option_if_not_defined(GPGMM_ENABLE_MEMORY_LEAK_CHECKS "Enables memory leak detection." OFF)
 option_if_not_defined(GPGMM_ENABLE_MEMORY_ALIGN_CHECKS "Enables checking of resource alignment." OFF)
 
 if(GPGMM_ENABLE_TESTS)
@@ -178,14 +177,6 @@ endif()
 
 if(GPGMM_DISABLE_SIZE_CACHE)
   target_compile_definitions(gpgmm_common_config INTERFACE "GPGMM_DISABLE_SIZE_CACHE")
-endif()
-
-if(GPGMM_ENABLE_MEMORY_LEAK_CHECKS)
-  target_compile_definitions(gpgmm_common_config INTERFACE "GPGMM_ENABLE_MEMORY_LEAK_CHECKS")
-else()
-  target_compile_definitions(gpgmm_common_config INTERFACE
-    $<$<CONFIG:Debug>:GPGMM_ENABLE_MEMORY_LEAK_CHECKS>
-  )
 endif()
 
 if(GPGMM_ENABLE_MEMORY_ALIGN_CHECKS)

--- a/build_overrides/gpgmm_features.gni
+++ b/build_overrides/gpgmm_features.gni
@@ -57,10 +57,6 @@ declare_args() {
   # Sets -dGPGMM_ENABLE_DEVICE_LEAK_CHECKS
   gpgmm_enable_device_leak_checks = false
 
-  # Enables checking of memory leaks.
-  # Sets -dGPGMM_ENABLE_MEMORY_LEAK_CHECKS
-  gpgmm_enable_memory_leak_checks = is_debug
-
   # Enables checking of resource alignment.
   # Sets -dGPGMM_ENABLE_MEMORY_ALIGN_CHECKS
   gpgmm_enable_memory_align_checks = is_debug

--- a/src/gpgmm/common/BUILD.gn
+++ b/src/gpgmm/common/BUILD.gn
@@ -75,10 +75,6 @@ config("gpgmm_common_config") {
     defines += [ "GPGMM_ENABLE_DEVICE_LEAK_CHECKS" ]
   }
 
-  if (gpgmm_enable_memory_leak_checks) {
-    defines += [ "GPGMM_ENABLE_MEMORY_LEAK_CHECKS" ]
-  }
-
   if (gpgmm_enable_memory_align_checks) {
     defines += [ "GPGMM_ENABLE_MEMORY_ALIGN_CHECKS" ]
   }

--- a/src/gpgmm/utils/PlatformDebug.h
+++ b/src/gpgmm/utils/PlatformDebug.h
@@ -15,6 +15,8 @@
 #ifndef GPGMM_UTILS_PLATFORMDEBUG_H_
 #define GPGMM_UTILS_PLATFORMDEBUG_H_
 
+#include "Log.h"
+
 namespace gpgmm {
 
     class DebugPlatform {
@@ -30,6 +32,7 @@ namespace gpgmm {
 
         // Output or dump leak detection to console.
         virtual void ReportMemoryLeaks() {
+            gpgmm::ErrorLog() << "Reporting of memory leaks is not supported by this platform.";
         }
 
         virtual ~DebugPlatform() = default;

--- a/src/gpgmm/utils/WindowsPlatformDebug.cpp
+++ b/src/gpgmm/utils/WindowsPlatformDebug.cpp
@@ -58,9 +58,7 @@ namespace gpgmm {
             // Perform automatic leak checking at program exit through a call to _CrtDumpMemoryLeaks
             // and generate an error report if the application failed to free all the memory it
             // allocated.
-#ifdef GPGMM_ENABLE_MEMORY_LEAK_CHECKS
             _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
-#endif
         }
 
       private:

--- a/src/tests/GPGMMTest.cpp
+++ b/src/tests/GPGMMTest.cpp
@@ -27,7 +27,9 @@ GPGMMTestBase::~GPGMMTestBase() {
 
 void GPGMMTestBase::SetUp() {
     if (mDebugPlatform != nullptr) {
-        mDebugPlatform->ReportMemoryLeaks();
+        if (gTestEnv->IsReportMemoryLeaksEnabled()) {
+            mDebugPlatform->ReportMemoryLeaks();
+        }
     }
 }
 
@@ -108,6 +110,11 @@ GPGMMTestEnvironment::GPGMMTestEnvironment(int argc, char** argv) {
             continue;
         }
 
+        if (strcmp("--no-leaks", argv[i]) == 0) {
+            mIsReportMemoryLeaksEnabled = true;
+            continue;
+        }
+
         constexpr const char kDebugMode[] = "--debug";
         size_t arglen = sizeof(kDebugMode) - 1;
         if (strncmp(argv[i], kDebugMode, arglen) == 0) {
@@ -142,8 +149,9 @@ GPGMMTestEnvironment::GPGMMTestEnvironment(int argc, char** argv) {
             gpgmm::InfoLog() << "Global options:\n"
                              << " --dump: Record all events to disk.\n"
                              << " --debug: Shortcut for --log-level=DEBUG.\n"
-                             << " --log-level=[DEBUG|INFO|WARN|ERROR]: Log severity "
-                                "level for log messages.\n";
+                             << " --log-level=[DEBUG|INFO|WARN|ERROR]: Log "
+                                "level for log messages.\n"
+                             << " --no-leaks: Report memory leaks.\n";
             continue;
         }
     }
@@ -160,6 +168,10 @@ void GPGMMTestEnvironment::SetUp() {
 
 bool GPGMMTestEnvironment::IsDumpEventsEnabled() const {
     return mIsDumpEventsEnabled;
+}
+
+bool GPGMMTestEnvironment::IsReportMemoryLeaksEnabled() const {
+    return mIsReportMemoryLeaksEnabled;
 }
 
 gpgmm::LogSeverity GPGMMTestEnvironment::GetLogLevel() const {

--- a/src/tests/GPGMMTest.h
+++ b/src/tests/GPGMMTest.h
@@ -81,10 +81,12 @@ class GPGMMTestEnvironment : public testing::Environment {
     void SetUp() override;
 
     bool IsDumpEventsEnabled() const;
+    bool IsReportMemoryLeaksEnabled() const;
     gpgmm::LogSeverity GetLogLevel() const;
 
   private:
     bool mIsDumpEventsEnabled = false;
+    bool mIsReportMemoryLeaksEnabled = false;
     gpgmm::LogSeverity mLogLevel;  // Initialized by Setup().
 };
 


### PR DESCRIPTION
CRT leak checks seem to be flaky. This change moves it behind a gtest flag (from compiler option) so it can be run as seperate step.