### PR TITLE
Add RESOURCE_ALLOCATOR_DESC::ExtraRequiredResourceFlags

### DIFF
--- a/include/gpgmm_d3d12.h
+++ b/include/gpgmm_d3d12.h
@@ -1052,6 +1052,19 @@ namespace gpgmm::d3d12 {
         allocation.
         */
         UINT64 ReleaseSizeInBytes;
+
+        /** \brief Additional resource flags to apply for any resource created by this resource
+        allocator.
+
+        Alternatively, resource flags can be applied at allocation-time so long as
+        RESOURCE_ALLOCATION_FLAG_ALLOW_SUBALLOCATE_WITHIN_RESOURCE was not specified.
+
+        For a list of available options, please read:
+        https://learn.microsoft.com/en-us/windows/win32/api/d3d12/ne-d3d12-d3d12_resource_flags
+
+        Optional parameter. When unspecified, no additional flags would be applied.
+        */
+        D3D12_RESOURCE_FLAGS ExtraRequiredResourceFlags;
     };
 
     /** \enum RESOURCE_ALLOCATION_FLAGS

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.h
@@ -102,6 +102,7 @@ namespace gpgmm::d3d12 {
             D3D12_HEAP_FLAGS heapFlags,
             const D3D12_HEAP_PROPERTIES& heapProperties,
             const HEAP_ALLOCATION_INFO& heapInfo,
+            D3D12_RESOURCE_FLAGS resourceFlags,
             D3D12_RESOURCE_STATES initialResourceState);
 
         ScopedRef<MemoryAllocatorBase> CreatePoolAllocator(
@@ -157,6 +158,7 @@ namespace gpgmm::d3d12 {
         std::unique_ptr<Caps> mCaps;
 
         const D3D12_RESOURCE_HEAP_TIER mResourceHeapTier;
+        const D3D12_RESOURCE_FLAGS mExtraRequiredResourceFlags;
         const bool mIsAlwaysCommitted;
         const bool mIsAlwaysCreatedInBudget;
         const bool mFlushEventBuffersOnDestruct;

--- a/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
+++ b/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
@@ -704,6 +704,23 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBuffer) {
             {}, CreateBasicBufferDesc(kBufferOf4MBAllocationSize + 1),
             D3D12_RESOURCE_STATE_UNORDERED_ACCESS, nullptr, nullptr));
     }
+
+    // Create a UAV buffer that that ALLOW_UAV flags applied.
+    {
+        RESOURCE_ALLOCATOR_DESC uavAllocatorDesc = CreateBasicAllocatorDesc();
+        uavAllocatorDesc.ExtraRequiredResourceFlags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
+
+        ComPtr<IResourceAllocator> uavResourceAllocator;
+        ASSERT_SUCCEEDED(CreateResourceAllocator(uavAllocatorDesc, mDevice.Get(), mAdapter.Get(),
+                                                 &uavResourceAllocator, nullptr));
+
+        ComPtr<IResourceAllocation> uavBuffer;
+        ASSERT_SUCCEEDED(uavResourceAllocator->CreateResource(
+            {}, CreateBasicBufferDesc(kBufferOf4MBAllocationSize),
+            D3D12_RESOURCE_STATE_UNORDERED_ACCESS, nullptr, &uavBuffer));
+
+        EXPECT_EQ(uavBuffer->GetResource()->GetDesc().Flags, uavAllocatorDesc.ExtraRequiredResourceFlags);
+    }
 }
 
 TEST_F(D3D12ResourceAllocatorTests, GetResourceAllocator) {


### PR DESCRIPTION
Allows resource allocators to be specialized with certain resource options.