### PR TITLE
Add support for RESIDENCY_HEAP_FLAG_CREATE_LOCKED.

### DIFF
--- a/include/gpgmm_d3d12.h
+++ b/include/gpgmm_d3d12.h
@@ -137,6 +137,14 @@ namespace gpgmm::d3d12 {
         cannot be determined.
         */
         RESIDENCY_HEAP_FLAG_CREATE_RESIDENT = 0x2,
+
+        /** \brief Creates a residency heap that is locked.
+
+        A locked heap cannot be evicted once made resident.
+
+        This flag is equivalent to calling LockHeap immediately after creation.
+        */
+        RESIDENCY_HEAP_FLAG_CREATE_LOCKED = 0x4,
     };
 
     DEFINE_ENUM_FLAG_OPERATORS(RESIDENCY_HEAP_FLAGS)
@@ -572,6 +580,8 @@ namespace gpgmm::d3d12 {
         Unlocking a heap allows the residency manager will evict it when over budget.
 
         @param pHeap A pointer to the heap being unlocked.
+
+        \return S_OK if unlocking was successful or S_FALSE if a lock remains.
         */
         virtual HRESULT UnlockHeap(IResidencyHeap * pHeap) = 0;
 

--- a/src/gpgmm/d3d12/ErrorD3D12.h
+++ b/src/gpgmm/d3d12/ErrorD3D12.h
@@ -51,6 +51,11 @@
 #define GPGMM_ASSERT_FAILED(hr) ASSERT(SUCCEEDED(hr));
 #define GPGMM_ASSERT_SUCCEEDED(hr) ASSERT(FAILED(hr));
 
+// Same as FAILED but also returns true if S_FALSE.
+// S_FALSE is used to denote a result where the operation didn't do anything.
+// For example, passing NULL to create an object without returning it will destroy it.
+#define GPGMM_UNSUCCESSFUL(hr) (FAILED(hr) || (hr == S_FALSE))
+
 namespace gpgmm::d3d12 {
 
     HRESULT GetErrorResult(ErrorCode error);

--- a/src/gpgmm/d3d12/ResidencyHeapD3D12.h
+++ b/src/gpgmm/d3d12/ResidencyHeapD3D12.h
@@ -59,10 +59,16 @@ namespace gpgmm::d3d12 {
         LPCWSTR GetDebugName() const override;
         HRESULT SetDebugName(LPCWSTR Name) override;
 
+        IResidencyManager* GetResidencyManager() const;
+
+        HRESULT Lock();
+        HRESULT Unlock();
+
       private:
         friend ResidencyManager;
 
-        ResidencyHeap(ComPtr<ID3D12Pageable> pageable,
+        ResidencyHeap(ComPtr<IResidencyManager> residencyManager,
+                      ComPtr<ID3D12Pageable> pageable,
                       const RESIDENCY_HEAP_DESC& descriptor,
                       bool isResidencyDisabled);
 
@@ -87,13 +93,13 @@ namespace gpgmm::d3d12 {
         void AddResidencyLockRef();
         void ReleaseResidencyLock();
 
+        ComPtr<IResidencyManager> mResidencyManager;
         ComPtr<ID3D12Pageable> mPageable;
 
         // mLastUsedFenceValue denotes the last time this pageable was submitted to the GPU.
         uint64_t mLastUsedFenceValue = 0;
         DXGI_MEMORY_SEGMENT_GROUP mHeapSegment;
         RefCounted mResidencyLock;
-        bool mIsResidencyDisabled;
         RESIDENCY_HEAP_STATUS mState;
     };
 }  // namespace gpgmm::d3d12

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
@@ -241,7 +241,7 @@ namespace gpgmm::d3d12 {
 
         // If the heap was never locked, nothing further should be done.
         if (!heap->IsResidencyLocked()) {
-            return S_OK;
+            return S_FALSE;
         }
 
         if (heap->IsInList()) {
@@ -256,7 +256,7 @@ namespace gpgmm::d3d12 {
 
         // If another lock still exists on the heap, nothing further should be done.
         if (heap->IsResidencyLocked()) {
-            return S_OK;
+            return S_FALSE;
         }
 
         // When all locks have been removed, the resource remains resident and becomes tracked in

--- a/src/gpgmm/d3d12/ResourceAllocationD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocationD3D12.h
@@ -61,7 +61,6 @@ namespace gpgmm::d3d12 {
         friend ResourceAllocator;
 
         ResourceAllocation(const RESOURCE_RESOURCE_ALLOCATION_DESC& desc,
-                           ResidencyManager* residencyManager,
                            MemoryAllocatorBase* allocator,
                            ResidencyHeap* resourceHeap,
                            MemoryBlock* block,
@@ -78,7 +77,6 @@ namespace gpgmm::d3d12 {
         // ObjectBase interface
         DEFINE_OBJECT_BASE_OVERRIDES(IResourceAllocation)
 
-        ResidencyManager* const mResidencyManager;
         ComPtr<ID3D12Resource> mResource;
 
         const uint64_t mOffsetFromResource;

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -1332,8 +1332,8 @@ namespace gpgmm::d3d12 {
                     allocationDesc.DebugName = allocationDescriptor.DebugName;
 
                     *ppResourceAllocationOut = new ResourceAllocation(
-                        allocationDesc, mResidencyManager.Get(), subAllocation.GetAllocator(),
-                        resourceHeap, subAllocation.GetBlock(), std::move(committedResource));
+                        allocationDesc, subAllocation.GetAllocator(), resourceHeap,
+                        subAllocation.GetBlock(), std::move(committedResource));
 
                     return S_OK;
                 }));
@@ -1373,8 +1373,8 @@ namespace gpgmm::d3d12 {
                     allocationDesc.DebugName = allocationDescriptor.DebugName;
 
                     *ppResourceAllocationOut = new ResourceAllocation(
-                        allocationDesc, mResidencyManager.Get(), subAllocation.GetAllocator(),
-                        resourceHeap, subAllocation.GetBlock(), std::move(placedResource));
+                        allocationDesc, subAllocation.GetAllocator(), resourceHeap,
+                        subAllocation.GetBlock(), std::move(placedResource));
 
                     return S_OK;
                 }));
@@ -1417,8 +1417,8 @@ namespace gpgmm::d3d12 {
                     allocationDesc.DebugName = allocationDescriptor.DebugName;
 
                     *ppResourceAllocationOut = new ResourceAllocation(
-                        allocationDesc, mResidencyManager.Get(), allocation.GetAllocator(),
-                        resourceHeap, allocation.GetBlock(), std::move(placedResource));
+                        allocationDesc, allocation.GetAllocator(), resourceHeap,
+                        allocation.GetBlock(), std::move(placedResource));
 
                     return S_OK;
                 }));
@@ -1478,8 +1478,7 @@ namespace gpgmm::d3d12 {
 
         if (ppResourceAllocationOut != nullptr) {
             *ppResourceAllocationOut = new ResourceAllocation(
-                allocationDesc, mResidencyManager.Get(), this, resourceHeap.Detach(), nullptr,
-                std::move(committedResource));
+                allocationDesc, this, resourceHeap.Detach(), nullptr, std::move(committedResource));
         }
 
         return ErrorCode::kNone;
@@ -1567,8 +1566,8 @@ namespace gpgmm::d3d12 {
         allocationDesc.Type = RESOURCE_ALLOCATION_TYPE_STANDALONE;
 
         *ppResourceAllocationOut = new ResourceAllocation(
-            allocationDesc, nullptr, this, static_cast<ResidencyHeap*>(resourceHeap.Detach()),
-            nullptr, pCommittedResource);
+            allocationDesc, this, static_cast<ResidencyHeap*>(resourceHeap.Detach()), nullptr,
+            pCommittedResource);
 
         return S_OK;
     }


### PR DESCRIPTION
Instead of having to manually call LockHeap, a creation flag can be used.