### PR TITLE
Remove <cstdint> from gpgmm_d3d12.h

### DIFF
--- a/include/gpgmm_d3d12.h
+++ b/include/gpgmm_d3d12.h
@@ -19,19 +19,19 @@
 // This file should not be modified by downstream GMM clients or forks of GPGMM.
 // Please consider submitting a pull-request to https://github.com/intel/gpgmm.
 
-#ifdef GPGMM_SHARED_LIBRARY
-#    include "gpgmm_export.h"
-#else // defined(GPGMM_SHARED_LIBRARY)
-#    define GPGMM_EXPORT
-#endif // defined(GPGMM_SHARED_LIBRARY)
-
-#include <cstdint>
-
 // User should decide to define the following macros:
+// - GPGMM_SHARED_LIBRARY: the implementation using this header wishes to be built as a shared
+// library.
 // - GPGMM_D3D12_HEADERS_ALREADY_INCLUDED: D3D12 platform headers will be already included before
 // this header and does not need to be re-included.
 // - GPGMM_WINDOWS_HEADERS_ALREADY_INCLUDED: Windows.h will be already included before this header
 // and does not need to be re-included.
+
+#ifdef GPGMM_SHARED_LIBRARY
+#    include "gpgmm_export.h"
+#else  // defined(GPGMM_SHARED_LIBRARY)
+#    define GPGMM_EXPORT
+#endif  // defined(GPGMM_SHARED_LIBRARY)
 
 #ifndef GPGMM_D3D12_HEADERS_ALREADY_INCLUDED
 #    include <d3d12.h>
@@ -70,7 +70,7 @@ namespace gpgmm::d3d12 {
     /** \enum RESIDENCY_HEAP_STATUS
 
        D3D12 allows heaps to be explicitly created resident or not. This means the expected
-       residency status of the heap cannot be solely  determined by checking for the existence in a
+       residency status of the heap cannot be solely determined by checking for the existence in a
        residency cache.
 
        Heaps are in one of three exclusive states: never made resident or unknown, about to become
@@ -105,19 +105,18 @@ namespace gpgmm::d3d12 {
 
         Must be non-zero. SizeInBytes is always a multiple of the alignment.
         */
-        uint64_t SizeInBytes;
+        UINT64 SizeInBytes;
 
         /** \brief Created alignment, in bytes, of the heap.
 
         Must be non-zero.
         */
-        uint64_t Alignment;
+        UINT64 Alignment;
 
         /** \brief Check if the heap is currently locked for residency.
 
-        A locked heap means the heap is not eligable for eviction.
-
-         */
+        A locked heap means the heap is not eligible for eviction.
+        */
         bool IsLocked;
 
         /** \brief Check if the heap was made resident or not.
@@ -159,13 +158,13 @@ namespace gpgmm::d3d12 {
 
         Must be non-zero. SizeInBytes is always a multiple of the alignment.
         */
-        uint64_t SizeInBytes;
+        UINT64 SizeInBytes;
 
         /** \brief Created alignment of the heap, in bytes.
 
         Must be non-zero.
         */
-        uint64_t Alignment;
+        UINT64 Alignment;
 
         /** \brief Specifies the memory segment the heap will reside in.
 
@@ -457,7 +456,7 @@ namespace gpgmm::d3d12 {
         Optional parameter. By default, the API will automatically set the budget to 95% of video
         memory, leaving 5% for the OS and other applications.
         */
-        float MaxPctOfVideoMemoryToBudget;
+        FLOAT MaxPctOfVideoMemoryToBudget;
 
         /** \brief Lowest amount of budgeted memory, expressed as a percentage, that can be
         reserved.
@@ -468,7 +467,7 @@ namespace gpgmm::d3d12 {
         Optional parameter. By default, the API restricts the residency manager reservation to never
         go below 50% of the budget.
         */
-        float MinPctOfBudgetToReserve;
+        FLOAT MinPctOfBudgetToReserve;
 
         /** \brief Maximum amount of budgeted memory, in bytes, that can be budgeted.
 
@@ -477,14 +476,14 @@ namespace gpgmm::d3d12 {
         Optional parameter. By default, the API will not further restrict the residency manager
         budget.
         */
-        uint64_t MaxBudgetInBytes;
+        UINT64 MaxBudgetInBytes;
 
         /** \brief Size of memory, in bytes, to evict from residency at once,
         should there not be enough budget left.
 
         Optional parameter. When 0 is specified, the API will use a evict size of 50MB.
         */
-        uint64_t EvictSizeInBytes;
+        UINT64 EvictSizeInBytes;
 
         /** \brief Initial fence value to use when managing heaps for residency.
 
@@ -494,7 +493,7 @@ namespace gpgmm::d3d12 {
 
         Optional parameter. Zero by default.
         */
-        uint64_t InitialFenceValue;
+        UINT64 InitialFenceValue;
     };
 
     /** \struct RESIDENCY_MANAGER_STATS
@@ -503,11 +502,11 @@ namespace gpgmm::d3d12 {
     struct RESIDENCY_MANAGER_STATS {
         /** \brief Amount of memory, in bytes, currently resident.
          */
