### PR TITLE
Move Lock/Unlock to ResidencyHeap.

### DIFF
--- a/include/gpgmm_d3d12.h
+++ b/include/gpgmm_d3d12.h
@@ -203,6 +203,22 @@ namespace gpgmm::d3d12 {
         */
         virtual RESIDENCY_HEAP_INFO GetInfo() const = 0;
 
+        /** \brief Locks the specified heap.
+
+        Locking a heap means the residency manager will never evict it when over budget.
+
+        \return S_OK if locking was successful.
+        */
+        virtual HRESULT Lock() = 0;
+
+        /** \brief Unlocks the specified heap.
+
+        Unlocking a heap allows the residency manager will evict it when over budget.
+
+        \return S_OK if unlocking was successful or S_FALSE if a lock remains.
+        */
+        virtual HRESULT Unlock() = 0;
+
         /** \brief Get the residency manager that manages this heap.
 
         @param[out] ppResidencyManagerOut Pointer to a memory block that receives a pointer to the
@@ -285,9 +301,8 @@ namespace gpgmm::d3d12 {
     IResourceAllocation::GetMemory, into the list. Once IResidencyManager::ExecuteCommandLists is
     called, the list can be reset or cleared for the next frame or compute job.
 
-    Without IResidencyList, the application would need to call IResidencyManager::LockHeap and
-    IResidencyManager::UnlockHeap for each heap before and after every GPU command or command-list
-    being executed.
+    Without IResidencyList, the application would need to lock and unlock each heap before and
+    after every GPU command or command-list being executed.
     */
     GPGMM_INTERFACE IResidencyList : public IUnknown {
         /** \brief  Adds a heap to the residency list.
@@ -569,24 +584,6 @@ namespace gpgmm::d3d12 {
     **/
     GPGMM_INTERFACE IResidencyManager : public IDebugObject {
       public:
-        /** \brief Locks the specified heap.
-
-        Locking a heap means the residency manager will never evict it when over budget.
-
-        @param pHeap A pointer to the heap being locked.
-        */
-        virtual HRESULT LockHeap(IResidencyHeap * pHeap) = 0;
-
-        /** \brief Unlocks the specified heap.
-
-        Unlocking a heap allows the residency manager will evict it when over budget.
-
-        @param pHeap A pointer to the heap being unlocked.
-
-        \return S_OK if unlocking was successful or S_FALSE if a lock remains.
-        */
-        virtual HRESULT UnlockHeap(IResidencyHeap * pHeap) = 0;
-
         /** \brief Execute command lists using residency managed heaps or E_OUTOFMEMORY.
 
         Submits an array of command lists and residency lists for the specified command queue.

--- a/src/gpgmm/d3d12/ResidencyHeapD3D12.cpp
+++ b/src/gpgmm/d3d12/ResidencyHeapD3D12.cpp
@@ -154,7 +154,7 @@ namespace gpgmm::d3d12 {
         }
 
         std::unique_ptr<ResidencyHeap> heap(
-            new ResidencyHeap(pResidencyManager, pPageable, newDescriptor, isResidencyDisabled));
+            new ResidencyHeap(residencyManager, pPageable, newDescriptor, isResidencyDisabled));
 
         if (!isResidencyDisabled) {
             // Check if the underlying memory was implicitly made resident.
@@ -280,7 +280,7 @@ namespace gpgmm::d3d12 {
                                    ppResidencyHeapOut);
     }
 
-    ResidencyHeap::ResidencyHeap(ComPtr<IResidencyManager> residencyManager,
+    ResidencyHeap::ResidencyHeap(ComPtr<ResidencyManager> residencyManager,
                                  ComPtr<ID3D12Pageable> pageable,
                                  const RESIDENCY_HEAP_DESC& descriptor,
                                  bool isResidencyDisabled)
@@ -382,12 +382,16 @@ namespace gpgmm::d3d12 {
     }
 
     HRESULT ResidencyHeap::Lock() {
-        ASSERT(mResidencyManager != nullptr);
+        if (mResidencyManager == nullptr) {
+            return S_FALSE;
+        }
         return mResidencyManager->LockHeap(this);
     }
 
     HRESULT ResidencyHeap::Unlock() {
-        ASSERT(mResidencyManager != nullptr);
+        if (mResidencyManager == nullptr) {
+            return S_FALSE;
+        }
         return mResidencyManager->UnlockHeap(this);
     }
 

--- a/src/gpgmm/d3d12/ResidencyHeapD3D12.h
+++ b/src/gpgmm/d3d12/ResidencyHeapD3D12.h
@@ -54,6 +54,8 @@ namespace gpgmm::d3d12 {
 
         // IResidencyHeap interface
         RESIDENCY_HEAP_INFO GetInfo() const override;
+        HRESULT Lock() override;
+        HRESULT Unlock() override;
         HRESULT GetResidencyManager(IResidencyManager** ppResidencyManagerOut) const override;
 
         // IUnknown interface
@@ -65,13 +67,10 @@ namespace gpgmm::d3d12 {
         LPCWSTR GetDebugName() const override;
         HRESULT SetDebugName(LPCWSTR Name) override;
 
-        HRESULT Lock();
-        HRESULT Unlock();
-
       private:
         friend ResidencyManager;
 
-        ResidencyHeap(ComPtr<IResidencyManager> residencyManager,
+        ResidencyHeap(ComPtr<ResidencyManager> residencyManager,
                       ComPtr<ID3D12Pageable> pageable,
                       const RESIDENCY_HEAP_DESC& descriptor,
                       bool isResidencyDisabled);
@@ -100,7 +99,7 @@ namespace gpgmm::d3d12 {
         void AddResidencyLockRef();
         void ReleaseResidencyLock();
 
-        ComPtr<IResidencyManager> mResidencyManager;
+        ComPtr<ResidencyManager> mResidencyManager;
         ComPtr<ID3D12Pageable> mPageable;
 
         DXGI_MEMORY_SEGMENT_GROUP mHeapSegment;

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
@@ -194,7 +194,7 @@ namespace gpgmm::d3d12 {
     }
 
     // Increments number of locks on a heap to ensure the heap remains resident.
-    HRESULT ResidencyManager::LockHeap(IResidencyHeap* pHeap) {
+    HRESULT ResidencyManager::LockHeap(ResidencyHeap* pHeap) {
         GPGMM_RETURN_IF_NULL(pHeap);
 
         std::lock_guard<std::mutex> lock(mMutex);
@@ -234,7 +234,7 @@ namespace gpgmm::d3d12 {
 
     // Decrements number of locks on a heap. When the number of locks becomes zero, the heap is
     // inserted into the LRU cache and becomes eligible for eviction.
-    HRESULT ResidencyManager::UnlockHeap(IResidencyHeap* pHeap) {
+    HRESULT ResidencyManager::UnlockHeap(ResidencyHeap* pHeap) {
         GPGMM_RETURN_IF_NULL(pHeap);
 
         std::lock_guard<std::mutex> lock(mMutex);

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.h
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.h
@@ -50,8 +50,6 @@ namespace gpgmm::d3d12 {
         ~ResidencyManager() override;
 
         // IResidencyManager interface
-        HRESULT LockHeap(IResidencyHeap* pHeap) override;
-        HRESULT UnlockHeap(IResidencyHeap* pHeap) override;
         HRESULT ExecuteCommandLists(ID3D12CommandQueue* pQueue,
                                     ID3D12CommandList* const* ppCommandLists,
                                     IResidencyList* const* ppResidencyLists,
@@ -73,6 +71,9 @@ namespace gpgmm::d3d12 {
         // IDebugObject interface
         LPCWSTR GetDebugName() const override;
         HRESULT SetDebugName(LPCWSTR Name) override;
+
+        HRESULT LockHeap(ResidencyHeap* pHeap);
+        HRESULT UnlockHeap(ResidencyHeap* pHeap);
 
       private:
         friend ResidencyHeap;

--- a/src/mvi/gpgmm_d3d12.cpp
+++ b/src/mvi/gpgmm_d3d12.cpp
@@ -97,6 +97,14 @@ namespace gpgmm::d3d12 {
         return {GetSize(), GetAlignment(), false, RESIDENCY_HEAP_STATUS_UNKNOWN};
     }
 
+    HRESULT ResidencyHeap::Lock() {
+        return S_OK;
+    }
+
+    HRESULT ResidencyHeap::Unlock() {
+        return S_OK;
+    }
+
     HRESULT ResidencyHeap::GetResidencyManager(IResidencyManager** ppResidencyManagerOut) const {
         return E_NOTIMPL;
     }
@@ -175,14 +183,6 @@ namespace gpgmm::d3d12 {
     }
 
     ResidencyManager::~ResidencyManager() = default;
-
-    HRESULT ResidencyManager::LockHeap(IResidencyHeap* pHeap) {
-        return S_OK;
-    }
-
-    HRESULT ResidencyManager::UnlockHeap(IResidencyHeap* pHeap) {
-        return S_OK;
-    }
 
     HRESULT ResidencyManager::ExecuteCommandLists(ID3D12CommandQueue* pQueue,
                                                   ID3D12CommandList* const* ppCommandLists,

--- a/src/mvi/gpgmm_d3d12.h
+++ b/src/mvi/gpgmm_d3d12.h
@@ -72,6 +72,8 @@ namespace gpgmm::d3d12 {
 
         // IResidencyHeap interface
         RESIDENCY_HEAP_INFO GetInfo() const override;
+        HRESULT Lock() override;
+        HRESULT Unlock() override;
         HRESULT GetResidencyManager(IResidencyManager** ppResidencyManagerOut) const override;
 
         // IUnknown interface
@@ -114,8 +116,6 @@ namespace gpgmm::d3d12 {
         ~ResidencyManager() override;
 
         // IResidencyManager interface
-        HRESULT LockHeap(IResidencyHeap* pHeap) override;
-        HRESULT UnlockHeap(IResidencyHeap* pHeap) override;
         HRESULT ExecuteCommandLists(ID3D12CommandQueue* pQueue,
                                     ID3D12CommandList* const* ppCommandLists,
                                     IResidencyList* const* ppResidencyLists,


### PR DESCRIPTION
Eliminates the need to access the residency manager again after creation.