### PR TITLE
Do not restrict available memory if NOT_RESIDENT is used.

### DIFF
--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -177,7 +177,7 @@ namespace gpgmm::d3d12 {
 
         const D3D12_RESOURCE_HEAP_TIER mResourceHeapTier;
         const bool mIsAlwaysCommitted;
-        const bool mIsHeapAlwaysCreatedInBudget;
+        const bool mIsAlwaysCreatedInBudget;
         const bool mFlushEventBuffersOnDestruct;
         const bool mUseDetailedTimingEvents;
         const bool mIsCustomHeapsDisabled;


### PR DESCRIPTION
Also, count pending request size in usage before restricting.