-        uint64_t CurrentHeapUsage;
+        UINT64 CurrentHeapUsage;
 
         /** \brief Number of heaps, currently resident.
          */
-        uint64_t CurrentHeapCount;
+        UINT64 CurrentHeapCount;
     };
 
     /** \enum ALLOCATION_METHOD
@@ -582,7 +581,7 @@ namespace gpgmm::d3d12 {
         */
         virtual HRESULT ExecuteCommandLists(
             ID3D12CommandQueue* const pQueue, ID3D12CommandList* const* ppCommandLists,
-            IResidencyList* const* ppResidencyLists, uint32_t count) = 0;
+            IResidencyList* const* ppResidencyLists, UINT count) = 0;
 
         /** \brief Sets video memory reservation.
 
@@ -596,8 +595,8 @@ namespace gpgmm::d3d12 {
         return the current reservation.
         */
         virtual HRESULT SetVideoMemoryReservation(const DXGI_MEMORY_SEGMENT_GROUP& heapSegment,
-                                                  uint64_t availableForReservation,
-                                                  uint64_t* pCurrentReservationOut = nullptr) = 0;
+                                                  UINT64 availableForReservation,
+                                                  UINT64* pCurrentReservationOut = nullptr) = 0;
 
         /** \brief Get the current budget and memory usage.
 
@@ -659,13 +658,13 @@ namespace gpgmm::d3d12 {
 
         Must be non-zero. SizeInBytes is always a multiple of the alignment.
         */
-        uint64_t SizeInBytes;
+        UINT64 SizeInBytes;
 
         /** \brief Created alignment, in bytes, of the resource allocation.
 
         Must be non-zero.
         */
-        uint64_t Alignment;
+        UINT64 Alignment;
 
         /** \brief Method used to allocate memory for the resource.
          */
@@ -696,8 +695,7 @@ namespace gpgmm::d3d12 {
         @param[out] ppDataOut A pointer to a memory block that receives a pointer to the resource
         data.
         */
-        virtual HRESULT Map(uint32_t subresource, const D3D12_RANGE* pReadRange,
-                            void** ppDataOut) = 0;
+        virtual HRESULT Map(UINT subresource, const D3D12_RANGE* pReadRange, void** ppDataOut) = 0;
 
         /** \brief Unmaps the resource allocation.
 
@@ -707,7 +705,7 @@ namespace gpgmm::d3d12 {
         @param pWrittenRange A pointer to a D3D12_RANGE structure that describes the range of memory
         to unmap.
         */
-        virtual void Unmap(uint32_t subresource, const D3D12_RANGE* pWrittenRange) = 0;
+        virtual void Unmap(UINT subresource, const D3D12_RANGE* pWrittenRange) = 0;
 
         /** \brief Returns the resource owned by this allocation.
 
@@ -730,7 +728,7 @@ namespace gpgmm::d3d12 {
 
         \return A offset, in bytes, of the start of this allocation in the resource.
         */
-        virtual uint64_t GetOffsetFromResource() const = 0;
+        virtual UINT64 GetOffsetFromResource() const = 0;
 
         /** \brief Returns information about this resource allocation.
 
@@ -954,7 +952,7 @@ namespace gpgmm::d3d12 {
         Optional parameter. When 0 is specified, the API will automatically set the preferred
         resource heap size to be a multiple of minimum resource heap size allowed by D3D12.
         */
-        uint64_t PreferredResourceHeapSize;
+        UINT64 PreferredResourceHeapSize;
 
         /** \brief Maximum size of the resource heap allowed.
 
@@ -965,7 +963,7 @@ namespace gpgmm::d3d12 {
         heap size based on the adapter's GPU virtual address range. If the max resource size
         exceeds the adapter's GPU virtual address range, it will default to the smaller range.
         */
-        uint64_t MaxResourceHeapSize;
+        UINT64 MaxResourceHeapSize;
 
         /** \brief Resource heap fragmentation limit, expressed as a percentage of the resource heap
         size, that is acceptable to be wasted due to fragmentation.
@@ -982,7 +980,7 @@ namespace gpgmm::d3d12 {
         Optional parameter. When 0 is specified, the default fragmentation limit is 1/8th the
         resource heap size.
         */
-        double ResourceHeapFragmentationLimit;
+        FLOAT ResourceHeapFragmentationLimit;
 
         /** \brief Resource heap growth factor, expressed as a multiple of the resource heap size
         that will monotonically increase.
@@ -999,7 +997,7 @@ namespace gpgmm::d3d12 {
 
         Optional parameter. When 0 is specified, the default of 1.25 is used (or 25% growth).
         */
-        double ResourceHeapGrowthFactor;
+        FLOAT ResourceHeapGrowthFactor;
     };
 
     /** \enum ALLOCATION_FLAGS
@@ -1151,7 +1149,7 @@ namespace gpgmm::d3d12 {
 
         Optional parameter. No extra padding is applied by default.
         */
