### PR TITLE
Depreciate DebugName in descriptors.

### DIFF
--- a/include/gpgmm_d3d12.h
+++ b/include/gpgmm_d3d12.h
@@ -178,12 +178,6 @@ namespace gpgmm::d3d12 {
         Optional parameter. By default, no flags are specified or RESIDENCY_HEAP_FLAG_NONE.
         */
         RESIDENCY_HEAP_FLAGS Flags;
-
-        /** \brief Debug name associated with the heap.
-
-        Optional parameter. By default, no name is associated.
-        */
-        LPCWSTR DebugName;
     };
 
     /** \brief Callback function used to create a ID3D12Pageable.
@@ -1207,12 +1201,6 @@ namespace gpgmm::d3d12 {
         Optional parameter. No extra padding is applied by default.
         */
         UINT64 ExtraRequiredResourcePadding;
-
-        /** \brief Associates a name with the given allocation.
-
-        Optional parameter. By default, no name is associated.
-        */
-        LPCWSTR DebugName;
     };
 
     /** \struct FEATURE_DATA_RESOURCE_ALLOCATION_SUPPORT

--- a/src/gpgmm/d3d12/JSONSerializerD3D12.cpp
+++ b/src/gpgmm/d3d12/JSONSerializerD3D12.cpp
@@ -64,9 +64,6 @@ namespace gpgmm::d3d12 {
         dict.AddItem("HeapType", desc.HeapType);
         dict.AddItem("ExtraRequiredHeapFlags", desc.ExtraRequiredHeapFlags);
         dict.AddItem("ExtraRequiredResourcePadding", desc.ExtraRequiredResourcePadding);
-        if (desc.DebugName != nullptr) {
-            dict.AddItem("DebugName", WCharToUTF8(desc.DebugName));
-        }
         return dict;
     }
 
@@ -164,9 +161,6 @@ namespace gpgmm::d3d12 {
         dict.AddItem("Alignment", desc.Alignment);
         dict.AddItem("HeapSegment", desc.HeapSegment);
         dict.AddItem("Flags", desc.Flags);
-        if (desc.DebugName != nullptr) {
-            dict.AddItem("DebugName", WCharToUTF8(desc.DebugName));
-        }
         return dict;
     }
 

--- a/src/gpgmm/d3d12/ResidencyHeapD3D12.cpp
+++ b/src/gpgmm/d3d12/ResidencyHeapD3D12.cpp
@@ -213,8 +213,6 @@ namespace gpgmm::d3d12 {
             }
         }
 
-        GPGMM_RETURN_IF_FAILED(heap->SetDebugName(newDescriptor.DebugName),
-                               GetDevice(pPageable).Get());
         GPGMM_TRACE_EVENT_OBJECT_SNAPSHOT(heap.get(), newDescriptor);
 
         DebugLog(MessageId::kObjectCreated, heap.get())

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -1065,9 +1065,6 @@ namespace gpgmm::d3d12 {
 
             ASSERT(allocation->GetResource() != nullptr);
 
-            GPGMM_RETURN_IF_FAILED(allocation->SetDebugName(allocationDescriptor.DebugName),
-                                   mDevice);
-
             if (GPGMM_UNLIKELY(mTrackingAllocator)) {
                 mTrackingAllocator->TrackAllocation(allocation.Get());
             }
@@ -1331,7 +1328,6 @@ namespace gpgmm::d3d12 {
                     allocationDesc.HeapOffset = kInvalidOffset;
                     allocationDesc.Type = RESOURCE_ALLOCATION_TYPE_SUBALLOCATED_WITHIN;
                     allocationDesc.OffsetFromResource = subAllocation.GetOffset();
-                    allocationDesc.DebugName = allocationDescriptor.DebugName;
 
                     ResidencyHeap* resourceHeap =
                         static_cast<ResidencyHeap*>(subAllocation.GetMemory());
@@ -1378,7 +1374,6 @@ namespace gpgmm::d3d12 {
                     allocationDesc.Type =
                         static_cast<RESOURCE_ALLOCATION_TYPE>(subAllocation.GetMethod());
                     allocationDesc.OffsetFromResource = 0;
-                    allocationDesc.DebugName = allocationDescriptor.DebugName;
 
                     GPGMM_RETURN_IF_FAILED(
                         ResourceAllocation::CreateResourceAllocation(
@@ -1425,7 +1420,6 @@ namespace gpgmm::d3d12 {
                     allocationDesc.Type =
                         static_cast<RESOURCE_ALLOCATION_TYPE>(allocation.GetMethod());
                     allocationDesc.OffsetFromResource = 0;
-                    allocationDesc.DebugName = allocationDescriptor.DebugName;
 
                     GPGMM_RETURN_IF_FAILED(
                         ResourceAllocation::CreateResourceAllocation(
@@ -1487,7 +1481,6 @@ namespace gpgmm::d3d12 {
         allocationDesc.HeapOffset = kInvalidOffset;
         allocationDesc.SizeInBytes = request.SizeInBytes;
         allocationDesc.Type = RESOURCE_ALLOCATION_TYPE_STANDALONE;
-        allocationDesc.DebugName = allocationDescriptor.DebugName;
 
         if (FAILED(ResourceAllocation::CreateResourceAllocation(
                 allocationDesc, this, this, resourceHeap.Detach(), nullptr, nullptr,
@@ -1629,7 +1622,6 @@ namespace gpgmm::d3d12 {
         RESIDENCY_HEAP_DESC resourceHeapDesc = {};
         resourceHeapDesc.SizeInBytes = info.SizeInBytes;
         resourceHeapDesc.Alignment = info.Alignment;
-        resourceHeapDesc.DebugName = L"Resource heap (committed)";
 
         if (IsResidencyEnabled()) {
             resourceHeapDesc.Flags |= GetHeapFlags(heapFlags, mIsAlwaysCreatedInBudget);
@@ -1648,6 +1640,8 @@ namespace gpgmm::d3d12 {
                                                CreateCommittedResourceCallbackContext::CreateHeap,
                                                &callbackContext, &resourceHeap),
             mDevice);
+
+        GPGMM_RETURN_IF_FAILED(resourceHeap->SetDebugName(L"Resource heap (committed)"), mDevice);
 
         if (resourceHeapOut != nullptr) {
             *resourceHeapOut = static_cast<ResidencyHeap*>(resourceHeap.Detach());

--- a/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceHeapAllocatorD3D12.cpp
@@ -56,7 +56,6 @@ namespace gpgmm::d3d12 {
         // https://docs.microsoft.com/en-us/windows/win32/api/d3d12/ns-d3d12-d3d12_HEAP_INFO
         resourceHeapDesc.SizeInBytes = AlignTo(request.SizeInBytes, request.Alignment);
         resourceHeapDesc.Alignment = request.Alignment;
-        resourceHeapDesc.DebugName = L"GPGMM Resource Heap";
 
         const bool isResidencyEnabled = (mResidencyManager != nullptr);
         if (isResidencyEnabled) {
@@ -79,6 +78,8 @@ namespace gpgmm::d3d12 {
         if (FAILED(hr)) {
             return GetErrorCode(hr);
         }
+
+        resourceHeap->SetDebugName(L"GPGMM Resource Heap");
 
         mStats.UsedMemoryUsage += resourceHeapDesc.SizeInBytes;
         mStats.UsedMemoryCount++;

--- a/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
+++ b/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
@@ -657,14 +657,14 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBuffer) {
     {
         RESOURCE_ALLOCATION_DESC allocationDesc = {};
         allocationDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
-        allocationDesc.DebugName = L"Buffer";
 
         ComPtr<IResourceAllocation> allocation;
         ASSERT_SUCCEEDED(resourceAllocator->CreateResource(
             allocationDesc, CreateBasicBufferDesc(kBufferOf4MBAllocationSize),
             D3D12_RESOURCE_STATE_COMMON, nullptr, &allocation));
         ASSERT_NE(allocation, nullptr);
-        EXPECT_EQUAL_WSTR(allocation->GetDebugName(), allocationDesc.DebugName);
+        ASSERT_SUCCEEDED(allocation->SetDebugName(L"Buffer"));
+        EXPECT_EQUAL_WSTR(allocation->GetDebugName(), L"Buffer");
     }
 
     // Creating a buffer without a heap type should be inferred based on the resource state.
@@ -1163,8 +1163,6 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferWithinMany) {
 
     // Create two small buffers that will be byte-aligned.
     ComPtr<IResourceAllocation> smallBufferA;
-    allocationDesc.DebugName = GPGMM_GET_VAR_NAME(smallBufferA);
-
     ASSERT_SUCCEEDED(resourceAllocator->CreateResource(allocationDesc, smallBufferDesc,
                                                        D3D12_RESOURCE_STATE_GENERIC_READ, nullptr,
                                                        &smallBufferA));
@@ -1173,8 +1171,6 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferWithinMany) {
     EXPECT_EQ(smallBufferA->GetInfo().SizeInBytes, smallBufferDesc.Width);
 
     ComPtr<IResourceAllocation> smallBufferB;
-    allocationDesc.DebugName = GPGMM_GET_VAR_NAME(smallBufferB);
-
     ASSERT_SUCCEEDED(resourceAllocator->CreateResource(allocationDesc, smallBufferDesc,
                                                        D3D12_RESOURCE_STATE_GENERIC_READ, nullptr,
                                                        &smallBufferB));
@@ -1183,8 +1179,6 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferWithinMany) {
     EXPECT_EQ(smallBufferB->GetInfo().SizeInBytes, smallBufferDesc.Width);
 
     ComPtr<IResourceAllocation> smallBufferC;
-    allocationDesc.DebugName = GPGMM_GET_VAR_NAME(smallBufferC);
-
     ASSERT_SUCCEEDED(resourceAllocator->CreateResource(allocationDesc, smallBufferDesc,
                                                        D3D12_RESOURCE_STATE_GENERIC_READ, nullptr,
                                                        &smallBufferC));


### PR DESCRIPTION
Use SetDebugName and GetDebugName instead.