### PR TITLE
Use platform conditions when skipping tests.

### DIFF
--- a/src/gpgmm/utils/Platform.h
+++ b/src/gpgmm/utils/Platform.h
@@ -16,6 +16,10 @@
 #ifndef SRC_GPGMM_UTILS_PLATFORM_H_
 #define SRC_GPGMM_UTILS_PLATFORM_H_
 
+// Converts "is platform X" macro into conditional expression.
+// Useful when skipping code without using raw #ifdef.
+#define GPGMM_PLATFORM_IS(X) (1 == GPGMM_PLATFORM_IS_##X)
+
 // Per operating system.
 
 // Windows

--- a/src/tests/GPGMMTest.h
+++ b/src/tests/GPGMMTest.h
@@ -19,18 +19,25 @@
 
 #include "gpgmm/common/MemoryAllocator.h"
 #include "gpgmm/utils/Log.h"
+#include "gpgmm/utils/Platform.h"
 #include "gpgmm/utils/PlatformDebug.h"
 
 #include <vector>
 
-#define GPGMM_SKIP_TEST_IF(expr)                            \
-    do {                                                    \
-        if (expr) {                                         \
-            gpgmm::InfoLog() << "Test skipped: " #expr "."; \
-            GTEST_SKIP();                                   \
-            return;                                         \
-        }                                                   \
+#define GPGMM_SKIP_TEST_IF(expr, kind, reason)             \
+    do {                                                   \
+        if (expr) {                                        \
+            gpgmm::InfoLog() << "Test " kind ": " #reason; \
+            GTEST_SKIP();                                  \
+            return;                                        \
+        }                                                  \
     } while (0)
+
+// Unsupported tests are tests that rely on some OS / driver / platform feature to run.
+#define GPGMM_SKIP_TEST_IF_UNSUPPORTED(expr) GPGMM_SKIP_TEST_IF(expr, "unsupported", expr)
+
+// Disabled tests are tests that are not working and can be skipped until fixed.
+#define GPGMM_SKIP_TEST_IF_DISABLED(expr) GPGMM_SKIP_TEST_IF(expr, "disabled", expr)
 
 #define GPGMM_TEST_MEMORY_LEAK_START()          \
     do {                                        \

--- a/src/tests/VKTest.cpp
+++ b/src/tests/VKTest.cpp
@@ -49,7 +49,8 @@ namespace gpgmm::vk {
 
         // vkCreateInstance fails if no Vulkan ICD was installed.
         // TODO: Consider installing a fall-back CPU-based Vulkan driver for testing.
-        GPGMM_SKIP_TEST_IF(vkCreateInstance(&instanceInfo, nullptr, &mInstance) != VK_SUCCESS);
+        GPGMM_SKIP_TEST_IF_UNSUPPORTED(vkCreateInstance(&instanceInfo, nullptr, &mInstance) !=
+                                       VK_SUCCESS);
 
         // Setup the physical device
         {

--- a/src/tests/capture_replay_tests/D3D12MemoryTraceReplay.cpp
+++ b/src/tests/capture_replay_tests/D3D12MemoryTraceReplay.cpp
@@ -184,7 +184,10 @@ class D3D12MemoryTraceReplay : public D3D12TestBase, public CaptureReplayTestWit
 
         Json::Value root;
         Json::Reader reader;
-        GPGMM_SKIP_TEST_IF(!reader.parse(traceFileStream, root, false));
+        if (!reader.parse(traceFileStream, root, false)) {
+            gpgmm::WarnLog() << "Json reader failed to parse from file: " << traceFile.path << ".";
+            GTEST_SKIP();
+        }
 
         PlaybackExecutionContext playbackContext = {};
 
@@ -399,7 +402,7 @@ class D3D12MemoryTraceReplay : public D3D12TestBase, public CaptureReplayTestWit
                                 << "Capture device does not match playback device (IsUMA: " +
                                        std::to_string(snapshot["IsUMA"].asBool()) + " vs " +
                                        std::to_string(mCaps->IsAdapterUMA()) + ").";
-                            GPGMM_SKIP_TEST_IF(!envParams.IsIgnoreCapsMismatchEnabled);
+                            GPGMM_SKIP_TEST_IF_UNSUPPORTED(!envParams.IsIgnoreCapsMismatchEnabled);
                         }
 
                         RESIDENCY_MANAGER_DESC newResidencyDesc = baseResidencyDesc;
@@ -461,7 +464,7 @@ class D3D12MemoryTraceReplay : public D3D12TestBase, public CaptureReplayTestWit
                                        " vs " +
                                        std::to_string(mCaps->GetMaxResourceHeapTierSupported()) +
                                        ").";
-                            GPGMM_SKIP_TEST_IF(!envParams.IsIgnoreCapsMismatchEnabled);
+                            GPGMM_SKIP_TEST_IF_UNSUPPORTED(!envParams.IsIgnoreCapsMismatchEnabled);
                         }
 
                         RESOURCE_ALLOCATOR_DESC allocatorDescOfProfile = baseAllocatorDesc;

--- a/src/tests/end2end/D3D12ResidencyManagerTests.cpp
+++ b/src/tests/end2end/D3D12ResidencyManagerTests.cpp
@@ -140,7 +140,7 @@ class D3D12ResidencyManagerTests : public D3D12TestBase, public ::testing::Test 
 
 TEST_F(D3D12ResidencyManagerTests, CreateResourceHeapNotResident) {
     // Adapters that do not support creating heaps will ignore D3D12_HEAP_FLAG_CREATE_NOT_RESIDENT.
-    GPGMM_SKIP_TEST_IF(!mCaps->IsCreateHeapNotResidentSupported());
+    GPGMM_SKIP_TEST_IF_UNSUPPORTED(!mCaps->IsCreateHeapNotResidentSupported());
 
     ComPtr<IResidencyManager> residencyManager;
     ASSERT_SUCCEEDED(CreateResidencyManager(CreateBasicResidencyDesc(kDefaultBudget), mDevice.Get(),
@@ -698,7 +698,7 @@ TEST_F(D3D12ResidencyManagerTests, OverBudget) {
 TEST_F(D3D12ResidencyManagerTests, OverBudgetAsync) {
     // TODO: Figure out why MSVC occasionally fails.
 #if defined(GPGMM_COMPILER_MSVC)
-    GPGMM_SKIP_TEST_IF(true);
+    GPGMM_SKIP_TEST_IF_DISABLED(true);
 #endif
 
     constexpr uint64_t kBudgetIsDeterminedByOS = 0;
@@ -916,7 +916,7 @@ TEST_F(D3D12ResidencyManagerTests, OverBudgetWithMappedResources) {
 // gets paged-out.
 TEST_F(D3D12ResidencyManagerTests, OverBudgetExecuteCommandList) {
     // Disable for WARP because the device always leaks after this test ends.
-    GPGMM_SKIP_TEST_IF(IsAdapterMicrosoftWARP());
+    GPGMM_SKIP_TEST_IF_UNSUPPORTED(IsAdapterMicrosoftWARP());
 
     ComPtr<IResidencyManager> residencyManager;
     ASSERT_SUCCEEDED(CreateResidencyManager(CreateBasicResidencyDesc(kDefaultBudget), mDevice.Get(),

--- a/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
+++ b/src/tests/end2end/D3D12ResourceAllocatorTests.cpp
@@ -195,7 +195,7 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferAndTextureInSameHeap) {
     allocatorDesc.PreferredResourceHeapSize = kBufferOf4MBAllocationSize;
 
     // Adapter must support mixing of resource types in same heap.
-    GPGMM_SKIP_TEST_IF(allocatorDesc.ResourceHeapTier < D3D12_RESOURCE_HEAP_TIER_2);
+    GPGMM_SKIP_TEST_IF_UNSUPPORTED(allocatorDesc.ResourceHeapTier < D3D12_RESOURCE_HEAP_TIER_2);
 
     ComPtr<IResourceAllocator> resourceAllocator;
     ASSERT_SUCCEEDED(CreateResourceAllocator(allocatorDesc, mDevice.Get(), mAdapter.Get(),
@@ -758,7 +758,7 @@ TEST_F(D3D12ResourceAllocatorTests, GetResourceAllocator) {
 
 // Verifies there are no attribution of heaps when UMA + no read-back.
 TEST_F(D3D12ResourceAllocatorTests, CreateBufferUMA) {
-    GPGMM_SKIP_TEST_IF(!mCaps->IsAdapterCacheCoherentUMA());
+    GPGMM_SKIP_TEST_IF_UNSUPPORTED(!mCaps->IsAdapterCacheCoherentUMA());
 
     RESOURCE_ALLOCATOR_DESC allocatorDesc = CreateBasicAllocatorDesc();
     allocatorDesc.Flags |= RESOURCE_ALLOCATOR_FLAG_ALLOW_UNIFIED_MEMORY;
@@ -1574,8 +1574,8 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferStats) {
         // Depending on the device, sub-allocation could fail. Since this test relies on a
         // sub-allocator's info counts, it must be skipped.
         // TODO: Consider testing counts by allocator type.
-        GPGMM_SKIP_TEST_IF(firstAllocation->GetInfo().Type !=
-                           RESOURCE_ALLOCATION_TYPE_SUBALLOCATED);
+        GPGMM_SKIP_TEST_IF(firstAllocation->GetInfo().Type != RESOURCE_ALLOCATION_TYPE_SUBALLOCATED,
+                           "failed", "unexpected allocation type used");
 
         RESOURCE_ALLOCATOR_STATS stats = GetStats(resourceAllocator);
         EXPECT_EQ(stats.UsedHeapCount, 1u);
@@ -1779,7 +1779,7 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferWithLimitedFragmentation) {
 TEST_F(D3D12ResourceAllocatorTests, CreateBufferManyPrefetch) {
     // TODO: Figure out why MSVC workflow occasionally fails.
 #if defined(GPGMM_COMPILER_MSVC)
-    GPGMM_SKIP_TEST_IF(true);
+    GPGMM_SKIP_TEST_IF_DISABLED(true);
 #endif
 
     RESOURCE_ALLOCATOR_DESC allocatorDesc = CreateBasicAllocatorDesc();
@@ -1876,7 +1876,7 @@ TEST_F(D3D12ResourceAllocatorTests, CreateBufferWithinManyThreaded) {
 TEST_F(D3D12ResourceAllocatorTests, CreateBufferCacheSize) {
     // Since we cannot determine which resource sizes will be cached upon CreateResourceAllocator,
     // skip the test.
-    GPGMM_SKIP_TEST_IF(IsSizeCacheEnabled());
+    GPGMM_SKIP_TEST_IF_UNSUPPORTED(IsSizeCacheEnabled());
 
     ComPtr<IResourceAllocator> resourceAllocator;
     ASSERT_SUCCEEDED(CreateResourceAllocator(CreateBasicAllocatorDesc(), mDevice.Get(),

--- a/src/tests/unittests/EventTraceWriterTests.cpp
+++ b/src/tests/unittests/EventTraceWriterTests.cpp
@@ -36,8 +36,8 @@ class EventTraceWriterTests : public testing::Test {
 
 TEST_F(EventTraceWriterTests, SingleThreadWrites) {
     // TODO: Figure out why win_clang_[rel|dbg]_x86 builder fails.
-#if defined(GPGMM_PLATFORM_IS_X86) && defined(GPGMM_PLATFORM_IS_32_BIT)
-    GPGMM_SKIP_TEST_IF(true);
+#if GPGMM_PLATFORM_IS(X86) && GPGMM_PLATFORM_IS(32_BIT)
+    GPGMM_SKIP_TEST_IF_DISABLED(true);
 #endif
 
     constexpr uint32_t kEventCount = 64u;
@@ -51,8 +51,8 @@ TEST_F(EventTraceWriterTests, SingleThreadWrites) {
 
 TEST_F(EventTraceWriterTests, MultiThreadWrites) {
     // TODO: Figure out why win_clang_[rel|dbg]_x86 builder fails.
-#if defined(GPGMM_PLATFORM_IS_X86) && defined(GPGMM_PLATFORM_IS_32_BIT)
-    GPGMM_SKIP_TEST_IF(true);
+#if GPGMM_PLATFORM_IS(X86) && GPGMM_PLATFORM_IS(32_BIT)
+    GPGMM_SKIP_TEST_IF_DISABLED(true);
 #endif
 
     constexpr uint32_t kThreadCount = 64u;


### PR DESCRIPTION
Adds macros to skip tests due to specific reasons (ie. unsupported or disabled).