-        uint64_t RequireResourceHeapPadding;
+        UINT64 RequireResourceHeapPadding;
 
         /** \brief Associates a name with the given allocation.
 
@@ -1195,39 +1193,39 @@ namespace gpgmm::d3d12 {
     struct ALLOCATOR_STATS {
         /** \brief Number of used sub-allocated blocks within the same memory.
          */
-        uint32_t UsedBlockCount;
+        UINT UsedBlockCount;
 
         /** \brief Total size, in bytes, of used sub-allocated blocks.
          */
-        uint64_t UsedBlockUsage;
+        UINT64 UsedBlockUsage;
 
         /** \brief Number of used memory allocations.
          */
-        uint32_t UsedHeapCount;
+        UINT UsedHeapCount;
 
         /** \brief Total size, in bytes, of used memory.
          */
-        uint64_t UsedHeapUsage;
+        UINT64 UsedHeapUsage;
 
         /** \brief Total size, in bytes, of free memory.
          */
-        uint64_t FreeHeapUsage;
+        UINT64 FreeHeapUsage;
 
         /** \brief Cache misses not eliminated by prefetching.
          */
-        uint64_t PrefetchedHeapMisses;
+        UINT64 PrefetchedHeapMisses;
 
         /** \brief Cache misses eliminated because of prefetching.
          */
-        uint64_t PrefetchedHeapMissesEliminated;
+        UINT64 PrefetchedHeapMissesEliminated;
 
         /** \brief Requested size was NOT cached.
          */
-        uint64_t SizeCacheMisses;
+        UINT64 SizeCacheMisses;
 
         /** \brief Requested size was cached.
          */
-        uint64_t SizeCacheHits;
+        UINT64 SizeCacheHits;
     };
 
     /** \brief ResourceAllocator is a MemoryAllocator that creates ID3D12Resources in a
@@ -1309,8 +1307,7 @@ namespace gpgmm::d3d12 {
         specified. Or S_FALSE if the released size was smaller, there was not enough memory or
         larger if releasable memory doesn't exactly total up to the amount.
         */
-        virtual HRESULT ReleaseResourceHeaps(uint64_t bytesToRelease,
-                                             uint64_t * pBytesReleased) = 0;
+        virtual HRESULT ReleaseResourceHeaps(UINT64 bytesToRelease, UINT64 * pBytesReleased) = 0;
 
         /** \brief  Query the current allocator usage.
 
@@ -1342,7 +1339,7 @@ namespace gpgmm::d3d12 {
         parameter.
         */
         virtual HRESULT CheckFeatureSupport(ALLOCATOR_FEATURE feature, void* pFeatureSupportData,
-                                            uint32_t featureSupportDataSize) const = 0;
+                                            UINT featureSupportDataSize) const = 0;
     };
 
     /** \brief Create a resource allocator with residency.

--- a/include/gpgmm_vk.h
+++ b/include/gpgmm_vk.h
@@ -214,7 +214,7 @@ namespace gpgmm::vk {
         Optional parameter. When 0 is specified, the default fragmentation limit is 1/8th the
         device memory size.
         */
