### PR TITLE
Suppress logging of internal objects.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ option_if_not_defined(GPGMM_ENABLE_ALLOCATOR_LEAK_CHECKS "Enables checking of al
 option_if_not_defined(GPGMM_ENABLE_ASSERT_ON_WARNING "Enables ASSERT on severity functionality" OFF)
 option_if_not_defined(GPGMM_DISABLE_SIZE_CACHE "Enables warming of caches with common resource sizes" OFF)
 option_if_not_defined(GPGMM_ENABLE_MEMORY_ALIGN_CHECKS "Enables checking of resource alignment." OFF)
+option_if_not_defined(GPGMM_ENABLE_LOGGING_INTERNAL_OBJECTS "Enables log messages for internal objects." OFF)
 
 if(GPGMM_ENABLE_TESTS)
   # Vulkan tests require static linking.

--- a/build_overrides/gpgmm_features.gni
+++ b/build_overrides/gpgmm_features.gni
@@ -66,4 +66,8 @@ declare_args() {
 
   # Configures Vulkan functions by dynamically importing them (ie. using vkGetInstanceProcAddr and vkGetDeviceProcAddr).
   gpgmm_vk_dynamic_functions = false
+
+  # Enables log messages for internal objects.
+  # Sets -dGPGMM_ENABLE_LOGGING_INTERNAL_OBJECTS
+  gpgmm_enable_logging_internal_objects = false
 }

--- a/src/gpgmm/common/BUILD.gn
+++ b/src/gpgmm/common/BUILD.gn
@@ -79,6 +79,10 @@ config("gpgmm_common_config") {
     defines += [ "GPGMM_ENABLE_MEMORY_ALIGN_CHECKS" ]
   }
 
+  if (gpgmm_enable_logging_internal_objects) {
+    defines += [ "GPGMM_ENABLE_LOGGING_INTERNAL_OBJECTS" ]
+  }
+
   # Only internal build targets can use this config, this means only targets in
   # this BUILD.gn file and related subdirs.
   visibility = [ "../../*" ]
@@ -203,6 +207,8 @@ source_set("gpgmm_common_sources") {
     "MemoryPool.h",
     "Message.cpp",
     "Message.h",
+    "Object.cpp",
+    "Object.h",
     "PooledMemoryAllocator.cpp",
     "PooledMemoryAllocator.h",
     "SegmentedMemoryAllocator.cpp",

--- a/src/gpgmm/common/CMakeLists.txt
+++ b/src/gpgmm/common/CMakeLists.txt
@@ -46,6 +46,8 @@ target_sources(gpgmm_common PRIVATE
     "MemoryPool.h"
     "Message.cpp"
     "Message.h"
+    "Object.cpp"
+    "Object.h"
     "PooledMemoryAllocator.cpp"
     "PooledMemoryAllocator.h"
     "SegmentedMemoryAllocator.cpp"

--- a/src/gpgmm/common/Object.cpp
+++ b/src/gpgmm/common/Object.cpp
@@ -12,25 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GPGMM_COMMON_OBJECT_H_
-#define GPGMM_COMMON_OBJECT_H_
+#include "gpgmm/common/Object.h"
 
 namespace gpgmm {
-
-    class ObjectBase {
-      public:
-        ObjectBase() = default;
-        virtual ~ObjectBase() = default;
-
-        ObjectBase(const ObjectBase&) = default;
-        ObjectBase& operator=(const ObjectBase&) = default;
-
-        virtual const char* GetTypename() const = 0;
-
-        // Overridden for objects that are API exposed.
-        virtual bool IsExternal() const;
-    };
-
+    bool ObjectBase::IsExternal() const {
+        return false;
+    }
 }  // namespace gpgmm
-
-#endif  // GPGMM_COMMON_OBJECT_H_

--- a/src/gpgmm/d3d12/HeapD3D12.cpp
+++ b/src/gpgmm/d3d12/HeapD3D12.cpp
@@ -202,6 +202,10 @@ namespace gpgmm::d3d12 {
         return "Heap";
     }
 
+    bool Heap::IsExternal() const {
+        return true;
+    }
+
     uint64_t Heap::GetLastUsedFenceValue() const {
         return mLastUsedFenceValue;
     }

--- a/src/gpgmm/d3d12/HeapD3D12.h
+++ b/src/gpgmm/d3d12/HeapD3D12.h
@@ -60,6 +60,7 @@ namespace gpgmm::d3d12 {
 
         // ObjectBase interface
         const char* GetTypename() const override;
+        bool IsExternal() const override;
 
         HRESULT SetDebugNameImpl(LPCWSTR name) override;
         DXGI_MEMORY_SEGMENT_GROUP GetMemorySegmentGroup() const;

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
@@ -313,6 +313,10 @@ namespace gpgmm::d3d12 {
         return "ResidencyManager";
     }
 
+    bool ResidencyManager::IsExternal() const {
+        return true;
+    }
+
     // Increments number of locks on a heap to ensure the heap remains resident.
     HRESULT ResidencyManager::LockHeap(IHeap* pHeap) {
         ReturnIfNullptr(pHeap);

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.h
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.h
@@ -96,6 +96,7 @@ namespace gpgmm::d3d12 {
 
         // ObjectBase interface
         const char* GetTypename() const override;
+        bool IsExternal() const override;
 
         // IDebugObject interface
         LPCWSTR GetDebugName() const override;

--- a/src/gpgmm/d3d12/ResourceAllocationD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocationD3D12.cpp
@@ -153,6 +153,10 @@ namespace gpgmm::d3d12 {
         return "ResourceAllocation";
     }
 
+    bool ResourceAllocation::IsExternal() const {
+        return true;
+    }
+
     IHeap* ResourceAllocation::GetMemory() const {
         return static_cast<Heap*>(MemoryAllocation::GetMemory());
     }

--- a/src/gpgmm/d3d12/ResourceAllocationD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocationD3D12.h
@@ -77,6 +77,7 @@ namespace gpgmm::d3d12 {
 
         // ObjectBase interface
         const char* GetTypename() const override;
+        bool IsExternal() const override;
 
         ResidencyManager* const mResidencyManager;
         ComPtr<ID3D12Resource> mResource;

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -878,6 +878,10 @@ namespace gpgmm::d3d12 {
         return "ResourceAllocator";
     }
 
+    bool ResourceAllocator::IsExternal() const {
+        return true;
+    }
+
     HRESULT ResourceAllocator::ReleaseResourceHeaps(uint64_t bytesToRelease,
                                                     uint64_t* pBytesReleased) {
         std::lock_guard<std::mutex> lock(mMutex);

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -76,6 +76,7 @@ namespace gpgmm::d3d12 {
 
         // ObjectBase interface
         const char* GetTypename() const override;
+        bool IsExternal() const override;
 
         // IDebugObject interface
         LPCWSTR GetDebugName() const override;

--- a/src/gpgmm/utils/Log.cpp
+++ b/src/gpgmm/utils/Log.cpp
@@ -109,6 +109,13 @@ namespace gpgmm {
             return;
         }
 
+        // Ignore internal objects being logged unless the build is enabled for it.
+#if !defined(GPGMM_ENABLE_LOGGING_INTERNAL_OBJECTS)
+        if (mObject != nullptr && !mObject->IsExternal()) {
+            return;
+        }
+#endif
+
         const char* severityName = SeverityName(mSeverity);
 
         FILE* outputStream = stdout;


### PR DESCRIPTION
Moves internal object logging behind a build flag.