### PR TITLE
Fix check when final lock is released for resource allocations.

### DIFF
--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
@@ -241,7 +241,7 @@ namespace gpgmm::d3d12 {
 
         // If the heap was never locked, nothing further should be done.
         if (!heap->IsResidencyLocked()) {
-            return S_FALSE;
+            return S_OK;
         }
 
         if (heap->IsInList()) {

--- a/src/gpgmm/d3d12/ResourceAllocationD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocationD3D12.cpp
@@ -74,8 +74,8 @@ namespace gpgmm::d3d12 {
         // If the developer forgots to unlock the heap, do so now so the heap can be made eligable
         // for eviction.
         ResidencyHeap* residencyHeap = static_cast<ResidencyHeap*>(GetMemory());
-        if (residencyHeap->GetResidencyManager() != nullptr) {
-            residencyHeap->Unlock();
+        if (residencyHeap->GetResidencyManager() != nullptr &&
+            GPGMM_UNSUCCESSFUL(residencyHeap->Unlock())) {
             WarnLog(MessageId::kPerformanceWarning, this)
                 << "Destroying a locked resource allocation is allowed but discouraged. Please "
                    "call UnlockHeap the same number of times as LockHeap before releasing the "

--- a/src/tests/end2end/D3D12ResidencyManagerTests.cpp
+++ b/src/tests/end2end/D3D12ResidencyManagerTests.cpp
@@ -202,6 +202,16 @@ TEST_F(D3D12ResidencyManagerTests, CreateResourceHeapLocked) {
     ASSERT_FAILED(CreateResidencyHeap(lockedResidencyHeapDesc, nullptr,
                                       CreateResourceHeapCallbackContext::CreateHeap,
                                       &createHeapContext, nullptr));
+
+    ASSERT_SUCCEEDED(residencyManager->LockHeap(resourceHeap.Get()));
+
+    // Unlocking a heap with another lock must return S_FALSE.
+    EXPECT_EQ(residencyManager->UnlockHeap(resourceHeap.Get()), S_FALSE);
+    EXPECT_TRUE(resourceHeap->GetInfo().IsLocked);
+
+    // But unlocking the last lock must return S_OK.
+    EXPECT_EQ(residencyManager->UnlockHeap(resourceHeap.Get()), S_OK);
+    EXPECT_FALSE(resourceHeap->GetInfo().IsLocked);
 }
 
 TEST_F(D3D12ResidencyManagerTests, CreateResourceHeap) {


### PR DESCRIPTION
Fixes issue when debug output may appear reguardless if the allocation was already unlocked.