-        double memoryFragmentationLimit;
+        float memoryFragmentationLimit;
 
         /** \brief Memory growth factor, expressed as a multipler of the device memory size
         that will monotonically increase.
@@ -231,7 +231,7 @@ namespace gpgmm::vk {
 
         Optional parameter. When 0 is specified, the default of 1.25 is used (or 25% growth).
         */
-        double memoryGrowthFactor;
+        float memoryGrowthFactor;
     };
 
     /** \enum GpResourceAllocationCreateFlags

--- a/src/fuzzers/D3D12Fuzzer.h
+++ b/src/fuzzers/D3D12Fuzzer.h
@@ -18,6 +18,7 @@
 #include <gpgmm_d3d12.h>
 
 #include <wrl.h>
+#include <cstdint>
 
 using Microsoft::WRL::ComPtr;
 

--- a/src/gpgmm/common/Defaults.h
+++ b/src/gpgmm/common/Defaults.h
@@ -19,8 +19,8 @@
 
 namespace gpgmm {
     static constexpr const char* kDefaultTraceFile = "gpgmm_event_trace.json";
-    static constexpr double kDefaultFragmentationLimit = 0.125;  // 1/8th or 12.5%
-    static constexpr double kDefaultMemoryGrowthFactor = 1.25;   // 25% growth
+    static constexpr float kDefaultMemoryFragmentationLimit = 0.125f;  // 1/8th or 12.5%
+    static constexpr float kDefaultMemoryGrowthFactor = 1.25f;         // 25% growth
 }  // namespace gpgmm
 
 #endif  // GPGMM_COMMON_DEFAULTS_H_

--- a/src/gpgmm/common/SlabMemoryAllocator.cpp
+++ b/src/gpgmm/common/SlabMemoryAllocator.cpp
@@ -82,9 +82,9 @@ namespace gpgmm {
                                              uint64_t maxSlabSize,
                                              uint64_t minSlabSize,
                                              uint64_t slabAlignment,
-                                             double slabFragmentationLimit,
+                                             float slabFragmentationLimit,
                                              bool allowSlabPrefetch,
-                                             double slabGrowthFactor,
+                                             float slabGrowthFactor,
                                              MemoryAllocator* memoryAllocator)
         : mLastUsedSlabSize(0),
           mBlockSize(blockSize),
@@ -97,7 +97,7 @@ namespace gpgmm {
           mMemoryAllocator(memoryAllocator) {
         ASSERT(IsPowerOfTwo(mSlabAlignment));
         ASSERT(mMemoryAllocator != nullptr);
-        ASSERT(mSlabGrowthFactor >= 1);
+        ASSERT(mSlabGrowthFactor >= 1.0f);
         ASSERT(IsAligned(mMaxSlabSize, mSlabAlignment));
         ASSERT(IsAligned(mMinSlabSize, mSlabAlignment));
         ASSERT(blockSize <= mMaxSlabSize);
@@ -488,9 +488,9 @@ namespace gpgmm {
     SlabCacheAllocator::SlabCacheAllocator(uint64_t maxSlabSize,
                                            uint64_t minSlabSize,
                                            uint64_t slabAlignment,
-                                           double slabFragmentationLimit,
+                                           float slabFragmentationLimit,
                                            bool allowPrefetchSlab,
-                                           double slabGrowthFactor,
+                                           float slabGrowthFactor,
                                            std::unique_ptr<MemoryAllocator> memoryAllocator)
         : MemoryAllocator(std::move(memoryAllocator)),
           mMaxSlabSize(maxSlabSize),

--- a/src/gpgmm/common/SlabMemoryAllocator.h
+++ b/src/gpgmm/common/SlabMemoryAllocator.h
@@ -48,9 +48,9 @@ namespace gpgmm {
                             uint64_t maxSlabSize,
                             uint64_t minSlabSize,
                             uint64_t slabAlignment,
-                            double slabFragmentationLimit,
+                            float slabFragmentationLimit,
                             bool allowSlabPrefetch,
-                            double slabGrowthFactor,
+                            float slabGrowthFactor,
                             MemoryAllocator* memoryAllocator);
         ~SlabMemoryAllocator() override;
 
@@ -99,9 +99,9 @@ namespace gpgmm {
         const uint64_t mMaxSlabSize;
         const uint64_t mMinSlabSize;  // Optional size when non-zero.
 
-        const double mSlabFragmentationLimit;
+        const float mSlabFragmentationLimit;
         const bool mAllowSlabPrefetch;
-        const double mSlabGrowthFactor;
+        const float mSlabGrowthFactor;
 
         MemoryAllocator* mMemoryAllocator = nullptr;
         std::shared_ptr<MemoryAllocationEvent> mNextSlabAllocationEvent;
@@ -114,9 +114,9 @@ namespace gpgmm {
         SlabCacheAllocator(uint64_t maxSlabSize,
                            uint64_t minSlabSize,
                            uint64_t slabAlignment,
-                           double slabFragmentationLimit,
+                           float slabFragmentationLimit,
                            bool allowSlabPrefetch,
-                           double slabGrowthFactor,
+                           float slabGrowthFactor,
                            std::unique_ptr<MemoryAllocator> memoryAllocator);
 
         ~SlabCacheAllocator() override;
@@ -153,9 +153,9 @@ namespace gpgmm {
         const uint64_t mMinSlabSize;
         const uint64_t mSlabAlignment;
 
-        const double mSlabFragmentationLimit;
+        const float mSlabFragmentationLimit;
         const bool mAllowSlabPrefetch;
-        const double mSlabGrowthFactor;
+        const float mSlabGrowthFactor;
 
         MemoryCache<SlabAllocatorCacheEntry> mSizeCache;
     };

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -478,7 +478,7 @@ namespace gpgmm::d3d12 {
 
         RESOURCE_ALLOCATOR_DESC newDescriptor = allocatorDescriptor;
         newDescriptor.ResourceHeapGrowthFactor =
-            (allocatorDescriptor.ResourceHeapGrowthFactor >= 1.0)
+            (allocatorDescriptor.ResourceHeapGrowthFactor >= 1.0f)
                 ? allocatorDescriptor.ResourceHeapGrowthFactor
                 : kDefaultMemoryGrowthFactor;
 
@@ -528,7 +528,7 @@ namespace gpgmm::d3d12 {
         newDescriptor.ResourceHeapFragmentationLimit =
             (allocatorDescriptor.ResourceHeapFragmentationLimit > 0)
                 ? allocatorDescriptor.ResourceHeapFragmentationLimit
-                : kDefaultFragmentationLimit;
+                : kDefaultMemoryFragmentationLimit;
 
         if (newDescriptor.PreferredResourceHeapSize > newDescriptor.MaxResourceHeapSize) {
             ErrorLog(MessageId::kInvalidArgument, true)
@@ -719,8 +719,8 @@ namespace gpgmm::d3d12 {
         ALLOCATOR_ALGORITHM algorithm,
         uint64_t memorySize,
         uint64_t memoryAlignment,
-        double memoryFragmentationLimit,
-        double memoryGrowthFactor,
+        float memoryFragmentationLimit,
+        float memoryGrowthFactor,
         bool isPrefetchAllowed,
         std::unique_ptr<MemoryAllocator> underlyingAllocator) {
         switch (algorithm) {
@@ -803,7 +803,7 @@ namespace gpgmm::d3d12 {
         // be smaller then the resource heap alignment.
         return CreateSubAllocator(
             descriptor.SubAllocationAlgorithm, heapSize, heapAlignment,
-            /*memoryFragmentationLimit*/ 1, descriptor.ResourceHeapGrowthFactor,
+            /*memoryFragmentationLimit*/ 1.0f, descriptor.ResourceHeapGrowthFactor,
             /*allowSlabPrefetch*/ false, std::move(pooledOrNonPooledAllocator));
     }
 

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -116,8 +116,8 @@ namespace gpgmm::d3d12 {
             ALLOCATOR_ALGORITHM algorithm,
             uint64_t memorySize,
             uint64_t memoryAlignment,
-            double memoryFragmentationLimit,
-            double memoryGrowthFactor,
+            float memoryFragmentationLimit,
+            float memoryGrowthFactor,
             bool isPrefetchAllowed,
             std::unique_ptr<MemoryAllocator> underlyingAllocator);
 

