### PR TITLE
Make MemoryAllocator ref-counted.

### DIFF
--- a/src/gpgmm/common/BuddyMemoryAllocator.cpp
+++ b/src/gpgmm/common/BuddyMemoryAllocator.cpp
@@ -24,7 +24,7 @@ namespace gpgmm {
     BuddyMemoryAllocator::BuddyMemoryAllocator(uint64_t systemSize,
                                                uint64_t memorySize,
                                                uint64_t memoryAlignment,
-                                               std::unique_ptr<MemoryAllocatorBase> memoryAllocator)
+                                               ScopedRef<MemoryAllocatorBase> memoryAllocator)
         : MemoryAllocatorBase(std::move(memoryAllocator)),
           mMemorySize(memorySize),
           mMemoryAlignment(memoryAlignment),

--- a/src/gpgmm/common/BuddyMemoryAllocator.h
+++ b/src/gpgmm/common/BuddyMemoryAllocator.h
@@ -40,7 +40,7 @@ namespace gpgmm {
         BuddyMemoryAllocator(uint64_t systemSize,
                              uint64_t memorySize,
                              uint64_t memoryAlignment,
-                             std::unique_ptr<MemoryAllocatorBase> memoryAllocator);
+                             ScopedRef<MemoryAllocatorBase> memoryAllocator);
 
         // MemoryAllocatorBase interface
         ResultOrError<std::unique_ptr<MemoryAllocationBase>> TryAllocateMemory(

--- a/src/gpgmm/common/DedicatedMemoryAllocator.cpp
+++ b/src/gpgmm/common/DedicatedMemoryAllocator.cpp
@@ -22,7 +22,7 @@
 namespace gpgmm {
 
     DedicatedMemoryAllocator::DedicatedMemoryAllocator(
-        std::unique_ptr<MemoryAllocatorBase> memoryAllocator,
+        ScopedRef<MemoryAllocatorBase> memoryAllocator,
         uint64_t memoryAlignment)
         : MemoryAllocatorBase(std::move(memoryAllocator)), mMemoryAlignment(memoryAlignment) {
     }

--- a/src/gpgmm/common/DedicatedMemoryAllocator.h
+++ b/src/gpgmm/common/DedicatedMemoryAllocator.h
@@ -25,7 +25,7 @@ namespace gpgmm {
     // memory to be tracked.
     class DedicatedMemoryAllocator final : public MemoryAllocatorBase {
       public:
-        DedicatedMemoryAllocator(std::unique_ptr<MemoryAllocatorBase> memoryAllocator,
+        DedicatedMemoryAllocator(ScopedRef<MemoryAllocatorBase> memoryAllocator,
                                  uint64_t memoryAlignment);
 
         // MemoryAllocatorBase interface

--- a/src/gpgmm/common/MemoryAllocator.cpp
+++ b/src/gpgmm/common/MemoryAllocator.cpp
@@ -90,11 +90,11 @@ namespace gpgmm {
 
     // MemoryAllocatorBase
 
-    MemoryAllocatorBase::MemoryAllocatorBase() {
+    MemoryAllocatorBase::MemoryAllocatorBase() : RefCounted(0) {
     }
 
-    MemoryAllocatorBase::MemoryAllocatorBase(std::unique_ptr<MemoryAllocatorBase> next) {
-        InsertIntoChain(std::move(next));
+    MemoryAllocatorBase::MemoryAllocatorBase(ScopedRef<MemoryAllocatorBase> next) : RefCounted(0) {
+        InsertIntoChain(next);
     }
 
     MemoryAllocatorBase::~MemoryAllocatorBase() {
@@ -110,7 +110,7 @@ namespace gpgmm {
 
         // Deletes adjacent node recursively (post-order).
         if (mNext != nullptr) {
-            SafeDelete(mNext);
+            mNext = nullptr;
         }
 
         if (IsInList()) {
@@ -195,17 +195,17 @@ namespace gpgmm {
     }
 
     MemoryAllocatorBase* MemoryAllocatorBase::GetNextInChain() const {
-        return mNext;
+        return mNext.Get();
     }
 
     MemoryAllocatorBase* MemoryAllocatorBase::GetParent() const {
         return mParent;
     }
 
-    void MemoryAllocatorBase::InsertIntoChain(std::unique_ptr<MemoryAllocatorBase> next) {
+    void MemoryAllocatorBase::InsertIntoChain(ScopedRef<MemoryAllocatorBase> next) {
         ASSERT(next != nullptr);
         next->mParent = this->value();
-        mNext = next.release();
+        mNext = next;
     }
 
 }  // namespace gpgmm

--- a/src/gpgmm/common/MemoryAllocator.h
+++ b/src/gpgmm/common/MemoryAllocator.h
@@ -25,6 +25,7 @@
 #include "gpgmm/utils/Limits.h"
 #include "gpgmm/utils/LinkedList.h"
 #include "gpgmm/utils/Log.h"
+#include "gpgmm/utils/Refcount.h"
 
 #include <memory>
 #include <mutex>
@@ -140,13 +141,15 @@ namespace gpgmm {
     // parent) and the next MemoryAllocatorBase (or child) form a one-way edge. This allows the
     // first-order MemoryAllocatorBase to sub-allocate from larger blocks provided by the
     // second-order MemoryAllocatorBase and so on.
-    class MemoryAllocatorBase : public ObjectBase, public LinkNode<MemoryAllocatorBase> {
+    class MemoryAllocatorBase : public ObjectBase,
+                                public LinkNode<MemoryAllocatorBase>,
+                                public RefCounted {
       public:
         // Constructs a standalone MemoryAllocatorBase.
         MemoryAllocatorBase();
 
         // Constructs a MemoryAllocatorBase that also owns a (child) allocator.
-        explicit MemoryAllocatorBase(std::unique_ptr<MemoryAllocatorBase> next);
+        explicit MemoryAllocatorBase(ScopedRef<MemoryAllocatorBase> next);
 
         virtual ~MemoryAllocatorBase() override;
 
@@ -252,14 +255,14 @@ namespace gpgmm {
                 nullptr, memory, kInvalidOffset, AllocationMethod::kUndefined, block, requestSize);
         }
 
-        void InsertIntoChain(std::unique_ptr<MemoryAllocatorBase> next);
+        void InsertIntoChain(ScopedRef<MemoryAllocatorBase> next);
 
         MemoryAllocatorStats mStats = {};
 
         mutable std::mutex mMutex;
 
       private:
-        MemoryAllocatorBase* mNext = nullptr;
+        ScopedRef<MemoryAllocatorBase> mNext;
         MemoryAllocatorBase* mParent = nullptr;
     };
 

--- a/src/gpgmm/common/PooledMemoryAllocator.cpp
+++ b/src/gpgmm/common/PooledMemoryAllocator.cpp
@@ -21,10 +21,9 @@
 
 namespace gpgmm {
 
-    PooledMemoryAllocator::PooledMemoryAllocator(
-        uint64_t memorySize,
-        uint64_t memoryAlignment,
-        std::unique_ptr<MemoryAllocatorBase> memoryAllocator)
+    PooledMemoryAllocator::PooledMemoryAllocator(uint64_t memorySize,
+                                                 uint64_t memoryAlignment,
+                                                 ScopedRef<MemoryAllocatorBase> memoryAllocator)
         : MemoryAllocatorBase(std::move(memoryAllocator)),
           mPool(new LIFOMemoryPool(memorySize)),
           mMemoryAlignment(memoryAlignment) {

--- a/src/gpgmm/common/PooledMemoryAllocator.h
+++ b/src/gpgmm/common/PooledMemoryAllocator.h
@@ -26,7 +26,7 @@ namespace gpgmm {
       public:
         PooledMemoryAllocator(uint64_t memorySize,
                               uint64_t memoryAlignment,
-                              std::unique_ptr<MemoryAllocatorBase> memoryAllocator);
+                              ScopedRef<MemoryAllocatorBase> memoryAllocator);
         ~PooledMemoryAllocator() override;
 
         // MemoryAllocatorBase interface

--- a/src/gpgmm/common/SegmentedMemoryAllocator.cpp
+++ b/src/gpgmm/common/SegmentedMemoryAllocator.cpp
@@ -79,7 +79,7 @@ namespace gpgmm {
     // SegmentedMemoryAllocator
 
     SegmentedMemoryAllocator::SegmentedMemoryAllocator(
-        std::unique_ptr<MemoryAllocatorBase> memoryAllocator,
+        ScopedRef<MemoryAllocatorBase> memoryAllocator,
         uint64_t memoryAlignment)
         : MemoryAllocatorBase(std::move(memoryAllocator)), mMemoryAlignment(memoryAlignment) {
     }

--- a/src/gpgmm/common/SegmentedMemoryAllocator.h
+++ b/src/gpgmm/common/SegmentedMemoryAllocator.h
@@ -34,7 +34,7 @@ namespace gpgmm {
     // variable-size memory blocks.
     class SegmentedMemoryAllocator : public MemoryAllocatorBase {
       public:
-        SegmentedMemoryAllocator(std::unique_ptr<MemoryAllocatorBase> memoryAllocator,
+        SegmentedMemoryAllocator(ScopedRef<MemoryAllocatorBase> memoryAllocator,
                                  uint64_t memoryAlignment);
         ~SegmentedMemoryAllocator() override;
 

--- a/src/gpgmm/common/SlabMemoryAllocator.cpp
+++ b/src/gpgmm/common/SlabMemoryAllocator.cpp
@@ -492,7 +492,7 @@ namespace gpgmm {
                                            float slabFragmentationLimit,
                                            bool allowPrefetchSlab,
                                            float slabGrowthFactor,
-                                           std::unique_ptr<MemoryAllocatorBase> memoryAllocator)
+                                           ScopedRef<MemoryAllocatorBase> memoryAllocator)
         : MemoryAllocatorBase(std::move(memoryAllocator)),
           mMaxSlabSize(maxSlabSize),
           mMinSlabSize(minSlabSize),

--- a/src/gpgmm/common/SlabMemoryAllocator.h
+++ b/src/gpgmm/common/SlabMemoryAllocator.h
@@ -117,7 +117,7 @@ namespace gpgmm {
                            float slabFragmentationLimit,
                            bool allowSlabPrefetch,
                            float slabGrowthFactor,
-                           std::unique_ptr<MemoryAllocatorBase> memoryAllocator);
+                           ScopedRef<MemoryAllocatorBase> memoryAllocator);
 
         ~SlabCacheAllocator() override;
 

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -95,34 +95,34 @@ namespace gpgmm::d3d12 {
                                           const D3D12_CLEAR_VALUE* clearValue,
                                           ResourceAllocation** ppResourceAllocationOut);
 
-        std::unique_ptr<MemoryAllocatorBase> CreateResourceAllocator(
+        ScopedRef<MemoryAllocatorBase> CreateResourceAllocator(
             const RESOURCE_ALLOCATOR_DESC& descriptor,
             D3D12_HEAP_FLAGS heapFlags,
             const D3D12_HEAP_PROPERTIES& heapProperties,
             uint64_t heapAlignment);
 
-        std::unique_ptr<MemoryAllocatorBase> CreateSmallBufferAllocator(
+        ScopedRef<MemoryAllocatorBase> CreateSmallBufferAllocator(
             const RESOURCE_ALLOCATOR_DESC& descriptor,
             D3D12_HEAP_FLAGS heapFlags,
             const D3D12_HEAP_PROPERTIES& heapProperties,
             uint64_t heapAlignment,
             D3D12_RESOURCE_STATES initialResourceState);
 
-        std::unique_ptr<MemoryAllocatorBase> CreatePoolAllocator(
+        ScopedRef<MemoryAllocatorBase> CreatePoolAllocator(
             RESOURCE_ALLOCATION_ALGORITHM algorithm,
             uint64_t memorySize,
             uint64_t memoryAlignment,
             bool isAlwaysOnDemand,
-            std::unique_ptr<MemoryAllocatorBase> underlyingAllocator);
+            ScopedRef<MemoryAllocatorBase> underlyingAllocator);
 
-        std::unique_ptr<MemoryAllocatorBase> CreateSubAllocator(
+        ScopedRef<MemoryAllocatorBase> CreateSubAllocator(
             RESOURCE_ALLOCATION_ALGORITHM algorithm,
             uint64_t memorySize,
             uint64_t memoryAlignment,
             float memoryFragmentationLimit,
             float memoryGrowthFactor,
             bool isPrefetchAllowed,
-            std::unique_ptr<MemoryAllocatorBase> underlyingAllocator);
+            ScopedRef<MemoryAllocatorBase> underlyingAllocator);
 
         HRESULT CreatePlacedResource(ResidencyHeap* const resourceHeap,
                                      uint64_t resourceOffset,
@@ -176,20 +176,20 @@ namespace gpgmm::d3d12 {
 
         static constexpr uint64_t kNumOfResourceHeapTypes = 12u;
 
-        std::array<std::unique_ptr<MemoryAllocatorBase>, kNumOfResourceHeapTypes>
+        std::array<ScopedRef<MemoryAllocatorBase>, kNumOfResourceHeapTypes>
             mDedicatedResourceAllocatorOfType;
-        std::array<std::unique_ptr<MemoryAllocatorBase>, kNumOfResourceHeapTypes>
+        std::array<ScopedRef<MemoryAllocatorBase>, kNumOfResourceHeapTypes>
             mResourceAllocatorOfType;
 
-        std::array<std::unique_ptr<MemoryAllocatorBase>, kNumOfResourceHeapTypes>
+        std::array<ScopedRef<MemoryAllocatorBase>, kNumOfResourceHeapTypes>
             mMSAADedicatedResourceAllocatorOfType;
-        std::array<std::unique_ptr<MemoryAllocatorBase>, kNumOfResourceHeapTypes>
+        std::array<ScopedRef<MemoryAllocatorBase>, kNumOfResourceHeapTypes>
             mMSAAResourceAllocatorOfType;
 
-        std::array<std::unique_ptr<MemoryAllocatorBase>, kNumOfResourceHeapTypes>
+        std::array<ScopedRef<MemoryAllocatorBase>, kNumOfResourceHeapTypes>
             mSmallBufferAllocatorOfType;
 
-        std::unique_ptr<ResourceAllocationTrackingAllocator> mTrackingAllocator;
+        ScopedRef<ResourceAllocationTrackingAllocator> mTrackingAllocator;
     };
 
 }  // namespace gpgmm::d3d12

--- a/src/gpgmm/utils/RefCount.h
+++ b/src/gpgmm/utils/RefCount.h
@@ -86,6 +86,11 @@ namespace gpgmm {
             return *this;
         }
 
+        ScopedRef& operator=(nullptr_t) {
+            SafeRelease(mPtr);
+            return *this;
+        }
+
         T* Get() const {
             return mPtr;
         }
@@ -120,6 +125,10 @@ namespace gpgmm {
 
         bool operator!=(const ScopedRef& other) const {
             return !operator==(other);
+        }
+
+        operator bool() const {
+            return mPtr != nullptr;
         }
 
       private:

--- a/src/gpgmm/vk/ResourceAllocatorVk.h
+++ b/src/gpgmm/vk/ResourceAllocatorVk.h
@@ -57,15 +57,14 @@ namespace gpgmm::vk {
                                      const GpResourceAllocationCreateInfo& allocationInfo,
                                      uint32_t* memoryTypeIndexOut);
 
-        std::unique_ptr<MemoryAllocatorBase> CreateDeviceMemoryAllocator(
+        ScopedRef<MemoryAllocatorBase> CreateDeviceMemoryAllocator(
             const GpAllocatorCreateInfo& info,
             uint64_t memoryTypeIndex,
             uint64_t memoryAlignment);
 
-        std::unique_ptr<MemoryAllocatorBase> CreateResourceSubAllocator(
-            const GpAllocatorCreateInfo& info,
-            uint64_t memoryTypeIndex,
-            uint64_t memoryAlignment);
+        ScopedRef<MemoryAllocatorBase> CreateResourceSubAllocator(const GpAllocatorCreateInfo& info,
+                                                                  uint64_t memoryTypeIndex,
+                                                                  uint64_t memoryAlignment);
 
         // ObjectBase interface
         DEFINE_OBJECT_BASE_OVERRIDES(GpResourceAllocator_T)
@@ -74,8 +73,8 @@ namespace gpgmm::vk {
         VulkanFunctions mVulkanFunctions;
         std::unique_ptr<Caps> mCaps;
 
-        std::vector<std::unique_ptr<MemoryAllocatorBase>> mResourceAllocatorsPerType;
-        std::vector<std::unique_ptr<MemoryAllocatorBase>> mDeviceAllocatorsPerType;
+        std::vector<ScopedRef<MemoryAllocatorBase>> mResourceAllocatorsPerType;
+        std::vector<ScopedRef<MemoryAllocatorBase>> mDeviceAllocatorsPerType;
         std::vector<VkMemoryType> mMemoryTypes;
     };
 

--- a/src/tests/DummyMemoryAllocator.h
+++ b/src/tests/DummyMemoryAllocator.h
@@ -31,7 +31,7 @@ namespace gpgmm {
       public:
         DummyMemoryAllocator() = default;
 
-        explicit DummyMemoryAllocator(std::unique_ptr<MemoryAllocatorBase> next)
+        explicit DummyMemoryAllocator(ScopedRef<MemoryAllocatorBase> next)
             : MemoryAllocatorBase(std::move(next)) {
         }
 

--- a/src/tests/perftests/MemoryAllocatorPerfTests.cpp
+++ b/src/tests/perftests/MemoryAllocatorPerfTests.cpp
@@ -81,7 +81,7 @@ class SingleSizeAllocationPerfTests : public MemoryAllocatorPerfTests {
 BENCHMARK_DEFINE_F(SingleSizeAllocationPerfTests, SlabCache_Warm)(benchmark::State& state) {
     SlabCacheAllocator allocator(state.range(1), state.range(0), kMemoryAlignment, kMemoryAlignment,
                                  /*allowPrefetch*/ false, kDisableSlabGrowth,
-                                 std::make_unique<DummyMemoryAllocator>());
+                                 new DummyMemoryAllocator);
 
     // Below is effectively equivelent to STL's reserve(size=1).
     {
@@ -99,7 +99,7 @@ BENCHMARK_DEFINE_F(SingleSizeAllocationPerfTests, SlabCache_Warm)(benchmark::Sta
 BENCHMARK_DEFINE_F(SingleSizeAllocationPerfTests, SlabCache_Cold)(benchmark::State& state) {
     SlabCacheAllocator allocator(state.range(1), state.range(0), kMemoryAlignment,
                                  /*slabFragmentationLimit*/ 1, /*allowPrefetch*/ false,
-                                 kDisableSlabGrowth, std::make_unique<DummyMemoryAllocator>());
+                                 kDisableSlabGrowth, new DummyMemoryAllocator);
 
     for (auto _ : state) {
         SingleStep(state, &allocator, CreateBasicRequest(state.range(2)));
@@ -107,11 +107,10 @@ BENCHMARK_DEFINE_F(SingleSizeAllocationPerfTests, SlabCache_Cold)(benchmark::Sta
 }
 
 BENCHMARK_DEFINE_F(SingleSizeAllocationPerfTests, Slab)(benchmark::State& state) {
-    std::unique_ptr<DummyMemoryAllocator> memoryAllocator =
-        std::make_unique<DummyMemoryAllocator>();
+    ScopedRef<DummyMemoryAllocator> memoryAllocator(new DummyMemoryAllocator);
     SlabMemoryAllocator allocator(state.range(2), state.range(1), state.range(0), kMemoryAlignment,
                                   /*slabFragmentationLimit*/ 1, /*allowPrefetch*/ false,
-                                  /*slabGrowthFactor*/ 1, memoryAllocator.get());
+                                  /*slabGrowthFactor*/ 1, memoryAllocator.Get());
 
     for (auto _ : state) {
         SingleStep(state, &allocator, CreateBasicRequest(state.range(2)));
@@ -120,7 +119,7 @@ BENCHMARK_DEFINE_F(SingleSizeAllocationPerfTests, Slab)(benchmark::State& state)
 
 BENCHMARK_DEFINE_F(SingleSizeAllocationPerfTests, BuddySystem)(benchmark::State& state) {
     BuddyMemoryAllocator allocator(state.range(1), state.range(0), kMemoryAlignment,
-                                   std::make_unique<DummyMemoryAllocator>());
+                                   new DummyMemoryAllocator);
 
     for (auto _ : state) {
         SingleStep(state, &allocator, CreateBasicRequest(state.range(2)));
@@ -128,7 +127,7 @@ BENCHMARK_DEFINE_F(SingleSizeAllocationPerfTests, BuddySystem)(benchmark::State&
 }
 
 BENCHMARK_DEFINE_F(SingleSizeAllocationPerfTests, Standalone)(benchmark::State& state) {
-    DedicatedMemoryAllocator allocator(std::make_unique<DummyMemoryAllocator>(), kMemoryAlignment);
+    DedicatedMemoryAllocator allocator(new DummyMemoryAllocator, kMemoryAlignment);
 
     for (auto _ : state) {
         SingleStep(state, &allocator, CreateBasicRequest(state.range(2)));
@@ -136,7 +135,7 @@ BENCHMARK_DEFINE_F(SingleSizeAllocationPerfTests, Standalone)(benchmark::State& 
 }
 
 BENCHMARK_DEFINE_F(SingleSizeAllocationPerfTests, SegmentedPool)(benchmark::State& state) {
-    SegmentedMemoryAllocator allocator(std::make_unique<DummyMemoryAllocator>(), kMemoryAlignment);
+    SegmentedMemoryAllocator allocator(new DummyMemoryAllocator, kMemoryAlignment);
 
     for (auto _ : state) {
         SingleStep(state, &allocator, CreateBasicRequest(state.range(2)));

--- a/src/tests/unittests/BuddyMemoryAllocatorTests.cpp
+++ b/src/tests/unittests/BuddyMemoryAllocatorTests.cpp
@@ -52,7 +52,7 @@ TEST_F(BuddyMemoryAllocatorTests, SingleHeap) {
     //
     constexpr uint64_t maxBlockSize = kDefaultMemorySize;
     BuddyMemoryAllocator allocator(maxBlockSize, kDefaultMemorySize, kDefaultMemoryAlignment,
-                                   std::make_unique<DummyMemoryAllocator>());
+                                   new DummyMemoryAllocator);
 
     // Cannot allocate greater than heap size.
     {
@@ -95,7 +95,7 @@ TEST_F(BuddyMemoryAllocatorTests, MultipleHeaps) {
     //
     constexpr uint64_t maxBlockSize = 256;
     BuddyMemoryAllocator allocator(maxBlockSize, kDefaultMemorySize, kDefaultMemoryAlignment,
-                                   std::make_unique<DummyMemoryAllocator>());
+                                   new DummyMemoryAllocator);
 
     // Cannot allocate greater than heap size.
     {
@@ -157,7 +157,7 @@ TEST_F(BuddyMemoryAllocatorTests, MultipleSplitHeaps) {
     //
     constexpr uint64_t maxBlockSize = 256;
     BuddyMemoryAllocator allocator(maxBlockSize, kDefaultMemorySize, kDefaultMemoryAlignment,
-                                   std::make_unique<DummyMemoryAllocator>());
+                                   new DummyMemoryAllocator);
 
     // Allocate two 64 byte sub-allocations.
     std::unique_ptr<MemoryAllocationBase> allocation1 =
@@ -220,7 +220,7 @@ TEST_F(BuddyMemoryAllocatorTests, MultiplSplitHeapsVariableSizes) {
     //
     constexpr uint64_t maxBlockSize = 512;
     BuddyMemoryAllocator allocator(maxBlockSize, kDefaultMemorySize, kDefaultMemoryAlignment,
-                                   std::make_unique<DummyMemoryAllocator>());
+                                   new DummyMemoryAllocator);
 
     // Allocate two 64-byte allocations.
     std::unique_ptr<MemoryAllocationBase> allocation1 =
@@ -311,7 +311,7 @@ TEST_F(BuddyMemoryAllocatorTests, SameSizeVariousAlignment) {
     //
     constexpr uint64_t maxBlockSize = 512;
     BuddyMemoryAllocator allocator(maxBlockSize, kDefaultMemorySize, kDefaultMemoryAlignment,
-                                   std::make_unique<DummyMemoryAllocator>());
+                                   new DummyMemoryAllocator);
 
     std::unique_ptr<MemoryAllocationBase> allocation1 =
         allocator.TryAllocateMemoryForTesting(CreateBasicRequest(64, 128));
@@ -385,7 +385,7 @@ TEST_F(BuddyMemoryAllocatorTests, VariousSizeSameAlignment) {
     //
     constexpr uint64_t maxBlockSize = 512;
     BuddyMemoryAllocator allocator(maxBlockSize, kDefaultMemorySize, kDefaultMemoryAlignment,
-                                   std::make_unique<DummyMemoryAllocator>());
+                                   new DummyMemoryAllocator);
 
     constexpr uint64_t alignment = 64;
 
@@ -448,7 +448,7 @@ TEST_F(BuddyMemoryAllocatorTests, VariousSizeSameAlignment) {
 TEST_F(BuddyMemoryAllocatorTests, AllocationOverflow) {
     constexpr uint64_t maxBlockSize = 512;
     BuddyMemoryAllocator allocator(maxBlockSize, kDefaultMemorySize, kDefaultMemoryAlignment,
-                                   std::make_unique<DummyMemoryAllocator>());
+                                   new DummyMemoryAllocator);
 
     constexpr uint64_t largeBlock = (1ull << 63) + 1;
     std::unique_ptr<MemoryAllocationBase> invalidAllocation = allocator.TryAllocateMemoryForTesting(
@@ -460,8 +460,8 @@ TEST_F(BuddyMemoryAllocatorTests, AllocationOverflow) {
 TEST_F(BuddyMemoryAllocatorTests, ReuseFreedHeaps) {
     constexpr uint64_t kMaxBlockSize = 4096;
 
-    std::unique_ptr<PooledMemoryAllocator> poolAllocator = std::make_unique<PooledMemoryAllocator>(
-        kDefaultMemorySize, kDefaultMemoryAlignment, std::make_unique<DummyMemoryAllocator>());
+    ScopedRef<MemoryAllocatorBase> poolAllocator(new PooledMemoryAllocator(
+        kDefaultMemorySize, kDefaultMemoryAlignment, new DummyMemoryAllocator));
 
     BuddyMemoryAllocator allocator(kMaxBlockSize, kDefaultMemorySize, kDefaultMemoryAlignment,
                                    std::move(poolAllocator));
@@ -521,8 +521,8 @@ TEST_F(BuddyMemoryAllocatorTests, ReuseFreedHeaps) {
 TEST_F(BuddyMemoryAllocatorTests, DestroyHeaps) {
     constexpr uint64_t kMaxBlockSize = 4096;
 
-    std::unique_ptr<PooledMemoryAllocator> poolAllocator = std::make_unique<PooledMemoryAllocator>(
-        kDefaultMemorySize, kDefaultMemoryAlignment, std::make_unique<DummyMemoryAllocator>());
+    ScopedRef<MemoryAllocatorBase> poolAllocator(new PooledMemoryAllocator(
+        kDefaultMemorySize, kDefaultMemoryAlignment, new DummyMemoryAllocator));
     BuddyMemoryAllocator allocator(kMaxBlockSize, kDefaultMemorySize, kDefaultMemoryAlignment,
                                    std::move(poolAllocator));
 

--- a/src/tests/unittests/PooledMemoryAllocatorTests.cpp
+++ b/src/tests/unittests/PooledMemoryAllocatorTests.cpp
@@ -40,7 +40,7 @@ class PooledMemoryAllocatorTests : public testing::Test {
 
 TEST_F(PooledMemoryAllocatorTests, SingleHeap) {
     PooledMemoryAllocator allocator(kDefaultMemorySize, kDefaultMemoryAlignment,
-                                    std::make_unique<DummyMemoryAllocator>());
+                                    new DummyMemoryAllocator);
 
     std::unique_ptr<MemoryAllocationBase> allocation = allocator.TryAllocateMemoryForTesting(
         CreateBasicRequest(kDefaultMemorySize, kDefaultMemoryAlignment));
@@ -58,7 +58,7 @@ TEST_F(PooledMemoryAllocatorTests, SingleHeap) {
 
 TEST_F(PooledMemoryAllocatorTests, MultipleHeaps) {
     PooledMemoryAllocator allocator(kDefaultMemorySize, kDefaultMemoryAlignment,
-                                    std::make_unique<DummyMemoryAllocator>());
+                                    new DummyMemoryAllocator);
 
     std::unique_ptr<MemoryAllocationBase> firstAllocation = allocator.TryAllocateMemoryForTesting(
         CreateBasicRequest(kDefaultMemorySize, kDefaultMemoryAlignment));
@@ -85,7 +85,7 @@ TEST_F(PooledMemoryAllocatorTests, MultipleHeaps) {
 
 TEST_F(PooledMemoryAllocatorTests, ReuseFreedHeaps) {
     PooledMemoryAllocator allocator(kDefaultMemorySize, kDefaultMemoryAlignment,
-                                    std::make_unique<DummyMemoryAllocator>());
+                                    new DummyMemoryAllocator);
     {
         std::unique_ptr<MemoryAllocationBase> allocation = allocator.TryAllocateMemoryForTesting(
             CreateBasicRequest(kDefaultMemorySize, kDefaultMemoryAlignment));
@@ -111,7 +111,7 @@ TEST_F(PooledMemoryAllocatorTests, ReuseFreedHeaps) {
 
 TEST_F(PooledMemoryAllocatorTests, GetInfo) {
     PooledMemoryAllocator allocator(kDefaultMemorySize, kDefaultMemoryAlignment,
-                                    std::make_unique<DummyMemoryAllocator>());
+                                    new DummyMemoryAllocator);
 
     std::unique_ptr<MemoryAllocationBase> allocation = allocator.TryAllocateMemoryForTesting(
         CreateBasicRequest(kDefaultMemorySize, kDefaultMemoryAlignment));

--- a/src/tests/unittests/SegmentedMemoryAllocatorTests.cpp
+++ b/src/tests/unittests/SegmentedMemoryAllocatorTests.cpp
@@ -33,8 +33,7 @@ MemoryAllocationRequest CreateBasicRequest(uint64_t size, uint64_t alignment) {
 }
 
 TEST(SegmentedMemoryAllocatorTests, SingleHeap) {
-    SegmentedMemoryAllocator allocator(std::make_unique<DummyMemoryAllocator>(),
-                                       kDefaultMemoryAlignment);
+    SegmentedMemoryAllocator allocator(new DummyMemoryAllocator, kDefaultMemoryAlignment);
 
     std::unique_ptr<MemoryAllocationBase> allocation = allocator.TryAllocateMemoryForTesting(
         CreateBasicRequest(kDefaultMemorySize, kDefaultMemoryAlignment));
@@ -51,8 +50,7 @@ TEST(SegmentedMemoryAllocatorTests, SingleHeap) {
 }
 
 TEST(SegmentedMemoryAllocatorTests, MultipleHeaps) {
-    SegmentedMemoryAllocator allocator(std::make_unique<DummyMemoryAllocator>(),
-                                       kDefaultMemoryAlignment);
+    SegmentedMemoryAllocator allocator(new DummyMemoryAllocator, kDefaultMemoryAlignment);
 
     std::unique_ptr<MemoryAllocationBase> firstAllocation = allocator.TryAllocateMemoryForTesting(
         CreateBasicRequest(kDefaultMemorySize, kDefaultMemoryAlignment));
@@ -78,8 +76,7 @@ TEST(SegmentedMemoryAllocatorTests, MultipleHeaps) {
 }
 
 TEST(SegmentedMemoryAllocatorTests, MultipleHeapsVariousSizes) {
-    SegmentedMemoryAllocator allocator(std::make_unique<DummyMemoryAllocator>(),
-                                       kDefaultMemoryAlignment);
+    SegmentedMemoryAllocator allocator(new DummyMemoryAllocator, kDefaultMemoryAlignment);
 
     // Append the 1st and 3rd segment, in sequence.
     uint64_t firstMemorySize = kDefaultMemorySize / 2;
@@ -161,8 +158,7 @@ TEST(SegmentedMemoryAllocatorTests, MultipleHeapsVariousSizes) {
 }
 
 TEST(SegmentedMemoryAllocatorTests, ReuseFreedHeaps) {
-    SegmentedMemoryAllocator allocator(std::make_unique<DummyMemoryAllocator>(),
-                                       kDefaultMemoryAlignment);
+    SegmentedMemoryAllocator allocator(new DummyMemoryAllocator, kDefaultMemoryAlignment);
     {
         std::unique_ptr<MemoryAllocationBase> allocation = allocator.TryAllocateMemoryForTesting(
             CreateBasicRequest(kDefaultMemorySize, kDefaultMemoryAlignment));
@@ -187,8 +183,7 @@ TEST(SegmentedMemoryAllocatorTests, ReuseFreedHeaps) {
 }
 
 TEST(SegmentedMemoryAllocatorTests, GetInfo) {
-    SegmentedMemoryAllocator allocator(std::make_unique<DummyMemoryAllocator>(),
-                                       kDefaultMemoryAlignment);
+    SegmentedMemoryAllocator allocator(new DummyMemoryAllocator, kDefaultMemoryAlignment);
 
     std::unique_ptr<MemoryAllocationBase> allocation = allocator.TryAllocateMemoryForTesting(
         CreateBasicRequest(kDefaultMemorySize, kDefaultMemoryAlignment));

--- a/src/tests/unittests/SlabMemoryAllocatorTests.cpp
+++ b/src/tests/unittests/SlabMemoryAllocatorTests.cpp
@@ -51,8 +51,7 @@ class SlabMemoryAllocatorTests : public testing::Test {
 
 // Verify allocation in a single slab.
 TEST_F(SlabMemoryAllocatorTests, SingleSlab) {
-    std::unique_ptr<DummyMemoryAllocator> dummyMemoryAllocator =
-        std::make_unique<DummyMemoryAllocator>();
+    ScopedRef<DummyMemoryAllocator> dummyMemoryAllocator(new DummyMemoryAllocator);
 
     // Verify allocation greater then the block size fails.
     {
@@ -61,7 +60,7 @@ TEST_F(SlabMemoryAllocatorTests, SingleSlab) {
         SlabMemoryAllocator allocator(kBlockSize, kMaxSlabSize, kDefaultSlabSize,
                                       kDefaultSlabAlignment, kDefaultSlabFragmentationLimit,
                                       kNoSlabPrefetchAllowed, kDisableSlabGrowth,
-                                      dummyMemoryAllocator.get());
+                                      dummyMemoryAllocator.Get());
 
         ASSERT_EQ(allocator.TryAllocateMemoryForTesting(CreateBasicRequest(kBlockSize * 2, 1)),
                   nullptr);
@@ -74,7 +73,7 @@ TEST_F(SlabMemoryAllocatorTests, SingleSlab) {
         SlabMemoryAllocator allocator(kBlockSize, kMaxSlabSize, kDefaultSlabSize,
                                       kDefaultSlabAlignment, kDefaultSlabFragmentationLimit,
                                       kNoSlabPrefetchAllowed, kDisableSlabGrowth,
-                                      dummyMemoryAllocator.get());
+                                      dummyMemoryAllocator.Get());
 
         ASSERT_EQ(allocator.TryAllocateMemoryForTesting(CreateBasicRequest(kMaxSlabSize, 1)),
                   nullptr);
@@ -89,7 +88,7 @@ TEST_F(SlabMemoryAllocatorTests, SingleSlab) {
         constexpr uint64_t kMaxSlabSize = kBlockSize;
         SlabMemoryAllocator allocator(kBlockSize, kMaxSlabSize, kSlabSize, kDefaultSlabAlignment,
                                       kDefaultSlabFragmentationLimit, kNoSlabPrefetchAllowed,
-                                      kDisableSlabGrowth, dummyMemoryAllocator.get());
+                                      kDisableSlabGrowth, dummyMemoryAllocator.Get());
 
         std::unique_ptr<MemoryAllocationBase> allocation =
             allocator.TryAllocateMemoryForTesting(CreateBasicRequest(kBlockSize, 1));
@@ -108,7 +107,7 @@ TEST_F(SlabMemoryAllocatorTests, SingleSlab) {
         constexpr uint64_t kSlabSize = 0;  // deduce slab size from allocation size.
         SlabMemoryAllocator allocator(kBlockSize, kMaxSlabSize, kSlabSize, kDefaultSlabAlignment,
                                       kDefaultSlabFragmentationLimit, kNoSlabPrefetchAllowed,
-                                      kDisableSlabGrowth, dummyMemoryAllocator.get());
+                                      kDisableSlabGrowth, dummyMemoryAllocator.Get());
 
         // Max allocation cannot be more than 1/8th the max slab size or 4 bytes.
         // Since a 10 byte allocation requires a 128 byte slab, allocation should always fail.
@@ -133,7 +132,7 @@ TEST_F(SlabMemoryAllocatorTests, SingleSlab) {
         constexpr uint64_t kMaxSlabSize = 128;
         SlabMemoryAllocator allocator(kBlockSize, kMaxSlabSize, kSlabSize, kDefaultSlabAlignment,
                                       kDefaultSlabFragmentationLimit, kNoSlabPrefetchAllowed,
-                                      kDisableSlabGrowth, dummyMemoryAllocator.get());
+                                      kDisableSlabGrowth, dummyMemoryAllocator.Get());
 
         std::unique_ptr<MemoryAllocationBase> allocation =
             allocator.TryAllocateMemoryForTesting(CreateBasicRequest(kBlockSize, 1));
@@ -151,7 +150,7 @@ TEST_F(SlabMemoryAllocatorTests, SingleSlab) {
         constexpr uint64_t kMaxSlabSize = 128;
         SlabMemoryAllocator allocator(kBlockSize, kMaxSlabSize, kSlabSize, kDefaultSlabAlignment,
                                       kDefaultSlabFragmentationLimit, kNoSlabPrefetchAllowed,
-                                      kDisableSlabGrowth, dummyMemoryAllocator.get());
+                                      kDisableSlabGrowth, dummyMemoryAllocator.Get());
 
         std::unique_ptr<MemoryAllocationBase> allocation =
             allocator.TryAllocateMemoryForTesting(CreateBasicRequest(kBlockSize, 1));
@@ -169,7 +168,7 @@ TEST_F(SlabMemoryAllocatorTests, SingleSlab) {
         SlabMemoryAllocator allocator(kBlockSize, kMaxSlabSize, kDefaultSlabSize,
                                       kDefaultSlabAlignment, kDefaultSlabFragmentationLimit,
                                       kNoSlabPrefetchAllowed, kDisableSlabGrowth,
-                                      dummyMemoryAllocator.get());
+                                      dummyMemoryAllocator.Get());
 
         EXPECT_EQ(allocator.TryAllocateMemoryForTesting(CreateBasicRequest(kBlockSize, 1, true)),
                   nullptr);
@@ -184,8 +183,7 @@ TEST_F(SlabMemoryAllocatorTests, SingleSlab) {
 
 // Verify allocation in multiple slabs.
 TEST_F(SlabMemoryAllocatorTests, MultipleSlabs) {
-    std::unique_ptr<DummyMemoryAllocator> dummyMemoryAllocator =
-        std::make_unique<DummyMemoryAllocator>();
+    ScopedRef<DummyMemoryAllocator> dummyMemoryAllocator(new DummyMemoryAllocator);
 
     // Fill up exactly N slabs (allocation = block = slab size).
     {
@@ -195,7 +193,7 @@ TEST_F(SlabMemoryAllocatorTests, MultipleSlabs) {
         SlabMemoryAllocator allocator(kBlockSize, kMaxSlabSize, /*slabSize*/ kBlockSize,
                                       kDefaultSlabAlignment, kDefaultSlabFragmentationLimit,
                                       kNoSlabPrefetchAllowed, kDisableSlabGrowth,
-                                      dummyMemoryAllocator.get());
+                                      dummyMemoryAllocator.Get());
         const uint64_t kNumOfSlabs = 12;
         std::vector<std::unique_ptr<MemoryAllocationBase>> allocations = {};
         for (uint32_t slabi = 0; slabi < kNumOfSlabs; slabi++) {
@@ -222,7 +220,7 @@ TEST_F(SlabMemoryAllocatorTests, MultipleSlabs) {
         SlabMemoryAllocator allocator(kBlockSize, kMaxSlabSize, kDefaultSlabSize,
                                       kDefaultSlabAlignment, kDefaultSlabFragmentationLimit,
                                       kNoSlabPrefetchAllowed, kDisableSlabGrowth,
-                                      dummyMemoryAllocator.get());
+                                      dummyMemoryAllocator.Get());
         // Fill up exactly two 128B slabs.
         std::vector<std::unique_ptr<MemoryAllocationBase>> allocations = {};
         for (uint32_t blocki = 0; blocki < (kDefaultSlabSize * 2 / kBlockSize); blocki++) {
@@ -249,7 +247,7 @@ TEST_F(SlabMemoryAllocatorTests, MultipleSlabs) {
         SlabMemoryAllocator allocator(kBlockSize, kMaxSlabSize, kDefaultSlabSize,
                                       kDefaultSlabAlignment, kDefaultSlabFragmentationLimit,
                                       kNoSlabPrefetchAllowed, kDisableSlabGrowth,
-                                      dummyMemoryAllocator.get());
+                                      dummyMemoryAllocator.Get());
 
         // Both allocation A and B go in Slab A, which will become full.
         std::unique_ptr<MemoryAllocationBase> allocationAinSlabA =
@@ -329,14 +327,13 @@ TEST_F(SlabMemoryAllocatorTests, MultipleSlabs) {
 
 // Verify a very large allocation does not overflow.
 TEST_F(SlabMemoryAllocatorTests, AllocationOverflow) {
-    std::unique_ptr<DummyMemoryAllocator> dummyMemoryAllocator =
-        std::make_unique<DummyMemoryAllocator>();
+    ScopedRef<DummyMemoryAllocator> dummyMemoryAllocator(new DummyMemoryAllocator);
 
     constexpr uint64_t kBlockSize = 32;
     constexpr uint64_t kMaxSlabSize = 512;
     SlabMemoryAllocator allocator(kBlockSize, kMaxSlabSize, kDefaultSlabSize, kDefaultSlabAlignment,
                                   kDefaultSlabFragmentationLimit, kNoSlabPrefetchAllowed,
-                                  kDisableSlabGrowth, dummyMemoryAllocator.get());
+                                  kDisableSlabGrowth, dummyMemoryAllocator.Get());
 
     constexpr uint64_t largeBlock = (1ull << 63) + 1;
     std::unique_ptr<MemoryAllocationBase> invalidAllocation = allocator.TryAllocateMemoryForTesting(
@@ -347,7 +344,7 @@ TEST_F(SlabMemoryAllocatorTests, AllocationOverflow) {
 // Verify slab will be reused from a pool.
 TEST_F(SlabMemoryAllocatorTests, ReuseSlabs) {
     std::unique_ptr<PooledMemoryAllocator> poolAllocator = std::make_unique<PooledMemoryAllocator>(
-        kDefaultSlabSize, kDefaultSlabAlignment, std::make_unique<DummyMemoryAllocator>());
+        kDefaultSlabSize, kDefaultSlabAlignment, new DummyMemoryAllocator);
 
     constexpr uint64_t kBlockSize = 32;
     constexpr uint64_t kMaxSlabSize = 512;
@@ -389,15 +386,14 @@ TEST_F(SlabMemoryAllocatorTests, ReuseSlabs) {
 TEST_F(SlabMemoryAllocatorTests, GetInfo) {
     // Test slab allocator.
     {
-        std::unique_ptr<DummyMemoryAllocator> dummyMemoryAllocator =
-            std::make_unique<DummyMemoryAllocator>();
+        ScopedRef<DummyMemoryAllocator> dummyMemoryAllocator(new DummyMemoryAllocator);
 
         constexpr uint64_t kBlockSize = 32;
         constexpr uint64_t kMaxSlabSize = 512;
         SlabMemoryAllocator allocator(kBlockSize, kMaxSlabSize, kDefaultSlabSize,
                                       kDefaultSlabAlignment, kDefaultSlabFragmentationLimit,
                                       kNoSlabPrefetchAllowed, kDisableSlabGrowth,
-                                      dummyMemoryAllocator.get());
+                                      dummyMemoryAllocator.Get());
 
         std::unique_ptr<MemoryAllocationBase> allocation =
             allocator.TryAllocateMemoryForTesting(CreateBasicRequest(kBlockSize, 1));
@@ -424,7 +420,7 @@ TEST_F(SlabMemoryAllocatorTests, GetInfo) {
     {
         std::unique_ptr<PooledMemoryAllocator> poolAllocator =
             std::make_unique<PooledMemoryAllocator>(kDefaultSlabSize, kDefaultSlabAlignment,
-                                                    std::make_unique<DummyMemoryAllocator>());
+                                                    new DummyMemoryAllocator);
 
         constexpr uint64_t kBlockSize = 32;
         constexpr uint64_t kMaxSlabSize = 512;
@@ -696,7 +692,7 @@ TEST_F(SlabCacheAllocatorTests, SlabOversized) {
     constexpr uint64_t kMinSlabSize = 16;
     SlabCacheAllocator allocator(kMaxSlabSize, kMinSlabSize, kDefaultSlabAlignment,
                                  kDefaultSlabFragmentationLimit, kNoSlabPrefetchAllowed,
-                                 kDisableSlabGrowth, std::make_unique<DummyMemoryAllocator>());
+                                 kDisableSlabGrowth, new DummyMemoryAllocator);
 
     EXPECT_EQ(allocator.TryAllocateMemoryForTesting(CreateBasicRequest(kMaxSlabSize + 1, 1)),
               nullptr);
@@ -707,7 +703,7 @@ TEST_F(SlabCacheAllocatorTests, SingleSlabMultipleSize) {
     constexpr uint64_t kSlabSize = 0;  // deduce slab size from allocation size.
     SlabCacheAllocator allocator(kMaxSlabSize, kSlabSize, kDefaultSlabAlignment,
                                  kDefaultSlabFragmentationLimit, kNoSlabPrefetchAllowed,
-                                 kDisableSlabGrowth, std::make_unique<DummyMemoryAllocator>());
+                                 kDisableSlabGrowth, new DummyMemoryAllocator);
 
     // Verify requesting an allocation without memory will not return a valid allocation.
     {
@@ -725,7 +721,7 @@ TEST_F(SlabCacheAllocatorTests, SingleSlabMultipleAlignments) {
     constexpr uint64_t kSlabSize = 0;  // deduce slab size from allocation size.
     SlabCacheAllocator allocator(kMaxSlabSize, kSlabSize, kDefaultSlabAlignment,
                                  kDefaultSlabFragmentationLimit, kNoSlabPrefetchAllowed,
-                                 kDisableSlabGrowth, std::make_unique<DummyMemoryAllocator>());
+                                 kDisableSlabGrowth, new DummyMemoryAllocator);
 
     // Verify requesting an allocation of same size using multiple alignment succeeds.
     {
@@ -750,7 +746,7 @@ TEST_F(SlabCacheAllocatorTests, MultipleSlabsSameSize) {
     constexpr uint64_t kSlabSize = 0;  // deduce slab size from allocation size.
     SlabCacheAllocator allocator(kMaxSlabSize, kSlabSize, kDefaultSlabAlignment,
                                  kDefaultSlabFragmentationLimit, kNoSlabPrefetchAllowed,
-                                 kDisableSlabGrowth, std::make_unique<DummyMemoryAllocator>());
+                                 kDisableSlabGrowth, new DummyMemoryAllocator);
 
     std::unique_ptr<MemoryAllocationBase> firstAllocation =
         allocator.TryAllocateMemoryForTesting(CreateBasicRequest(22, 1));
@@ -780,7 +776,7 @@ TEST_F(SlabCacheAllocatorTests, MultipleSlabsVariableSizes) {
     constexpr uint64_t kSlabSize = 0;  // deduce slab size from allocation size.
     SlabCacheAllocator allocator(kMaxSlabSize, kSlabSize, kDefaultSlabAlignment,
                                  kDefaultSlabFragmentationLimit, kNoSlabPrefetchAllowed,
-                                 kDisableSlabGrowth, std::make_unique<DummyMemoryAllocator>());
+                                 kDisableSlabGrowth, new DummyMemoryAllocator);
     {
         constexpr uint64_t allocationSize = 22;
         std::unique_ptr<MemoryAllocationBase> allocation =
@@ -824,12 +820,11 @@ TEST_F(SlabCacheAllocatorTests, SingleSlabInBuddy) {
     constexpr uint64_t kMaxBlockSize = 256;
     constexpr uint64_t kMaxSlabSize = kMaxBlockSize;
     constexpr uint64_t kSlabSize = kDefaultSlabSize / 8;
-    SlabCacheAllocator allocator(kMaxSlabSize, kSlabSize, kDefaultSlabAlignment,
-                                 kDefaultSlabFragmentationLimit, kNoSlabPrefetchAllowed,
-                                 kDisableSlabGrowth,
-                                 std::make_unique<BuddyMemoryAllocator>(
-                                     kMaxBlockSize, kDefaultSlabSize, kDefaultSlabAlignment,
-                                     std::make_unique<DummyMemoryAllocator>()));
+    SlabCacheAllocator allocator(
+        kMaxSlabSize, kSlabSize, kDefaultSlabAlignment, kDefaultSlabFragmentationLimit,
+        kNoSlabPrefetchAllowed, kDisableSlabGrowth,
+        new BuddyMemoryAllocator(kMaxBlockSize, kDefaultSlabSize, kDefaultSlabAlignment,
+                                 new DummyMemoryAllocator));
 
     constexpr uint64_t kBlockSize = 4;
     std::unique_ptr<MemoryAllocationBase> allocation =
@@ -848,12 +843,11 @@ TEST_F(SlabCacheAllocatorTests, MultipleSlabsInBuddy) {
     constexpr uint64_t kMaxBlockSize = 256;
     constexpr uint64_t kMaxSlabSize = kMaxBlockSize;
     constexpr uint64_t kSlabSize = kDefaultSlabSize / 8;
-    SlabCacheAllocator allocator(kMaxSlabSize, kSlabSize, kDefaultSlabAlignment,
-                                 kDefaultSlabFragmentationLimit, kNoSlabPrefetchAllowed,
-                                 kDisableSlabGrowth,
-                                 std::make_unique<BuddyMemoryAllocator>(
-                                     kMaxBlockSize, kDefaultSlabSize, kDefaultSlabAlignment,
-                                     std::make_unique<DummyMemoryAllocator>()));
+    SlabCacheAllocator allocator(
+        kMaxSlabSize, kSlabSize, kDefaultSlabAlignment, kDefaultSlabFragmentationLimit,
+        kNoSlabPrefetchAllowed, kDisableSlabGrowth,
+        new BuddyMemoryAllocator(kMaxBlockSize, kDefaultSlabSize, kDefaultSlabAlignment,
+                                 new DummyMemoryAllocator));
 
     // Verify multiple slab-buddy sub-allocation in the same slab are allocated contigiously.
     {
@@ -927,7 +921,7 @@ TEST_F(SlabCacheAllocatorTests, GetInfo) {
         constexpr uint64_t kMaxSlabSize = 512;
         SlabCacheAllocator allocator(kMaxSlabSize, kDefaultSlabSize, kDefaultSlabAlignment,
                                      kDefaultSlabFragmentationLimit, kNoSlabPrefetchAllowed,
-                                     kDisableSlabGrowth, std::make_unique<DummyMemoryAllocator>());
+                                     kDisableSlabGrowth, new DummyMemoryAllocator);
 
         std::unique_ptr<MemoryAllocationBase> allocation =
             allocator.TryAllocateMemoryForTesting(CreateBasicRequest(kBlockSize, 1));
@@ -957,8 +951,8 @@ TEST_F(SlabCacheAllocatorTests, GetInfo) {
         SlabCacheAllocator allocator(
             kMaxSlabSize, kDefaultSlabSize, kDefaultSlabAlignment, kDefaultSlabFragmentationLimit,
             kNoSlabPrefetchAllowed, kDisableSlabGrowth,
-            std::make_unique<PooledMemoryAllocator>(kDefaultSlabSize, kDefaultSlabAlignment,
-                                                    std::make_unique<DummyMemoryAllocator>()));
+            new PooledMemoryAllocator(kDefaultSlabSize, kDefaultSlabAlignment,
+                                      new DummyMemoryAllocator));
 
         std::unique_ptr<MemoryAllocationBase> allocation =
             allocator.TryAllocateMemoryForTesting(CreateBasicRequest(kBlockSize, 1));
@@ -986,12 +980,11 @@ TEST_F(SlabCacheAllocatorTests, GetInfo) {
         constexpr uint64_t kMaxBlockSize = 256;
         constexpr uint64_t kMaxSlabSize = kMaxBlockSize;
         constexpr uint64_t kSlabSize = kDefaultSlabSize / 8;
-        SlabCacheAllocator allocator(kMaxSlabSize, kSlabSize, kDefaultSlabAlignment,
-                                     kDefaultSlabFragmentationLimit, kNoSlabPrefetchAllowed,
-                                     kDisableSlabGrowth,
-                                     std::make_unique<BuddyMemoryAllocator>(
-                                         kMaxBlockSize, kDefaultSlabSize, kDefaultSlabAlignment,
-                                         std::make_unique<DummyMemoryAllocator>()));
+        SlabCacheAllocator allocator(
+            kMaxSlabSize, kSlabSize, kDefaultSlabAlignment, kDefaultSlabFragmentationLimit,
+            kNoSlabPrefetchAllowed, kDisableSlabGrowth,
+            new BuddyMemoryAllocator(kMaxBlockSize, kDefaultSlabSize, kDefaultSlabAlignment,
+                                     new DummyMemoryAllocator));
 
         constexpr uint64_t kBlockSize = 4;
         std::unique_ptr<MemoryAllocationBase> allocation =
@@ -1023,7 +1016,7 @@ TEST_F(SlabCacheAllocatorTests, SlabPrefetch) {
 
     SlabCacheAllocator allocator(kMaxSlabSize, kDefaultSlabSize, kDefaultSlabAlignment,
                                  kDefaultSlabFragmentationLimit, kAllowSlabPrefetching,
-                                 kDisableSlabGrowth, std::make_unique<DummyMemoryAllocator>());
+                                 kDisableSlabGrowth, new DummyMemoryAllocator);
 
     constexpr uint64_t kNumOfSlabs = 10u;
     std::vector<std::unique_ptr<MemoryAllocationBase>> allocations = {};
@@ -1046,7 +1039,7 @@ TEST_F(SlabCacheAllocatorTests, SlabPrefetchDisabled) {
 
     SlabCacheAllocator allocator(kMaxSlabSize, kDefaultSlabSize, kDefaultSlabAlignment,
                                  kDefaultSlabFragmentationLimit, !kAllowSlabPrefetching,
-                                 kDisableSlabGrowth, std::make_unique<DummyMemoryAllocator>());
+                                 kDisableSlabGrowth, new DummyMemoryAllocator);
 
     MemoryAllocationRequest alwaysPrefetchRequest = CreateBasicRequest(kBlockSize, 1);
     alwaysPrefetchRequest.AlwaysPrefetch = true;
@@ -1069,7 +1062,7 @@ TEST_F(SlabCacheAllocatorTests, AlwaysCache) {
     constexpr uint64_t kMaxSlabSize = 512;
     SlabCacheAllocator allocator(kMaxSlabSize, kDefaultSlabSize, kDefaultSlabAlignment,
                                  kDefaultSlabFragmentationLimit, kNoSlabPrefetchAllowed,
-                                 kDisableSlabGrowth, std::make_unique<DummyMemoryAllocator>());
+                                 kDisableSlabGrowth, new DummyMemoryAllocator);
 
     // Re-requesting same size from cached allocation should always succeed.
     MemoryAllocationRequest request = CreateBasicRequest(32, 1);
@@ -1088,7 +1081,7 @@ TEST_F(SlabCacheAllocatorTests, AlwaysCache) {
 TEST_F(SlabCacheAllocatorTests, OutOfMemory) {
     SlabCacheAllocator allocator(kDefaultSlabSize, kDefaultSlabSize, kDefaultSlabAlignment,
                                  kDefaultSlabFragmentationLimit, kNoSlabPrefetchAllowed,
-                                 kDisableSlabGrowth, std::make_unique<DummyMemoryAllocator>());
+                                 kDisableSlabGrowth, new DummyMemoryAllocator);
 
     constexpr uint64_t kTotalMemoryAvailable = 512;
 


### PR DESCRIPTION
Since allocators can retain memory, make them shared so they can be reused.