### PR TITLE
Allow SUBALLOCATED_WITHIN to share only pools.

### DIFF
--- a/src/gpgmm/common/MemoryAllocator.cpp
+++ b/src/gpgmm/common/MemoryAllocator.cpp
@@ -201,6 +201,10 @@ namespace gpgmm {
         std::lock_guard<std::mutex> lock(mMutex);
         ASSERT(next != nullptr);
         next->mParent = this->value();
+        SetNextInChain(std::move(next));
+    }
+
+    void MemoryAllocatorBase::SetNextInChain(ScopedRef<MemoryAllocatorBase> next) {
         mNext = next;
     }
 

--- a/src/gpgmm/common/MemoryAllocator.h
+++ b/src/gpgmm/common/MemoryAllocator.h
@@ -208,6 +208,7 @@ namespace gpgmm {
 
         // Return the next MemoryAllocatorBase.
         MemoryAllocatorBase* GetNextInChain() const;
+        void SetNextInChain(ScopedRef<MemoryAllocatorBase> next);
 
         // Return the previous MemoryAllocatorBase.
         MemoryAllocatorBase* GetParent() const;

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -621,8 +621,10 @@ namespace gpgmm::d3d12 {
                 allocator->mPooledOrNonPooledHeapAllocator[resourceHeapTypeIndex];
             mMSAAPooledOrNonPooledHeapAllocator[resourceHeapTypeIndex] =
                 allocator->mMSAAPooledOrNonPooledHeapAllocator[resourceHeapTypeIndex];
-            mSmallBufferAllocatorOfType[resourceHeapTypeIndex] =
-                allocator->mSmallBufferAllocatorOfType[resourceHeapTypeIndex];
+
+            // Small buffers have seperate pools within because they cannot use managed heaps.
+            mSmallBufferAllocatorOfType[resourceHeapTypeIndex]->SetNextInChain(
+                allocator->mSmallBufferAllocatorOfType[resourceHeapTypeIndex]->GetNextInChain());
         }
     }
 


### PR DESCRIPTION
Fixes a possible issue when nested allocators could override the allocation type.