--- a/src/gpgmm/vk/ResourceAllocatorVk.cpp
+++ b/src/gpgmm/vk/ResourceAllocatorVk.cpp
@@ -229,7 +229,7 @@ namespace gpgmm::vk {
 
         newInfo.memoryFragmentationLimit = (newInfo.memoryFragmentationLimit > 0)
                                                ? newInfo.memoryFragmentationLimit
-                                               : kDefaultFragmentationLimit;
+                                               : kDefaultMemoryFragmentationLimit;
 
         // By default, slab-allocate from a sorted segmented list.
         if (newInfo.poolAlgorithm == GP_ALLOCATOR_ALGORITHM_DEFAULT) {

--- a/src/tests/capture_replay_tests/D3D12MemoryTraceReplay.cpp
+++ b/src/tests/capture_replay_tests/D3D12MemoryTraceReplay.cpp
@@ -102,9 +102,9 @@ namespace {
             allocatorDescJson["PreferredResourceHeapSize"].asUInt64();
         newAllocatorDesc.MaxResourceHeapSize = allocatorDescJson["MaxResourceHeapSize"].asUInt64();
         newAllocatorDesc.ResourceHeapFragmentationLimit =
-            allocatorDescJson["ResourceHeapFragmentationLimit"].asDouble();
+            allocatorDescJson["ResourceHeapFragmentationLimit"].asFloat();
         newAllocatorDesc.ResourceHeapGrowthFactor =
-            allocatorDescJson["ResourceHeapGrowthFactor"].asDouble();
+            allocatorDescJson["ResourceHeapGrowthFactor"].asFloat();
         return newAllocatorDesc;
     }
 
@@ -476,7 +476,7 @@ class D3D12MemoryTraceReplay : public D3D12TestBase, public CaptureReplayTestWit
                             allocatorDescOfProfile.Flags |=
                                 RESOURCE_ALLOCATOR_FLAG_ALWAYS_ON_DEMAND;
                             allocatorDescOfProfile.ResourceHeapFragmentationLimit =
-                                0.125;  // 1/8th of 4MB
+                                0.125f;  // 1/8th of 4MB
                         }
 
                         ComPtr<IResidencyManager> residencyManager;

--- a/src/tests/end2end/D3D12ResidencyManagerTests.cpp
+++ b/src/tests/end2end/D3D12ResidencyManagerTests.cpp
@@ -50,7 +50,7 @@ class D3D12ResidencyManagerTests : public D3D12TestBase, public ::testing::Test 
 
         // Disable memory growth so older heap being paged out are the same size as newer heaps
         // being paged-in, and the test expectation based on these sizes is easy to determine.
-        desc.ResourceHeapGrowthFactor = 1.0;
+        desc.ResourceHeapGrowthFactor = 1.0f;
 
         return desc;
     }
