### PR TITLE
Add RESIDENCY_FLAG_ALWAYS_IN_BUDGET support.

### DIFF
--- a/include/gpgmm_d3d12.h
+++ b/include/gpgmm_d3d12.h
@@ -322,6 +322,13 @@ namespace gpgmm::d3d12 {
         memory segments, respectively.
         */
         RESIDENCY_FLAG_DISABLE_UNIFIED_MEMORY = 0x2,
+
+        /** \brief Requires heaps to be in budget or E_OUTOFMEMORY.
+
+        With this flag, heaps created for this residency manager will effectively never
+        specify D3D12_RESIDENCY_FLAG_DENY_OVERBUDGET.
+        */
+        RESIDENCY_FLAG_ALWAYS_IN_BUDGET = 0x4,
     };
 
     DEFINE_ENUM_FLAG_OPERATORS(RESIDENCY_FLAGS)

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.h
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.h
@@ -138,6 +138,7 @@ namespace gpgmm::d3d12 {
         const bool mIsBudgetChangeEventsDisabled;
         const bool mFlushEventBuffersOnDestruct;
         const uint64_t mInitialFenceValue;
+        const bool mIsAlwaysInBudget;
 
         mutable std::mutex mMutex;
 

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -437,6 +437,10 @@ namespace gpgmm::d3d12 {
             residencyDesc.MinLogLevel = allocatorDescriptor.MinLogLevel;
             residencyDesc.RecordOptions = allocatorDescriptor.RecordOptions;
 
+            if (allocatorDescriptor.Flags & ALLOCATOR_FLAG_ALWAYS_IN_BUDGET) {
+                residencyDesc.Flags |= RESIDENCY_FLAG_ALWAYS_IN_BUDGET;
+            }
+
             ReturnIfFailed(
                 ResidencyManager::CreateResidencyManager(residencyDesc, &residencyManager));
         }


### PR DESCRIPTION
Allow apps to decide how to deal with over budget behavior.