### PR TITLE
Avoid re-allocation when returing to pool.

### DIFF
--- a/src/gpgmm/common/PooledMemoryAllocator.cpp
+++ b/src/gpgmm/common/PooledMemoryAllocator.cpp
@@ -76,12 +76,9 @@ namespace gpgmm {
         mStats.UsedMemoryCount--;
         mStats.UsedMemoryUsage -= allocationSize;
 
-        MemoryBase* memory = allocation->GetMemory();
-        ASSERT(memory != nullptr);
+        allocation->SetAllocator(GetNextInChain());
 
-        mPool->ReturnToPool(std::make_unique<MemoryAllocationBase>(GetNextInChain(), memory,
-                                                                   allocation->GetRequestSize()),
-                            kInvalidIndex);
+        mPool->ReturnToPool(std::move(allocation), kInvalidIndex);
     }
 
     uint64_t PooledMemoryAllocator::ReleaseMemory(uint64_t bytesToRelease) {

--- a/src/gpgmm/common/SegmentedMemoryAllocator.cpp
+++ b/src/gpgmm/common/SegmentedMemoryAllocator.cpp
@@ -172,8 +172,9 @@ namespace gpgmm {
         MemoryPoolBase* pool = memory->GetPool();
         ASSERT(pool != nullptr);
 
-        static_cast<MemorySegment*>(pool)->ReturnToPool(std::make_unique<MemoryAllocationBase>(
-            GetNextInChain(), memory, allocation->GetRequestSize()));
+        allocation->SetAllocator(GetNextInChain());
+
+        pool->ReturnToPool(std::move(allocation), kInvalidIndex);
     }
 
     uint64_t SegmentedMemoryAllocator::ReleaseMemory(uint64_t bytesToRelease) {


### PR DESCRIPTION
Patches the allocation instead of re-creating it.