### PR TITLE
Allow cmake install paths to be overridden.

### DIFF
--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -12,14 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Provide the configure_package_config_file function below. 
+# Provide the configure_package_config_file function below.
 include(CMakePackageConfigHelpers)
+
+if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
+  set(CMAKE_INSTALL_LIBDIR lib)
+endif()
+
+if(NOT DEFINED CMAKE_INSTALL_BINDIR)
+  set(CMAKE_INSTALL_BINDIR bin)
+endif()
 
 install(TARGETS gpgmm
     EXPORT gpgmmTargets
-    RUNTIME DESTINATION bin
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
 # vulkan-headers must be rolled to export gpgmm.


### PR DESCRIPTION
Adds CMAKE_INSTALL_BINDIR and CMAKE_INSTALL_LIBDIR to specify a custom install path for runtime and library/achieve files, respectively.