### PR TITLE
Disable background budgets by default.

### DIFF
--- a/include/gpgmm_d3d12.h
+++ b/include/gpgmm_d3d12.h
@@ -403,13 +403,12 @@ namespace gpgmm::d3d12 {
          */
         RESIDENCY_FLAG_NONE = 0x0,
 
-        /** \brief Disables background memory budget updates from OS notifications.
+        /** \brief Allow background budget updates from OS notifications.
 
-        By default, memory budget updates will be pushed by the OS using a background thread. If
-        the OS does not support push notifications or budget updates are not frequent enough, this
-        mechanism can be disabled where a pull-based method is used instead.
+        By default, budget updates will be queried by the residency manager
+        instead of pushed by OS notifications using a background thread.
         */
-        RESIDENCY_FLAG_DISABLE_BACKGROUND_BUDGET_UPDATES = 0x1,
+        RESIDENCY_FLAG_ALLOW_BACKGROUND_BUDGET_UPDATES = 0x1,
 
         /** \brief Specifies if unified memory architecture (UMA) is always disabled.
 

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
@@ -87,11 +87,13 @@ namespace gpgmm::d3d12 {
         std::unique_ptr<ResidencyManager> residencyManager = std::unique_ptr<ResidencyManager>(
             new ResidencyManager(descriptor, pDevice, pAdapter, std::move(caps)));
 
-        // Require automatic video memory budget updates.
-        if (!(descriptor.Flags & RESIDENCY_FLAG_DISABLE_BACKGROUND_BUDGET_UPDATES)) {
-            GPGMM_RETURN_IF_FAILED(residencyManager->StartBudgetNotificationUpdates(), pDevice);
-            DebugLog(residencyManager.get(), MessageId::kBudgetUpdated)
-                << "OS based memory budget updates were successfully enabled.";
+        // Enable automatic video memory budget updates.
+        if (descriptor.Flags & RESIDENCY_FLAG_ALLOW_BACKGROUND_BUDGET_UPDATES) {
+            if (FAILED(residencyManager->StartBudgetNotificationUpdates())) {
+                WarnLog(residencyManager.get(), MessageId::kBudgetUpdated)
+                    << "RESIDENCY_FLAG_ALLOW_BACKGROUND_BUDGET_UPDATES was requested but failed to "
+                       "start.";
+            }
         }
 
         // Set the initial video memory limits.

--- a/src/tests/end2end/D3D12ResidencyManagerTests.cpp
+++ b/src/tests/end2end/D3D12ResidencyManagerTests.cpp
@@ -60,9 +60,6 @@ class D3D12ResidencyManagerTests : public D3D12TestBase, public ::testing::Test 
     RESIDENCY_MANAGER_DESC CreateBasicResidencyDesc(uint64_t budget) const {
         RESIDENCY_MANAGER_DESC residencyDesc = D3D12TestBase::CreateBasicResidencyDesc();
 
-        // Disable automatic budget updates, since it occurs uncontrollably by the OS.
-        residencyDesc.Flags |= RESIDENCY_FLAG_DISABLE_BACKGROUND_BUDGET_UPDATES;
-
         // Specify a restricted budget, the OS budget fluctuates unpredicatbly.
         residencyDesc.MaxBudgetInBytes = budget;
 
@@ -554,7 +551,7 @@ TEST_F(D3D12ResidencyManagerTests, OverBudget) {
 TEST_F(D3D12ResidencyManagerTests, OverBudgetAsync) {
     constexpr uint64_t kBudgetIsDeterminedByOS = 0;
     RESIDENCY_MANAGER_DESC residencyDesc = CreateBasicResidencyDesc(kBudgetIsDeterminedByOS);
-    residencyDesc.Flags ^= RESIDENCY_FLAG_DISABLE_BACKGROUND_BUDGET_UPDATES;
+    residencyDesc.Flags |= RESIDENCY_FLAG_ALLOW_BACKGROUND_BUDGET_UPDATES;
 
     ComPtr<IResidencyManager> residencyManager;
     ASSERT_SUCCEEDED(


### PR DESCRIPTION
Changes DISABLE_BACKGROUND_BUDGET_UPDATES to ALLOW_BACKGROUND_BUDGET_UPDATES to match D3D12's default behavior.