### PR TITLE
Minor refactor in ResourceAllocator.

### DIFF
--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -137,7 +137,7 @@ namespace gpgmm::d3d12 {
                                         ID3D12Resource** commitedResourceOut,
                                         Heap** resourceHeapOut);
 
-        static HRESULT ReportLiveDeviceObjects(ComPtr<ID3D12Device> device);
+        HRESULT ReportLiveDeviceObjects() const;
 
         bool IsCreateHeapNotResident() const;
         bool IsResidencyEnabled() const;


### PR DESCRIPTION
Moves ReportLiveDeviceObjects to the resource allocator and removes device being specified to TryAllocateResource.