### PR TITLE
Eliminate heap alloc in DedicatedMemoryAllocator::TryAllocateMemory.

### DIFF
--- a/src/gpgmm/common/DedicatedMemoryAllocator.cpp
+++ b/src/gpgmm/common/DedicatedMemoryAllocator.cpp
@@ -46,9 +46,7 @@ namespace gpgmm {
         mStats.UsedBlockCount++;
         mStats.UsedBlockUsage += allocation->GetSize();
 
-        allocation->SetOffset(0);
         allocation->SetAllocator(this);
-        allocation->SetBlock(new MemoryBlock{0, allocation->GetSize()});
 
         return allocation;
     }
@@ -60,11 +58,9 @@ namespace gpgmm {
 
         std::lock_guard<std::mutex> lock(mMutex);
 
-        MemoryBlock* block = allocation->GetBlock();
         mStats.UsedBlockCount--;
-        mStats.UsedBlockUsage -= block->Size;
+        mStats.UsedBlockUsage -= allocation->GetSize();
 
-        SafeDelete(block);
         GetNextInChain()->DeallocateMemory(std::move(allocation));
     }
 

--- a/src/gpgmm/common/DedicatedMemoryAllocator.h
+++ b/src/gpgmm/common/DedicatedMemoryAllocator.h
@@ -19,12 +19,13 @@
 
 namespace gpgmm {
 
-    // DedicatedMemoryAllocator allocates from device memory with exactly one block.
-    // DedicatedMemoryAllocator is useful in situations where whole memory objects could be reused
-    // without the need for sub-allocation. DedicatedMemoryAllocator also allows
-    // memory to be tracked.
+    // DedicatedMemoryAllocator always allocates the entire region of memory.
+    // This is useful in situations where entire memory allocations could be reused
+    // without the need for sub-allocation.
     class DedicatedMemoryAllocator final : public MemoryAllocatorBase {
       public:
+        // Constructs a dedicated allocation.
+        // The underlying |memoryAllocator| cannot be a sub-allocator.
         DedicatedMemoryAllocator(ScopedRef<MemoryAllocatorBase> memoryAllocator,
                                  uint64_t memoryAlignment);
 

--- a/src/gpgmm/common/MemoryAllocation.h
+++ b/src/gpgmm/common/MemoryAllocation.h
@@ -99,6 +99,8 @@ namespace gpgmm {
         uint64_t mRequestSize;
 #endif
 
+        // Assigns a contiguously allocated sub-region.
+        // When the entire allocation region gets assigned, |mBlock| will be nullptr.
         MemoryBlock* mBlock;
     };
 }  // namespace gpgmm


### PR DESCRIPTION
Extra heap alloc also prevents dedicated allocations from getting sub-allocated because only one tracking block can be used at a time.