### PR TITLE
Terminate multi-sampled resource allocators.

### DIFF
--- a/src/gpgmm/common/BUILD.gn
+++ b/src/gpgmm/common/BUILD.gn
@@ -212,6 +212,8 @@ source_set("gpgmm_common_sources") {
     "PooledMemoryAllocator.h",
     "SegmentedMemoryAllocator.cpp",
     "SegmentedMemoryAllocator.h",
+    "SentinelMemoryAllocator.cpp",
+    "SentinelMemoryAllocator.h",
     "SlabBlockAllocator.cpp",
     "SlabBlockAllocator.h",
     "SlabMemoryAllocator.cpp",

--- a/src/gpgmm/common/CMakeLists.txt
+++ b/src/gpgmm/common/CMakeLists.txt
@@ -51,6 +51,8 @@ target_sources(gpgmm_common PRIVATE
     "PooledMemoryAllocator.h"
     "SegmentedMemoryAllocator.cpp"
     "SegmentedMemoryAllocator.h"
+    "SentinelMemoryAllocator.cpp"
+    "SentinelMemoryAllocator.h"
     "SlabBlockAllocator.cpp"
     "SlabBlockAllocator.h"
     "SlabMemoryAllocator.cpp"

--- a/src/gpgmm/common/SentinelMemoryAllocator.cpp
+++ b/src/gpgmm/common/SentinelMemoryAllocator.cpp
@@ -1,0 +1,30 @@
+// Copyright 2023 The GPGMM Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gpgmm/common/SentinelMemoryAllocator.h"
+
+namespace gpgmm {
+
+    ResultOrError<std::unique_ptr<MemoryAllocationBase>> SentinelMemoryAllocator::TryAllocateMemory(
+        const MemoryAllocationRequest& request) {
+        // Return error because |this| represents the last of the chain of allocators that could
+        // process the request.
+        return {};
+    }
+
+    void SentinelMemoryAllocator::DeallocateMemory(
+        std::unique_ptr<MemoryAllocationBase> allocation) {
+        // Do nothing because nothing can be allocated.
+    }
+}  // namespace gpgmm

--- a/src/gpgmm/common/SentinelMemoryAllocator.h
+++ b/src/gpgmm/common/SentinelMemoryAllocator.h
@@ -1,0 +1,40 @@
+// Copyright 2023 The GPGMM Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SRC_GPGMM_COMMON_SENTINELMEMORYALLOCATOR_H_
+#define SRC_GPGMM_COMMON_SENTINELMEMORYALLOCATOR_H_
+
+#include "gpgmm/common/MemoryAllocator.h"
+
+namespace gpgmm {
+
+    // A MemoryAllocator that will be inserted last in the sequence to terminate or reject requests.
+    class SentinelMemoryAllocator final : public MemoryAllocatorBase {
+      public:
+        SentinelMemoryAllocator() = default;
+        ~SentinelMemoryAllocator() override = default;
+
+        // MemoryAllocatorBase interface
+        ResultOrError<std::unique_ptr<MemoryAllocationBase>> TryAllocateMemory(
+            const MemoryAllocationRequest& request) override;
+        void DeallocateMemory(std::unique_ptr<MemoryAllocationBase> allocation) override;
+
+      private:
+        // ObjectBase interface
+        DEFINE_OBJECT_BASE_OVERRIDES(SentinelMemoryAllocator)
+    };
+
+}  // namespace gpgmm
+
+#endif  // SRC_GPGMM_COMMON_SENTINELMEMORYALLOCATOR_H_


### PR DESCRIPTION
Instead of leaving them unused, terminate them by always rejecting requests.