### PR TITLE
Rename [Next|Prev|PowerOfTwo to [Upper|Lower]PowerOfTwo.

### DIFF
--- a/src/gpgmm/common/BuddyMemoryAllocator.cpp
+++ b/src/gpgmm/common/BuddyMemoryAllocator.cpp
@@ -51,7 +51,7 @@ namespace gpgmm {
         GPGMM_RETURN_ERROR_IF(!ValidateRequest(request));
 
         // Round allocation size to nearest power-of-two.
-        const uint64_t allocationSize = NextPowerOfTwo(request.SizeInBytes);
+        const uint64_t allocationSize = UpperPowerOfTwo(request.SizeInBytes);
 
         // Request cannot exceed memory size.
         GPGMM_RETURN_ERROR_IF(allocationSize > mMemorySize);

--- a/src/gpgmm/common/SlabMemoryAllocator.cpp
+++ b/src/gpgmm/common/SlabMemoryAllocator.cpp
@@ -141,7 +141,7 @@ namespace gpgmm {
             slabSize *= 2;
         }
 
-        slabSize = NextPowerOfTwo(slabSize);
+        slabSize = UpperPowerOfTwo(slabSize);
 
         // If the larger slab excceeds available memory, re-use a slab instead.
         // Otherwise, creating a larger slab will page-out smaller slabs.

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -728,8 +728,8 @@ namespace gpgmm::d3d12 {
             case ALLOCATOR_ALGORITHM_BUDDY_SYSTEM: {
                 // System and memory size must be aligned at creation-time.
                 return std::make_unique<BuddyMemoryAllocator>(
-                    /*systemSize*/ PrevPowerOfTwo(mMaxResourceHeapSize),
-                    /*memorySize*/ NextPowerOfTwo(memorySize),
+                    /*systemSize*/ LowerPowerOfTwo(mMaxResourceHeapSize),
+                    /*memorySize*/ UpperPowerOfTwo(memorySize),
                     /*memoryAlignment*/ memoryAlignment,
                     /*memoryAllocator*/ std::move(underlyingAllocator));
             }
@@ -737,7 +737,7 @@ namespace gpgmm::d3d12 {
                 // Min slab size is always equal to the memory size because the
                 // slab allocator aligns the slab size at allocate-time.
                 return std::make_unique<SlabCacheAllocator>(
-                    /*maxSlabSize*/ PrevPowerOfTwo(mMaxResourceHeapSize),
+                    /*maxSlabSize*/ LowerPowerOfTwo(mMaxResourceHeapSize),
                     /*minSlabSize*/ memorySize,
                     /*slabAlignment*/ memoryAlignment,
                     /*slabFragmentationLimit*/ memoryFragmentationLimit,
@@ -1170,7 +1170,7 @@ namespace gpgmm::d3d12 {
                 // Only constant buffers must be 256B aligned.
                 request.Alignment = (initialResourceState == D3D12_RESOURCE_STATE_GENERIC_READ)
                                         ? D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT
-                                        : NextPowerOfTwo(newResourceDesc.Width);
+                                        : UpperPowerOfTwo(newResourceDesc.Width);
             } else {
                 request.Alignment = resourceDescriptor.Alignment;
             }

--- a/src/gpgmm/utils/Math.cpp
+++ b/src/gpgmm/utils/Math.cpp
@@ -74,7 +74,7 @@ namespace gpgmm {
 #endif      // defined(GPGMM_COMPILER_MSVC)
     }
 
-    uint64_t NextPowerOfTwo(uint64_t number) {
+    uint64_t UpperPowerOfTwo(uint64_t number) {
         if (number <= 1) {
             return 1;
         }
@@ -82,7 +82,7 @@ namespace gpgmm {
         return 1ull << (Log2(number - 1) + 1);
     }
 
-    uint64_t PrevPowerOfTwo(uint64_t number) {
+    uint64_t LowerPowerOfTwo(uint64_t number) {
         ASSERT(number != 0);
         return 1ull << Log2(number);
     }

--- a/src/gpgmm/utils/Math.h
+++ b/src/gpgmm/utils/Math.h
@@ -29,10 +29,10 @@ namespace gpgmm {
     uint32_t ScanForward(uint32_t bits);
     uint32_t Log2(uint32_t number);
     uint32_t Log2(uint64_t number);
-    uint64_t PrevPowerOfTwo(uint64_t number);
+    uint64_t LowerPowerOfTwo(uint64_t number);
 
     bool IsPowerOfTwo(uint64_t number);
-    uint64_t NextPowerOfTwo(uint64_t number);
+    uint64_t UpperPowerOfTwo(uint64_t number);
     bool IsAligned(uint64_t number, size_t multiple);
 
     // Aligns number to the nearest power-of-two multiple.

--- a/src/tests/unittests/MathTests.cpp
+++ b/src/tests/unittests/MathTests.cpp
@@ -36,17 +36,17 @@ TEST(MathTests, IsPowerOfTwo) {
     EXPECT_FALSE(IsPowerOfTwo(3u));
 }
 
-TEST(MathTests, PrevPowerOfTwo) {
+TEST(MathTests, LowerPowerOfTwo) {
     // Check number from POT.
-    EXPECT_EQ(PrevPowerOfTwo(1u), 1u);
-    EXPECT_EQ(PrevPowerOfTwo(2u), 2u);
+    EXPECT_EQ(LowerPowerOfTwo(1u), 1u);
+    EXPECT_EQ(LowerPowerOfTwo(2u), 2u);
 
     // Check number from NPOT.
-    EXPECT_EQ(PrevPowerOfTwo(3u), 2u);
-    EXPECT_EQ(PrevPowerOfTwo(9u), 8u);
-    EXPECT_EQ(PrevPowerOfTwo(15u), 8u);
+    EXPECT_EQ(LowerPowerOfTwo(3u), 2u);
+    EXPECT_EQ(LowerPowerOfTwo(9u), 8u);
+    EXPECT_EQ(LowerPowerOfTwo(15u), 8u);
 
-    EXPECT_EQ(PrevPowerOfTwo((2ull << 31) + 1), 2ull << 31);
+    EXPECT_EQ(LowerPowerOfTwo((2ull << 31) + 1), 2ull << 31);
 }
 
 TEST(MathTests, IsAligned) {


### PR DESCRIPTION
Better describes what the rounding behavior is.