### PR TITLE
Default the creation of resources to being resident.

### DIFF
--- a/include/gpgmm_d3d12.h
+++ b/include/gpgmm_d3d12.h
@@ -814,14 +814,13 @@ namespace gpgmm::d3d12 {
         */
         RESOURCE_ALLOCATOR_FLAG_NEVER_LEAK = 0x20,
 
-        /** \brief Requires resource allocation to be created resident.
+        /** \brief Create resource allocation to be NOT created resident.
 
-        With this flag, resource heaps created by this resource allocator will never specify
+        With this flag, resource heaps created by this resource allocator will specify
         D3D12_HEAP_FLAG_CREATE_NOT_RESIDENT, when supported, to avoid unnecessary GPU paging
-        operations at resource creation, and instead, reverts back to the default behavior of D3D12
-        of always making heaps implicitly resident on creation.
+        operations at resource creation.
         */
-        RESOURCE_ALLOCATOR_FLAG_ALWAYS_RESIDENT = 0x40,
+        RESOURCE_ALLOCATOR_FLAG_CREATE_NOT_RESIDENT = 0x40,
     };
 
     DEFINE_ENUM_FLAG_OPERATORS(RESOURCE_ALLOCATOR_FLAGS)

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -141,7 +141,7 @@ namespace gpgmm::d3d12 {
 
         HRESULT ReportLiveDeviceObjects() const;
 
-        bool IsCreateHeapNotResident() const;
+        bool IsCreateHeapNotResidentEnabled() const;
         bool IsResidencyEnabled() const;
 
         D3D12_RESOURCE_ALLOCATION_INFO GetResourceAllocationInfo(
@@ -166,7 +166,7 @@ namespace gpgmm::d3d12 {
         const bool mFlushEventBuffersOnDestruct;
         const bool mUseDetailedTimingEvents;
         const bool mIsCustomHeapsEnabled;
-        const bool mIsAlwaysCreateResident;
+        const bool mIsCreateNotResidentEnabled;
         const uint64_t mMaxResourceHeapSize;
 
         static constexpr uint64_t kNumOfResourceHeapTypes = 12u;


### PR DESCRIPTION
This is to prevent mistakes of creating a resource allocator then using the allocation without doing some operation to page it in. Rather then assume residency is 100% aware, this reverts back to the D3D12 default of "always resident" on creation.