### PR TITLE
Reland "Add GetResidencyManager to IResourceAllocation. (#917)"

### DIFF
--- a/include/gpgmm_d3d12.h
+++ b/include/gpgmm_d3d12.h
@@ -761,6 +761,14 @@ namespace gpgmm::d3d12 {
         \return A pointer to the IResidencyHeap used by this resource allocation.
         */
         virtual IResidencyHeap* GetMemory() const = 0;
+
+        /** \brief Get the residency manager that manages the memory for this resource allocation.
+
+        @param[out] ppResidencyManagerOut Pointer to a memory block that receives a pointer to the
+        residency manager. Pass NULL to test if the residency manager exists.
+        \return S_OK when exists else S_FALSE if NULL was passed to test.
+        */
+        virtual HRESULT GetResidencyManager(IResidencyManager * *ppResidencyManagerOut) const = 0;
     };
 
     /** \enum RESOURCE_ALLOCATOR_FLAGS

--- a/src/gpgmm/d3d12/ResourceAllocationD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocationD3D12.cpp
@@ -197,4 +197,19 @@ namespace gpgmm::d3d12 {
         return DebugObject::SetDebugName(Name);
     }
 
+    HRESULT ResourceAllocation::GetResidencyManager(
+        IResidencyManager** ppResidencyManagerOut) const {
+        ResidencyHeap* residencyHeap = static_cast<ResidencyHeap*>(GetMemory());
+        ASSERT(residencyHeap != nullptr);
+
+        ComPtr<IResidencyManager> residencyManager(residencyHeap->GetResidencyManager());
+        if (ppResidencyManagerOut != nullptr) {
+            *ppResidencyManagerOut = residencyManager.Detach();
+        } else {
+            return S_FALSE;
+        }
+
+        return S_OK;
+    }
+
 }  // namespace gpgmm::d3d12

--- a/src/gpgmm/d3d12/ResourceAllocationD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocationD3D12.h
@@ -50,6 +50,7 @@ namespace gpgmm::d3d12 {
         uint64_t GetOffsetFromResource() const override;
         RESOURCE_ALLOCATION_INFO GetInfo() const override;
         IResidencyHeap* GetMemory() const override;
+        HRESULT GetResidencyManager(IResidencyManager** ppResidencyManagerOut) const override;
 
         DEFINE_UNKNOWN_OVERRIDES()
 

--- a/src/mvi/gpgmm_d3d12.cpp
+++ b/src/mvi/gpgmm_d3d12.cpp
@@ -298,6 +298,11 @@ namespace gpgmm::d3d12 {
         return E_NOTIMPL;
     }
 
+    HRESULT ResourceAllocation::GetResidencyManager(
+        IResidencyManager** ppResidencyManagerOut) const {
+        return E_NOTIMPL;
+    }
+
     // ResourceAllocator
 
     HRESULT CreateResourceAllocator(const RESOURCE_ALLOCATOR_DESC& allocatorDescriptor,

--- a/src/mvi/gpgmm_d3d12.h
+++ b/src/mvi/gpgmm_d3d12.h
@@ -162,6 +162,7 @@ namespace gpgmm::d3d12 {
         uint64_t GetOffsetFromResource() const override;
         RESOURCE_ALLOCATION_INFO GetInfo() const override;
         IResidencyHeap* GetMemory() const override;
+        HRESULT GetResidencyManager(IResidencyManager** ppResidencyManagerOut) const override;
 
         // IUnknown interface
         HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject) override;


### PR DESCRIPTION
Fixes bug where QI was causing access violation.

This reverts commit 30295a363500b6244fff723d1c366efcac81cec7.