### PR TITLE
Disable OverBudgetAsync on MSVC builder.

### DIFF
--- a/src/tests/end2end/D3D12ResidencyManagerTests.cpp
+++ b/src/tests/end2end/D3D12ResidencyManagerTests.cpp
@@ -696,6 +696,11 @@ TEST_F(D3D12ResidencyManagerTests, OverBudget) {
 
 // Keeps allocating until it goes over the OS provided budget.
 TEST_F(D3D12ResidencyManagerTests, OverBudgetAsync) {
+    // TODO: Figure out why MSVC occasionally fails.
+#if defined(GPGMM_COMPILER_MSVC)
+    GPGMM_SKIP_TEST_IF(true);
+#endif
+
     constexpr uint64_t kBudgetIsDeterminedByOS = 0;
     RESIDENCY_MANAGER_DESC residencyDesc = CreateBasicResidencyDesc(kBudgetIsDeterminedByOS);
     residencyDesc.Flags |= RESIDENCY_MANAGER_FLAG_ALLOW_BACKGROUND_BUDGET_UPDATES;


### PR DESCRIPTION
OverBudgetAsync keeps failing so disable it for now.