@@ -579,7 +579,7 @@ TEST_F(D3D12ResidencyManagerTests, OverBudgetDisablesGrowth) {
         CreateResidencyManager(residencyDesc, mDevice.Get(), mAdapter.Get(), &residencyManager));
 
     RESOURCE_ALLOCATOR_DESC allocatorDesc = CreateBasicAllocatorDesc();
-    allocatorDesc.ResourceHeapGrowthFactor = 2;
+    allocatorDesc.ResourceHeapGrowthFactor = 2.0f;
 
     ComPtr<IResourceAllocator> resourceAllocator;
     ASSERT_SUCCEEDED(CreateResourceAllocator(CreateBasicAllocatorDesc(), mDevice.Get(),

--- a/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
+++ b/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
@@ -1672,7 +1672,7 @@ TEST_F(D3D12ResourceAllocatorTests, CreateTexturePooled) {
 // fragmentation limit.
 TEST_F(D3D12ResourceAllocatorTests, CreateBufferWithLimitedFragmentation) {
     RESOURCE_ALLOCATOR_DESC allocatorDesc = CreateBasicAllocatorDesc();
-    allocatorDesc.ResourceHeapFragmentationLimit = 0.0265;  // or 2.65%
+    allocatorDesc.ResourceHeapFragmentationLimit = 0.0265f;  // or 2.65%
 
     ALLOCATION_DESC baseAllocationDesc = {};
     baseAllocationDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;


### PR DESCRIPTION
Removes STL type dependency when using D3D12 header.