### PR TITLE
Depreciate RESIDENCY_HEAP_INFO::IsCachedForResidency

### DIFF
--- a/include/gpgmm_d3d12.h
+++ b/include/gpgmm_d3d12.h
@@ -113,13 +113,12 @@ namespace gpgmm::d3d12 {
         */
         uint64_t Alignment;
 
-        /** \brief Check if the heap currently locked for residency.
+        /** \brief Check if the heap is currently locked for residency.
+
+        A locked heap means the heap is not eligable for eviction.
+
          */
         bool IsLocked;
-
-        /** \brief Check if the heap is in a residency cache.
-         */
-        bool IsCachedForResidency;
 
         /** \brief Check if the heap was made resident or not.
          */

--- a/src/gpgmm/d3d12/ResidencyHeapD3D12.cpp
+++ b/src/gpgmm/d3d12/ResidencyHeapD3D12.cpp
@@ -231,7 +231,7 @@ namespace gpgmm::d3d12 {
     }
 
     RESIDENCY_HEAP_INFO ResidencyHeap::GetInfo() const {
-        return {GetSize(), GetAlignment(), IsResidencyLocked(), IsInList(), mState};
+        return {GetSize(), GetAlignment(), IsResidencyLocked(), mState};
     }
 
     HRESULT ResidencyHeap::SetDebugNameImpl(LPCWSTR name) {

--- a/src/mvi/gpgmm_d3d12.cpp
+++ b/src/mvi/gpgmm_d3d12.cpp
@@ -94,7 +94,7 @@ namespace gpgmm::d3d12 {
     }
 
     RESIDENCY_HEAP_INFO ResidencyHeap::GetInfo() const {
-        return {GetSize(), GetAlignment(), false, false, RESIDENCY_HEAP_STATUS_UNKNOWN};
+        return {GetSize(), GetAlignment(), false, RESIDENCY_HEAP_STATUS_UNKNOWN};
     }
 
     HRESULT STDMETHODCALLTYPE ResidencyHeap::QueryInterface(REFIID riid, void** ppvObject) {


### PR DESCRIPTION
Use RESIDENCY_HEAP_INFO::RESIDENCY_HEAP_STATUS to determine residency state.