### PR TITLE
Reuse MemoryAllocationBase upon TryAllocateMemory.

### DIFF
--- a/src/gpgmm/common/BuddyMemoryAllocator.cpp
+++ b/src/gpgmm/common/BuddyMemoryAllocator.cpp
@@ -90,9 +90,11 @@ namespace gpgmm {
         // Memory allocation offset is always memory-relative.
         const uint64_t memoryOffset = block->Offset % mMemorySize;
 
-        return std::make_unique<MemoryAllocationBase>(
-            /*allocator*/ this, subAllocation->GetMemory(), memoryOffset,
-            AllocationMethod::kSubAllocated, block, request.SizeInBytes);
+        subAllocation->SetOffset(memoryOffset);
+        subAllocation->SetMethod(AllocationMethod::kSubAllocated);
+        subAllocation->SetAllocator(this);
+
+        return subAllocation;
     }
 
     void BuddyMemoryAllocator::DeallocateMemory(

--- a/src/gpgmm/common/DedicatedMemoryAllocator.cpp
+++ b/src/gpgmm/common/DedicatedMemoryAllocator.cpp
@@ -46,9 +46,11 @@ namespace gpgmm {
         mStats.UsedBlockCount++;
         mStats.UsedBlockUsage += allocation->GetSize();
 
-        return std::make_unique<MemoryAllocationBase>(
-            this, allocation->GetMemory(), /*offset*/ 0, allocation->GetMethod(),
-            new MemoryBlock{0, allocation->GetSize()}, request.SizeInBytes);
+        allocation->SetOffset(0);
+        allocation->SetAllocator(this);
+        allocation->SetBlock(new MemoryBlock{0, allocation->GetSize()});
+
+        return allocation;
     }
 
     void DedicatedMemoryAllocator::DeallocateMemory(

--- a/src/gpgmm/common/MemoryAllocation.cpp
+++ b/src/gpgmm/common/MemoryAllocation.cpp
@@ -138,4 +138,20 @@ namespace gpgmm {
         return GetRequestSize() != kInvalidSize && GetSize() > GetRequestSize();
     }
 
+    void MemoryAllocationBase::SetOffset(uint64_t offset) {
+        mOffset = offset;
+    }
+
+    void MemoryAllocationBase::SetMethod(AllocationMethod method) {
+        mMethod = method;
+    }
+
+    void MemoryAllocationBase::SetAllocator(MemoryAllocatorBase* allocator) {
+        mAllocator = allocator;
+    }
+
+    void MemoryAllocationBase::SetBlock(MemoryBlock* block) {
+        mBlock = block;
+    }
+
 }  // namespace gpgmm

--- a/src/gpgmm/common/MemoryAllocation.h
+++ b/src/gpgmm/common/MemoryAllocation.h
@@ -77,6 +77,11 @@ namespace gpgmm {
         MemoryBlock* GetBlock() const;
         bool IsRequestedSizeMisaligned() const;
 
+        void SetOffset(uint64_t offset);
+        void SetMethod(AllocationMethod method);
+        void SetAllocator(MemoryAllocatorBase* allocator);
+        void SetBlock(MemoryBlock* block);
+
       protected:
         friend class MemoryAllocatorBase;
 

--- a/src/gpgmm/common/PooledMemoryAllocator.cpp
+++ b/src/gpgmm/common/PooledMemoryAllocator.cpp
@@ -62,7 +62,7 @@ namespace gpgmm {
         MemoryBase* memory = allocation->GetMemory();
         ASSERT(memory != nullptr);
 
-        return std::make_unique<MemoryAllocationBase>(this, memory, allocation->GetRequestSize());
+        return allocation;
     }
 
     void PooledMemoryAllocator::DeallocateMemory(std::unique_ptr<MemoryAllocationBase> allocation) {

--- a/src/gpgmm/common/SegmentedMemoryAllocator.cpp
+++ b/src/gpgmm/common/SegmentedMemoryAllocator.cpp
@@ -152,7 +152,7 @@ namespace gpgmm {
         ASSERT(memory != nullptr);
         memory->SetPool(segment);
 
-        return std::make_unique<MemoryAllocationBase>(this, memory, request.SizeInBytes);
+        return allocation;
     }
 
     void SegmentedMemoryAllocator::DeallocateMemory(

--- a/src/gpgmm/common/SlabMemoryAllocator.cpp
+++ b/src/gpgmm/common/SlabMemoryAllocator.cpp
@@ -387,9 +387,11 @@ namespace gpgmm {
         mStats.UsedBlockCount++;
         mStats.UsedBlockUsage += blockInSlab->Size;
 
-        return std::make_unique<MemoryAllocationBase>(
-            this, subAllocation->GetMemory(), offsetFromMemory, AllocationMethod::kSubAllocated,
-            blockInSlab, request.SizeInBytes);
+        subAllocation->SetOffset(offsetFromMemory);
+        subAllocation->SetMethod(AllocationMethod::kSubAllocated);
+        subAllocation->SetAllocator(this);
+
+        return subAllocation;
     }
 
     void SlabMemoryAllocator::DeallocateMemory(
@@ -533,9 +535,9 @@ namespace gpgmm {
         // Hold onto the cached allocator until the last allocation gets deallocated.
         entry->Ref();
 
-        return std::make_unique<MemoryAllocationBase>(
-            this, subAllocation->GetMemory(), subAllocation->GetOffset(),
-            subAllocation->GetMethod(), subAllocation->GetBlock(), request.SizeInBytes);
+        subAllocation->SetAllocator(this);
+
+        return subAllocation;
     }
 
     void SlabCacheAllocator::DeallocateMemory(std::unique_ptr<MemoryAllocationBase> subAllocation) {


### PR DESCRIPTION
Avoids re-creating allocations in favor of patching them during allocation.