### PR TITLE
Always re-align memory requests.

### DIFF
--- a/src/gpgmm/common/DedicatedMemoryAllocator.cpp
+++ b/src/gpgmm/common/DedicatedMemoryAllocator.cpp
@@ -36,7 +36,7 @@ namespace gpgmm {
 
         MemoryAllocationRequest memoryRequest = request;
         memoryRequest.Alignment = mMemoryAlignment;
-        memoryRequest.SizeInBytes = AlignTo(request.SizeInBytes, request.Alignment);
+        memoryRequest.SizeInBytes = AlignTo(request.SizeInBytes, mMemoryAlignment);
 
         std::unique_ptr<MemoryAllocation> allocation;
         GPGMM_TRY_ASSIGN(GetNextInChain()->TryAllocateMemory(memoryRequest), allocation);

--- a/src/gpgmm/common/PooledMemoryAllocator.cpp
+++ b/src/gpgmm/common/PooledMemoryAllocator.cpp
@@ -44,8 +44,12 @@ namespace gpgmm {
 
         MemoryAllocation allocation = mPool->AcquireFromPool();
         if (allocation == GPGMM_INVALID_ALLOCATION) {
+            MemoryAllocationRequest memoryRequest = request;
+            memoryRequest.Alignment = mMemoryAlignment;
+            memoryRequest.SizeInBytes = AlignTo(request.SizeInBytes, mMemoryAlignment);
+
             std::unique_ptr<MemoryAllocation> allocationPtr;
-            GPGMM_TRY_ASSIGN(GetNextInChain()->TryAllocateMemory(request), allocationPtr);
+            GPGMM_TRY_ASSIGN(GetNextInChain()->TryAllocateMemory(memoryRequest), allocationPtr);
             allocation = *allocationPtr;
         } else {
             mStats.FreeMemoryUsage -= allocation.GetSize();

--- a/src/gpgmm/common/SegmentedMemoryAllocator.cpp
+++ b/src/gpgmm/common/SegmentedMemoryAllocator.cpp
@@ -133,8 +133,12 @@ namespace gpgmm {
 
         MemoryAllocation allocation = segment->AcquireFromPool();
         if (allocation == GPGMM_INVALID_ALLOCATION) {
+            MemoryAllocationRequest memoryRequest = request;
+            memoryRequest.Alignment = mMemoryAlignment;
+            memoryRequest.SizeInBytes = AlignTo(request.SizeInBytes, mMemoryAlignment);
+
             std::unique_ptr<MemoryAllocation> allocationPtr;
-            GPGMM_TRY_ASSIGN(GetNextInChain()->TryAllocateMemory(request), allocationPtr);
+            GPGMM_TRY_ASSIGN(GetNextInChain()->TryAllocateMemory(memoryRequest), allocationPtr);
             allocation = *allocationPtr;
         } else {
             mStats.FreeMemoryUsage -= allocation.GetSize();


### PR DESCRIPTION
Fixes a possible bug when a memory allocator may not align memory objects.