### PR TITLE
Decouple HEAP_FLAG_ALWAYS_IN_BUDGET from D3D12_HEAP_FLAG_CREATE_NOT_RESIDENT.

### DIFF
--- a/include/gpgmm_d3d12.h
+++ b/include/gpgmm_d3d12.h
@@ -134,7 +134,7 @@ namespace gpgmm::d3d12 {
 
         /** \brief Requires the heap to be created in budget.
 
-        This flags allows the heap to be tracked for residency but not made resident.
+        This flags ensures there is enough budget to exist for the heap or E_OUTOFMEMORY.
         */
         HEAP_FLAG_ALWAYS_IN_BUDGET = 0x1,
 
@@ -648,14 +648,9 @@ namespace gpgmm::d3d12 {
         */
         ALLOCATOR_FLAG_ALWAYS_COMMITTED = 0x1,
 
-        /** \brief Creates resource within budget.
+        /** \brief Requires resource allocation to be created within budget.
 
-        By default (and when residency is used), resources will not be created resident unless an
-        operation is performed on the allocation that requires them to be (ex. Map). Otherwise, the
-        resource will become resident once ExecuteCommandList() is called. However, this flag can be
-        used to change this behavior by requiring resource heaps to be always resident at resource
-        creation. When residency is not used, ALLOCATOR_FLAG_ALWAYS_IN_BUDGET is implicitly enabled
-        through the GPU/driver instead of explicitly through GPGMM.
+        Always use HEAP_FLAG_ALWAYS_IN_BUDGET to resource heaps created by this resource allocator.
         */
         ALLOCATOR_FLAG_ALWAYS_IN_BUDGET = 0x2,
 
@@ -690,14 +685,6 @@ namespace gpgmm::d3d12 {
         to be released, it will report details on any leaked allocations as log messages.
         */
         ALLOCATOR_FLAG_NEVER_LEAK_MEMORY = 0x20,
-
-        /** \brief Allows resources to be created over budget.
-
-        Used when GPGMM is unable to manage enough budget (external heaps, multiple GMMs per
-        process) and instead relies on the default OS/kernel behavior. This should be considered a
-        temporary measure and should not replace implementing good budget management.
-        */
-        ALLOCATOR_FLAG_ALLOW_OVER_BUDGET = 0x40,
     };
 
     DEFINE_ENUM_FLAG_OPERATORS(ALLOCATOR_FLAGS)

--- a/src/gpgmm/d3d12/HeapD3D12.cpp
+++ b/src/gpgmm/d3d12/HeapD3D12.cpp
@@ -45,16 +45,12 @@ namespace gpgmm::d3d12 {
         }
     }  // namespace
 
-    HEAP_FLAGS GetHeapFlags(D3D12_HEAP_FLAGS heapFlags, bool isResidencyEnabled) {
-        if (heapFlags & D3D12_HEAP_FLAG_CREATE_NOT_RESIDENT) {
-            return HEAP_FLAG_NONE | HEAP_FLAG_ALWAYS_IN_RESIDENCY;
-        }
-
-        if (isResidencyEnabled) {
+    HEAP_FLAGS GetHeapFlags(D3D12_HEAP_FLAGS heapFlags, bool alwaysCreatedInBudget) {
+        if (alwaysCreatedInBudget) {
             return HEAP_FLAG_ALWAYS_IN_BUDGET | HEAP_FLAG_ALWAYS_IN_RESIDENCY;
         }
 
-        return HEAP_FLAG_NONE;
+        return HEAP_FLAG_ALWAYS_IN_RESIDENCY;
     }
 
     HRESULT CreateHeap(const HEAP_DESC& descriptor,

--- a/src/gpgmm/d3d12/HeapD3D12.h
+++ b/src/gpgmm/d3d12/HeapD3D12.h
@@ -27,7 +27,7 @@ namespace gpgmm::d3d12 {
 
     class ResidencyManager;
 
-    HEAP_FLAGS GetHeapFlags(D3D12_HEAP_FLAGS heapFlags, bool isResidencyEnabled);
+    HEAP_FLAGS GetHeapFlags(D3D12_HEAP_FLAGS heapFlags, bool alwaysCreatedInBudget);
 
     class Heap final : public MemoryBase, public DebugObject, public LinkNode<Heap>, public IHeap {
       public:

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -153,7 +153,6 @@ namespace gpgmm::d3d12 {
         const bool mFlushEventBuffersOnDestruct;
         const bool mUseDetailedTimingEvents;
         const bool mIsCustomHeapsDisabled;
-        const bool mIsOverBudgetEnabled;
 
         static constexpr uint64_t kNumOfResourceHeapTypes = 12u;
 

--- a/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.cpp
@@ -33,12 +33,12 @@ namespace gpgmm::d3d12 {
                                                  ID3D12Device* device,
                                                  D3D12_HEAP_PROPERTIES heapProperties,
                                                  D3D12_HEAP_FLAGS heapFlags,
-                                                 bool isOverBudgetEnabled)
+                                                 bool alwaysCreatedInBudget)
         : mResidencyManager(residencyManager),
           mDevice(device),
           mHeapProperties(heapProperties),
           mHeapFlags(heapFlags),
-          mIsOverBudgetEnabled(isOverBudgetEnabled) {
+          mIsAlwaysCreatedInBudget(alwaysCreatedInBudget) {
     }
 
     ResultOrError<std::unique_ptr<MemoryAllocation>> ResourceHeapAllocator::TryAllocateMemory(
@@ -60,13 +60,8 @@ namespace gpgmm::d3d12 {
         resourceHeapDesc.DebugName = kResourceHeapDebugName;
 
         const bool isResidencyEnabled = (mResidencyManager != nullptr);
-        resourceHeapDesc.Flags |= GetHeapFlags(mHeapFlags, isResidencyEnabled);
-
-        if (mIsOverBudgetEnabled) {
-            resourceHeapDesc.Flags &= ~(HEAP_FLAG_ALWAYS_IN_BUDGET);  // clear
-        }
-
         if (isResidencyEnabled) {
+            resourceHeapDesc.Flags |= GetHeapFlags(mHeapFlags, mIsAlwaysCreatedInBudget);
             resourceHeapDesc.MemorySegmentGroup = GetMemorySegmentGroup(
                 mHeapProperties.MemoryPoolPreference, mResidencyManager->IsUMA());
         }

--- a/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.h
@@ -58,7 +58,7 @@ namespace gpgmm::d3d12 {
         ID3D12Device* const mDevice;
         const D3D12_HEAP_PROPERTIES mHeapProperties;
         const D3D12_HEAP_FLAGS mHeapFlags;
-        const bool mIsOverBudgetEnabled;
+        const bool mIsAlwaysCreatedInBudget;
     };
 
 }  // namespace gpgmm::d3d12


### PR DESCRIPTION
Allows HEAP_FLAG_ALWAYS_IN_BUDGET to be disabled while also allowing D3D12 heaps to be created as non-resident.