### PR TITLE
Replace DXGI_MEMORY_SEGMENT_GROUP with RESIDENCY_HEAP_SEGMENT

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Residency also works for non-resources too:
 // Shader-visible heaps should be locked or always resident.
 gpgmm::d3d12::RESIDENCY_HEAP_DESC shaderVisibleHeapDesc = {};
 shaderVisibleHeapDesc.Flags |= RESIDENCY_HEAP_FLAG_CREATE_LOCKED;
-shaderVisibleHeapDesc.HeapSegment = DXGI_MEMORY_SEGMENT_GROUP_LOCAL;
+shaderVisibleHeapDesc.HeapSegment = RESIDENCY_HEAP_SEGMENT_LOCAL;
 
 ComPtr<gpgmm::d3d12::IResidencyHeap> descriptorHeap;
 gpgmm::d3d12::CreateResidencyHeap(shaderVisibleHeapDesc, residency.Get(),

--- a/include/gpgmm_d3d12.h
+++ b/include/gpgmm_d3d12.h
@@ -149,6 +149,19 @@ namespace gpgmm::d3d12 {
 
     DEFINE_ENUM_FLAG_OPERATORS(RESIDENCY_HEAP_FLAGS)
 
+    /** \enum RESIDENCY_HEAP_SEGMENT
+    Specify the heap segment to use for residency.
+    */
+    enum RESIDENCY_HEAP_SEGMENT {
+        /** \brief Heap segment is local to the adapter.
+         */
+        RESIDENCY_HEAP_SEGMENT_LOCAL = 0,
+
+        /** \brief Heap segment is non-local to the adapter.
+         */
+        RESIDENCY_HEAP_SEGMENT_NON_LOCAL = 1,
+    };
+
     /** \struct RESIDENCY_HEAP_DESC
       Specifies creation options for a residency managed heap.
       */
@@ -157,7 +170,7 @@ namespace gpgmm::d3d12 {
 
         Required parameter. Must be local or non-local segment.
         */
-        DXGI_MEMORY_SEGMENT_GROUP HeapSegment;
+        RESIDENCY_HEAP_SEGMENT HeapSegment;
 
         /** \brief Created size of the heap, in bytes.
 
@@ -615,7 +628,7 @@ namespace gpgmm::d3d12 {
         |reservation| when under video memory pressure. A value of nullptr will update but not
         return the current reservation.
         */
-        virtual HRESULT SetVideoMemoryReservation(const DXGI_MEMORY_SEGMENT_GROUP& heapSegment,
+        virtual HRESULT SetVideoMemoryReservation(const RESIDENCY_HEAP_SEGMENT& heapSegment,
                                                   UINT64 availableForReservation,
                                                   UINT64* pCurrentReservationOut = nullptr) = 0;
 
@@ -625,7 +638,7 @@ namespace gpgmm::d3d12 {
         @param[out] pVideoMemoryInfoOut Pointer to DXGI_QUERY_VIDEO_MEMORY_INFO to populate. A value
         of nullptr will update but not return the current info.
         */
-        virtual HRESULT QueryVideoMemoryInfo(const DXGI_MEMORY_SEGMENT_GROUP& heapSegment,
+        virtual HRESULT QueryVideoMemoryInfo(const RESIDENCY_HEAP_SEGMENT& heapSegment,
                                              DXGI_QUERY_VIDEO_MEMORY_INFO* pVideoMemoryInfoOut) = 0;
 
         /** \brief Update the residency status of a heap.

--- a/src/fuzzers/D3D12ResidencyManagerFuzzer.cpp
+++ b/src/fuzzers/D3D12ResidencyManagerFuzzer.cpp
@@ -30,7 +30,7 @@ namespace {
     std::vector<ComPtr<gpgmm::d3d12::IResourceAllocation>> gAllocationsBelowBudget = {};
 
     uint64_t GetBudgetLeft(gpgmm::d3d12::IResidencyManager* const residencyManager,
-                           const DXGI_MEMORY_SEGMENT_GROUP& heapSegment) {
+                           const gpgmm::d3d12::RESIDENCY_HEAP_SEGMENT& heapSegment) {
         if (residencyManager == nullptr) {
             return 0;
         }
@@ -88,7 +88,7 @@ extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv) {
     D3D12_HEAP_PROPERTIES heapProperties =
         gDevice->GetCustomHeapProperties(0, allocationDesc.HeapType);
 
-    const DXGI_MEMORY_SEGMENT_GROUP bufferMemorySegment =
+    const gpgmm::d3d12::RESIDENCY_HEAP_SEGMENT bufferMemorySegment =
         gpgmm::d3d12::GetMemorySegment(heapProperties.MemoryPoolPreference, arch.UMA);
 
     constexpr uint64_t kBufferMemorySize = GPGMM_MB_TO_BYTES(1);

--- a/src/gpgmm/d3d12/CapsD3D12.cpp
+++ b/src/gpgmm/d3d12/CapsD3D12.cpp
@@ -132,16 +132,16 @@ namespace gpgmm::d3d12 {
         return mMaxResourceHeapSize;
     }
 
-    uint64_t Caps::GetMaxSegmentSize(DXGI_MEMORY_SEGMENT_GROUP heapSegment) const {
+    uint64_t Caps::GetMaxSegmentSize(RESIDENCY_HEAP_SEGMENT heapSegment) const {
         if (mIsAdapterUMA) {
             return mSharedSegmentSize;
         }
 
         switch (heapSegment) {
-            case DXGI_MEMORY_SEGMENT_GROUP_LOCAL:
+            case RESIDENCY_HEAP_SEGMENT_LOCAL:
                 return mDedicatedSegmentSize;
 
-            case DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL:
+            case RESIDENCY_HEAP_SEGMENT_NON_LOCAL:
                 return mSharedSegmentSize;
 
             default:

--- a/src/gpgmm/d3d12/CapsD3D12.h
+++ b/src/gpgmm/d3d12/CapsD3D12.h
@@ -19,7 +19,7 @@
 #include "gpgmm/d3d12/D3D12Platform.h"
 #include "gpgmm/utils/Limits.h"
 
-#include <cstdint>
+#include <gpgmm_d3d12.h>
 
 namespace gpgmm::d3d12 {
 
@@ -48,7 +48,7 @@ namespace gpgmm::d3d12 {
         // Specifies if a texture and buffer can belong in the same heap.
         D3D12_RESOURCE_HEAP_TIER GetMaxResourceHeapTierSupported() const;
 
-        uint64_t GetMaxSegmentSize(DXGI_MEMORY_SEGMENT_GROUP heapSegment) const;
+        uint64_t GetMaxSegmentSize(RESIDENCY_HEAP_SEGMENT heapSegment) const;
 
       private:
         Caps() = default;

--- a/src/gpgmm/d3d12/ResidencyHeapD3D12.cpp
+++ b/src/gpgmm/d3d12/ResidencyHeapD3D12.cpp
@@ -336,7 +336,7 @@ namespace gpgmm::d3d12 {
         mLastUsedFenceValue = fenceValue;
     }
 
-    DXGI_MEMORY_SEGMENT_GROUP ResidencyHeap::GetMemorySegment() const {
+    RESIDENCY_HEAP_SEGMENT ResidencyHeap::GetMemorySegment() const {
         return mHeapSegment;
     }
 

--- a/src/gpgmm/d3d12/ResidencyHeapD3D12.h
+++ b/src/gpgmm/d3d12/ResidencyHeapD3D12.h
@@ -67,7 +67,7 @@ namespace gpgmm::d3d12 {
         LPCWSTR GetDebugName() const override;
         HRESULT SetDebugName(LPCWSTR Name) override;
 
-        DXGI_MEMORY_SEGMENT_GROUP GetMemorySegment() const;
+        RESIDENCY_HEAP_SEGMENT GetMemorySegment() const;
 
         uint64_t GetLastUsedFenceValue() const;
         void SetLastUsedFenceValue(uint64_t fenceValue);
@@ -98,7 +98,7 @@ namespace gpgmm::d3d12 {
         ComPtr<ResidencyManager> mResidencyManager;
         ComPtr<ID3D12Pageable> mPageable;
 
-        DXGI_MEMORY_SEGMENT_GROUP mHeapSegment;
+        RESIDENCY_HEAP_SEGMENT mHeapSegment;
         RefCounted mResidencyLockCount;
 
         // Protects thread-access to the mutable members below.

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.cpp
@@ -102,10 +102,10 @@ namespace gpgmm::d3d12 {
         GPGMM_RETURN_IF_FAILED(residencyManager->UpdateMemorySegments());
 
         DXGI_QUERY_VIDEO_MEMORY_INFO* localVideoMemorySegmentInfo =
-            residencyManager->GetVideoMemoryInfo(DXGI_MEMORY_SEGMENT_GROUP_LOCAL);
+            residencyManager->GetVideoMemoryInfo(RESIDENCY_HEAP_SEGMENT_LOCAL);
 
         DXGI_QUERY_VIDEO_MEMORY_INFO* nonLocalVideoMemorySegmentInfo =
-            residencyManager->GetVideoMemoryInfo(DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL);
+            residencyManager->GetVideoMemoryInfo(RESIDENCY_HEAP_SEGMENT_NON_LOCAL);
 
         // D3D12 has non-zero memory usage even before any resources have been created, and this
         // value can vary by OS enviroment. By adding this in addition to the artificial budget
@@ -124,13 +124,13 @@ namespace gpgmm::d3d12 {
         if (localVideoMemorySegmentInfo->Budget == 0) {
             WarnLog(MessageId::kBudgetUpdated, residencyManager.get())
                 << "GPU memory segment ("
-                << GetMemorySegmentName(DXGI_MEMORY_SEGMENT_GROUP_LOCAL, residencyManager->mIsUMA)
+                << GetMemorySegmentName(RESIDENCY_HEAP_SEGMENT_LOCAL, residencyManager->mIsUMA)
                 << ") did not initialize a budget. This means either a restricted budget was not "
                    "used or the first OS budget update hasn't occured.";
             if (!residencyManager->mIsUMA && nonLocalVideoMemorySegmentInfo->Budget == 0) {
                 WarnLog(MessageId::kBudgetUpdated, residencyManager.get())
                     << "GPU memory segment ("
-                    << GetMemorySegmentName(DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL,
+                    << GetMemorySegmentName(RESIDENCY_HEAP_SEGMENT_NON_LOCAL,
                                             residencyManager->mIsUMA)
                     << ") did not initialize a budget. This means either a "
                        "restricted budget was not "
@@ -139,9 +139,9 @@ namespace gpgmm::d3d12 {
         }
 
         // Dump out the initialized memory segment status.
-        residencyManager->ReportSegmentInfoForTesting(DXGI_MEMORY_SEGMENT_GROUP_LOCAL);
+        residencyManager->ReportSegmentInfoForTesting(RESIDENCY_HEAP_SEGMENT_LOCAL);
         if (!residencyManager->mIsUMA) {
-            residencyManager->ReportSegmentInfoForTesting(DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL);
+            residencyManager->ReportSegmentInfoForTesting(RESIDENCY_HEAP_SEGMENT_NON_LOCAL);
         }
 
         GPGMM_TRACE_EVENT_OBJECT_SNAPSHOT(residencyManager.get(), descriptor);
@@ -298,11 +298,11 @@ namespace gpgmm::d3d12 {
     }
 
     DXGI_QUERY_VIDEO_MEMORY_INFO* ResidencyManager::GetVideoMemoryInfo(
-        const DXGI_MEMORY_SEGMENT_GROUP& heapSegment) {
+        const RESIDENCY_HEAP_SEGMENT& heapSegment) {
         switch (heapSegment) {
-            case DXGI_MEMORY_SEGMENT_GROUP_LOCAL:
+            case RESIDENCY_HEAP_SEGMENT_LOCAL:
                 return &mLocalVideoMemorySegment.Info;
-            case DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL:
+            case RESIDENCY_HEAP_SEGMENT_NON_LOCAL:
                 return &mNonLocalVideoMemorySegment.Info;
             default:
                 UNREACHABLE();
@@ -311,11 +311,11 @@ namespace gpgmm::d3d12 {
     }
 
     ResidencyManager::LRUCache* ResidencyManager::GetVideoMemorySegmentCache(
-        const DXGI_MEMORY_SEGMENT_GROUP& heapSegment) {
+        const RESIDENCY_HEAP_SEGMENT& heapSegment) {
         switch (heapSegment) {
-            case DXGI_MEMORY_SEGMENT_GROUP_LOCAL:
+            case RESIDENCY_HEAP_SEGMENT_LOCAL:
                 return &mLocalVideoMemorySegment.cache;
-            case DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL:
+            case RESIDENCY_HEAP_SEGMENT_NON_LOCAL:
                 return &mNonLocalVideoMemorySegment.cache;
             default:
                 UNREACHABLE();
@@ -326,12 +326,11 @@ namespace gpgmm::d3d12 {
     // Sends the minimum required physical video memory for an application, to this residency
     // manager. Returns the amount of memory reserved, which may be less then the |reservation| when
     // under video memory pressure.
-    HRESULT ResidencyManager::SetVideoMemoryReservation(
-        const DXGI_MEMORY_SEGMENT_GROUP& heapSegment,
-        uint64_t availableForReservation,
-        uint64_t* pCurrentReservationOut) {
+    HRESULT ResidencyManager::SetVideoMemoryReservation(const RESIDENCY_HEAP_SEGMENT& heapSegment,
+                                                        uint64_t availableForReservation,
+                                                        uint64_t* pCurrentReservationOut) {
         GPGMM_TRACE_EVENT_DURATION(TraceEventCategory::kDefault,
-                                   "ResidencyManager.SetVideoMemoryReservation");
+                                   "ResidencyManager.SetMemoryReservation");
 
         std::lock_guard<std::mutex> lock(mMutex);
 
@@ -351,15 +350,18 @@ namespace gpgmm::d3d12 {
     }
 
     HRESULT ResidencyManager::UpdateMemorySegmentInternal(
-        const DXGI_MEMORY_SEGMENT_GROUP& heapSegment) {
+        const RESIDENCY_HEAP_SEGMENT& heapSegment) {
         // For UMA adapters, non-local is always zero.
-        if (mIsUMA && heapSegment == DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL) {
+        if (mIsUMA && heapSegment == RESIDENCY_HEAP_SEGMENT_NON_LOCAL) {
             return S_OK;
         }
 
+        // Residency heap segments are 1:1 with DXGI memory segment groups.
         DXGI_QUERY_VIDEO_MEMORY_INFO queryVideoMemoryInfoOut;
         GPGMM_RETURN_IF_FAILED(
-            mAdapter->QueryVideoMemoryInfo(0, heapSegment, &queryVideoMemoryInfoOut), mDevice);
+            mAdapter->QueryVideoMemoryInfo(0, static_cast<DXGI_MEMORY_SEGMENT_GROUP>(heapSegment),
+                                           &queryVideoMemoryInfoOut),
+            mDevice);
 
         // The video memory budget provided by QueryVideoMemoryInfo is defined by the operating
         // system, and may be lower than expected in certain scenarios. Under memory pressure, we
@@ -466,13 +468,13 @@ namespace gpgmm::d3d12 {
 
     HRESULT ResidencyManager::UpdateMemorySegments() {
         std::lock_guard<std::mutex> lock(mMutex);
-        GPGMM_RETURN_IF_FAILED(UpdateMemorySegmentInternal(DXGI_MEMORY_SEGMENT_GROUP_LOCAL));
-        GPGMM_RETURN_IF_FAILED(UpdateMemorySegmentInternal(DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL));
+        GPGMM_RETURN_IF_FAILED(UpdateMemorySegmentInternal(RESIDENCY_HEAP_SEGMENT_LOCAL));
+        GPGMM_RETURN_IF_FAILED(UpdateMemorySegmentInternal(RESIDENCY_HEAP_SEGMENT_NON_LOCAL));
         return S_OK;
     }
 
     HRESULT ResidencyManager::QueryVideoMemoryInfo(
-        const DXGI_MEMORY_SEGMENT_GROUP& heapSegment,
+        const RESIDENCY_HEAP_SEGMENT& heapSegment,
         DXGI_QUERY_VIDEO_MEMORY_INFO* pVideoMemoryInfoOut) {
         std::lock_guard<std::mutex> lock(mMutex);
         if (IsBudgetNotificationUpdatesDisabled()) {
@@ -489,7 +491,7 @@ namespace gpgmm::d3d12 {
     // Evicts |evictSizeInBytes| bytes of memory in |heapSegment| and returns the number of
     // bytes evicted.
     HRESULT ResidencyManager::EvictInternal(uint64_t bytesToEvict,
-                                            const DXGI_MEMORY_SEGMENT_GROUP& heapSegment,
+                                            const RESIDENCY_HEAP_SEGMENT& heapSegment,
                                             uint64_t* bytesEvictedOut) {
         GPGMM_TRACE_EVENT_DURATION(TraceEventCategory::kDefault, "ResidencyManager.Evict");
 
@@ -503,7 +505,7 @@ namespace gpgmm::d3d12 {
         if (pVideoMemoryInfo->Budget == 0) {
             WarnEvent(MessageId::kBudgetExceeded, this)
                 << "GPU memory segment ("
-                << GetMemorySegmentName(DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL, IsUMA())
+                << GetMemorySegmentName(RESIDENCY_HEAP_SEGMENT_NON_LOCAL, IsUMA())
                 << ") was unable to evict memory because a budget was not specified.";
             return S_FALSE;
         }
@@ -646,7 +648,7 @@ namespace gpgmm::d3d12 {
                 ComPtr<ID3D12Pageable> pageable;
                 GPGMM_RETURN_IF_FAILED(backendHeap->QueryInterface(IID_PPV_ARGS(&pageable)));
 
-                if (backendHeap->GetMemorySegment() == DXGI_MEMORY_SEGMENT_GROUP_LOCAL) {
+                if (backendHeap->GetMemorySegment() == RESIDENCY_HEAP_SEGMENT_LOCAL) {
                     localSizeToMakeResident += backendHeap->GetSize();
                     localHeapsToMakeResident.push_back(pageable.Get());
                 } else {
@@ -683,13 +685,13 @@ namespace gpgmm::d3d12 {
             const uint32_t numberOfObjectsToMakeResident =
                 static_cast<uint32_t>(localHeapsToMakeResident.size());
             GPGMM_RETURN_IF_FAILED(
-                MakeResident(DXGI_MEMORY_SEGMENT_GROUP_LOCAL, localSizeToMakeResident,
+                MakeResident(RESIDENCY_HEAP_SEGMENT_LOCAL, localSizeToMakeResident,
                              numberOfObjectsToMakeResident, localHeapsToMakeResident.data()));
         } else if (nonLocalSizeToMakeResident > 0) {
             const uint32_t numberOfObjectsToMakeResident =
                 static_cast<uint32_t>(nonLocalHeapsToMakeResident.size());
             GPGMM_RETURN_IF_FAILED(
-                MakeResident(DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL, nonLocalSizeToMakeResident,
+                MakeResident(RESIDENCY_HEAP_SEGMENT_NON_LOCAL, nonLocalSizeToMakeResident,
                              numberOfObjectsToMakeResident, nonLocalHeapsToMakeResident.data()));
         }
 
@@ -719,9 +721,8 @@ namespace gpgmm::d3d12 {
         // never changes (ie. not manually updated or through budget change events), the
         // residency manager wouldn't know what to page in or out.
         if (IsBudgetNotificationUpdatesDisabled()) {
-            GPGMM_RETURN_IF_FAILED(UpdateMemorySegmentInternal(DXGI_MEMORY_SEGMENT_GROUP_LOCAL));
-            GPGMM_RETURN_IF_FAILED(
-                UpdateMemorySegmentInternal(DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL));
+            GPGMM_RETURN_IF_FAILED(UpdateMemorySegmentInternal(RESIDENCY_HEAP_SEGMENT_LOCAL));
+            GPGMM_RETURN_IF_FAILED(UpdateMemorySegmentInternal(RESIDENCY_HEAP_SEGMENT_NON_LOCAL));
         }
 
         GPGMM_TRACE_EVENT_OBJECT_CALL(
@@ -731,7 +732,7 @@ namespace gpgmm::d3d12 {
         return S_OK;
     }
 
-    HRESULT ResidencyManager::MakeResident(const DXGI_MEMORY_SEGMENT_GROUP heapSegment,
+    HRESULT ResidencyManager::MakeResident(const RESIDENCY_HEAP_SEGMENT heapSegment,
                                            uint64_t sizeToMakeResident,
                                            uint32_t numberOfObjectsToMakeResident,
                                            ID3D12Pageable** allocations) {
@@ -857,7 +858,7 @@ namespace gpgmm::d3d12 {
         return mIsUMA;
     }
 
-    void ResidencyManager::ReportSegmentInfoForTesting(DXGI_MEMORY_SEGMENT_GROUP segmentGroup) {
+    void ResidencyManager::ReportSegmentInfoForTesting(RESIDENCY_HEAP_SEGMENT segmentGroup) {
         DXGI_QUERY_VIDEO_MEMORY_INFO* info = GetVideoMemoryInfo(segmentGroup);
         ASSERT(info != nullptr);
 

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.h
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.h
@@ -55,11 +55,11 @@ namespace gpgmm::d3d12 {
                                     IResidencyList* const* ppResidencyLists,
                                     uint32_t count) override;
 
-        HRESULT SetVideoMemoryReservation(const DXGI_MEMORY_SEGMENT_GROUP& heapSegment,
+        HRESULT SetVideoMemoryReservation(const RESIDENCY_HEAP_SEGMENT& heapSegment,
                                           uint64_t availableForReservation,
                                           uint64_t* pCurrentReservationOut = nullptr) override;
 
-        HRESULT QueryVideoMemoryInfo(const DXGI_MEMORY_SEGMENT_GROUP& heapSegment,
+        HRESULT QueryVideoMemoryInfo(const RESIDENCY_HEAP_SEGMENT& heapSegment,
                                      DXGI_QUERY_VIDEO_MEMORY_INFO* pVideoMemoryInfoOut) override;
         HRESULT SetResidencyStatus(IResidencyHeap* pHeap,
                                    const RESIDENCY_HEAP_STATUS& newStatus) override;
@@ -89,7 +89,7 @@ namespace gpgmm::d3d12 {
         void DeleteThis() override;
 
         HRESULT EvictInternal(uint64_t bytesToEvict,
-                              const DXGI_MEMORY_SEGMENT_GROUP& heapSegment,
+                              const RESIDENCY_HEAP_SEGMENT& heapSegment,
                               uint64_t* bytesEvictedOut = nullptr);
 
         HRESULT InsertHeap(ResidencyHeap* heap);
@@ -113,24 +113,23 @@ namespace gpgmm::d3d12 {
             DXGI_QUERY_VIDEO_MEMORY_INFO Info = {};
         };
 
-        HRESULT MakeResident(const DXGI_MEMORY_SEGMENT_GROUP heapSegment,
+        HRESULT MakeResident(const RESIDENCY_HEAP_SEGMENT heapSegment,
                              uint64_t sizeToMakeResident,
                              uint32_t numberOfObjectsToMakeResident,
                              ID3D12Pageable** allocations);
 
-        LRUCache* GetVideoMemorySegmentCache(const DXGI_MEMORY_SEGMENT_GROUP& heapSegment);
+        LRUCache* GetVideoMemorySegmentCache(const RESIDENCY_HEAP_SEGMENT& heapSegment);
 
-        DXGI_QUERY_VIDEO_MEMORY_INFO* GetVideoMemoryInfo(
-            const DXGI_MEMORY_SEGMENT_GROUP& heapSegment);
+        DXGI_QUERY_VIDEO_MEMORY_INFO* GetVideoMemoryInfo(const RESIDENCY_HEAP_SEGMENT& heapSegment);
 
-        HRESULT UpdateMemorySegmentInternal(const DXGI_MEMORY_SEGMENT_GROUP& heapSegment);
+        HRESULT UpdateMemorySegmentInternal(const RESIDENCY_HEAP_SEGMENT& heapSegment);
 
         HRESULT StartBudgetNotificationUpdates();
         void StopBudgetNotificationUpdates();
 
         bool IsBudgetNotificationUpdatesDisabled() const;
 
-        void ReportSegmentInfoForTesting(DXGI_MEMORY_SEGMENT_GROUP segmentGroup);
+        void ReportSegmentInfoForTesting(RESIDENCY_HEAP_SEGMENT segmentGroup);
 
         HRESULT EnsureResidencyFenceExists();
 

--- a/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
+++ b/src/gpgmm/d3d12/ResourceAllocatorD3D12.cpp
@@ -1288,7 +1288,7 @@ namespace gpgmm::d3d12 {
         // allocation-time, it must be set here and again, when a resource heap is created.
         heapProperties.MemoryPoolPreference = GetMemoryPool(heapProperties, isUMA);
 
-        const DXGI_MEMORY_SEGMENT_GROUP heapSegment =
+        const RESIDENCY_HEAP_SEGMENT heapSegment =
             GetMemorySegment(heapProperties.MemoryPoolPreference, isUMA);
 
         const uint64_t maxSegmentSize = mCaps->GetMaxSegmentSize(heapSegment);

--- a/src/gpgmm/d3d12/UtilsD3D12.cpp
+++ b/src/gpgmm/d3d12/UtilsD3D12.cpp
@@ -437,28 +437,28 @@ namespace gpgmm::d3d12 {
         return object->SetName(name);
     }
 
-    DXGI_MEMORY_SEGMENT_GROUP GetMemorySegment(D3D12_MEMORY_POOL memoryPool, bool isUMA) {
+    RESIDENCY_HEAP_SEGMENT GetMemorySegment(D3D12_MEMORY_POOL memoryPool, bool isUMA) {
         if (isUMA) {
-            return DXGI_MEMORY_SEGMENT_GROUP_LOCAL;
+            return RESIDENCY_HEAP_SEGMENT_LOCAL;
         }
 
         if (memoryPool == D3D12_MEMORY_POOL_L1) {
-            return DXGI_MEMORY_SEGMENT_GROUP_LOCAL;
+            return RESIDENCY_HEAP_SEGMENT_LOCAL;
         }
 
-        return DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL;
+        return RESIDENCY_HEAP_SEGMENT_NON_LOCAL;
     }
 
-    const char* GetMemorySegmentName(DXGI_MEMORY_SEGMENT_GROUP heapSegment, bool isUMA) {
+    const char* GetMemorySegmentName(RESIDENCY_HEAP_SEGMENT heapSegment, bool isUMA) {
         if (isUMA) {
             return "Shared";
         }
 
         switch (heapSegment) {
-            case DXGI_MEMORY_SEGMENT_GROUP_LOCAL:
+            case RESIDENCY_HEAP_SEGMENT_LOCAL:
                 return "Dedicated";
 
-            case DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL:
+            case RESIDENCY_HEAP_SEGMENT_NON_LOCAL:
                 return "Shared";
 
             default:

--- a/src/gpgmm/d3d12/UtilsD3D12.h
+++ b/src/gpgmm/d3d12/UtilsD3D12.h
@@ -17,14 +17,16 @@
 #include "gpgmm/common/Message.h"
 #include "gpgmm/d3d12/D3D12Platform.h"
 
+#include <gpgmm_d3d12.h>
+
 namespace gpgmm::d3d12 {
 
     MessageSeverity GetMessageSeverity(D3D12_MESSAGE_SEVERITY messageSeverity);
     bool IsDepthFormat(DXGI_FORMAT format);
     bool IsAllowedToUseSmallAlignment(const D3D12_RESOURCE_DESC& Desc);
     HRESULT SetDebugObjectName(ID3D12Object* object, LPCWSTR name);
-    DXGI_MEMORY_SEGMENT_GROUP GetMemorySegment(D3D12_MEMORY_POOL memoryPool, bool isUMA);
-    const char* GetMemorySegmentName(DXGI_MEMORY_SEGMENT_GROUP heapSegment, bool isUMA);
+    RESIDENCY_HEAP_SEGMENT GetMemorySegment(D3D12_MEMORY_POOL memoryPool, bool isUMA);
+    const char* GetMemorySegmentName(RESIDENCY_HEAP_SEGMENT heapSegment, bool isUMA);
     ComPtr<ID3D12Device> GetDevice(ID3D12DeviceChild* pDeviceChild);
     bool IsTexture(const D3D12_RESOURCE_DESC& resourceDescriptor);
     bool IsBuffer(const D3D12_RESOURCE_DESC& resourceDescriptor);

--- a/src/tests/end2end/D3D12ResidencyManagerTests.cpp
+++ b/src/tests/end2end/D3D12ResidencyManagerTests.cpp
@@ -80,14 +80,14 @@ class D3D12ResidencyManagerTests : public D3D12TestBase, public ::testing::Test 
     }
 
     uint64_t GetBudgetLeft(IResidencyManager* residencyManager,
-                           const DXGI_MEMORY_SEGMENT_GROUP& heapSegment) {
+                           const RESIDENCY_HEAP_SEGMENT& heapSegment) {
         DXGI_QUERY_VIDEO_MEMORY_INFO segment = {};
         residencyManager->QueryVideoMemoryInfo(heapSegment, &segment);
         return (segment.Budget > segment.CurrentUsage) ? (segment.Budget - segment.CurrentUsage)
                                                        : 0;
     }
 
-    DXGI_MEMORY_SEGMENT_GROUP GetMemorySegment(D3D12_HEAP_TYPE heapType) const {
+    RESIDENCY_HEAP_SEGMENT GetMemorySegment(D3D12_HEAP_TYPE heapType) const {
         D3D12_HEAP_PROPERTIES heapProperties = mDevice->GetCustomHeapProperties(0, heapType);
         return ::GetMemorySegment(heapProperties.MemoryPoolPreference, mCaps->IsAdapterUMA());
     }
@@ -153,7 +153,7 @@ TEST_F(D3D12ResidencyManagerTests, CreateResourceHeapNotResident) {
 
     RESIDENCY_HEAP_DESC resourceHeapInBudgetDesc = {};
     resourceHeapInBudgetDesc.SizeInBytes = kHeapSize;
-    resourceHeapInBudgetDesc.HeapSegment = DXGI_MEMORY_SEGMENT_GROUP_LOCAL;
+    resourceHeapInBudgetDesc.HeapSegment = RESIDENCY_HEAP_SEGMENT_LOCAL;
     resourceHeapInBudgetDesc.Flags |= RESIDENCY_HEAP_FLAG_CREATE_IN_BUDGET;
 
     D3D12_HEAP_DESC heapDesc = {};
@@ -178,7 +178,7 @@ TEST_F(D3D12ResidencyManagerTests, CreateResourceHeapLocked) {
     D3D12_HEAP_DESC heapDesc = GetBasicHeapDesc(GPGMM_MB_TO_BYTES(10), D3D12_HEAP_TYPE_DEFAULT);
 
     RESIDENCY_HEAP_DESC residencyHeapDesc = {};
-    residencyHeapDesc.HeapSegment = DXGI_MEMORY_SEGMENT_GROUP_LOCAL;
+    residencyHeapDesc.HeapSegment = RESIDENCY_HEAP_SEGMENT_LOCAL;
 
     CreateResourceHeapCallbackContext createHeapContext(mDevice.Get(), &heapDesc);
 
@@ -231,7 +231,7 @@ TEST_F(D3D12ResidencyManagerTests, CreateResourceHeap) {
     heapDesc.Flags |= D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS;
 
     RESIDENCY_HEAP_DESC residencyHeapDesc = {};
-    residencyHeapDesc.HeapSegment = DXGI_MEMORY_SEGMENT_GROUP_LOCAL;
+    residencyHeapDesc.HeapSegment = RESIDENCY_HEAP_SEGMENT_LOCAL;
 
     {
         BadCreateHeapCallbackContext badCreateHeapCallbackContext;
@@ -366,7 +366,7 @@ TEST_F(D3D12ResidencyManagerTests, CreateDescriptorHeap) {
     RESIDENCY_HEAP_DESC descriptorHeapDesc = {};
     descriptorHeapDesc.SizeInBytes =
         heapDesc.NumDescriptors * mDevice->GetDescriptorHandleIncrementSize(heapDesc.Type);
-    descriptorHeapDesc.HeapSegment = DXGI_MEMORY_SEGMENT_GROUP_LOCAL;
+    descriptorHeapDesc.HeapSegment = RESIDENCY_HEAP_SEGMENT_LOCAL;
 
     CreateDescHeapCallbackContext createDescHeapCallbackContext(mDevice.Get(), heapDesc);
 
@@ -420,7 +420,7 @@ TEST_F(D3D12ResidencyManagerTests, CreateDescriptorHeapResident) {
     RESIDENCY_HEAP_DESC descriptorHeapDesc = {};
     descriptorHeapDesc.SizeInBytes =
         heapDesc.NumDescriptors * mDevice->GetDescriptorHandleIncrementSize(heapDesc.Type);
-    descriptorHeapDesc.HeapSegment = DXGI_MEMORY_SEGMENT_GROUP_LOCAL;
+    descriptorHeapDesc.HeapSegment = RESIDENCY_HEAP_SEGMENT_LOCAL;
     descriptorHeapDesc.Flags |= RESIDENCY_HEAP_FLAG_CREATE_RESIDENT;
 
     CreateDescHeapCallbackContext createDescHeapCallbackContext(mDevice.Get(), heapDesc);
@@ -720,7 +720,7 @@ TEST_F(D3D12ResidencyManagerTests, OverBudgetAsync) {
     RESOURCE_ALLOCATION_DESC bufferAllocationDesc = {};
     bufferAllocationDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
 
-    const DXGI_MEMORY_SEGMENT_GROUP bufferMemorySegment =
+    const RESIDENCY_HEAP_SEGMENT bufferMemorySegment =
         GetMemorySegment(bufferAllocationDesc.HeapType);
 
     const uint64_t memoryUnderBudget = GetBudgetLeft(residencyManager.Get(), bufferMemorySegment);


### PR DESCRIPTION
Requires use of a segment agnostic type instead of a DXGI specific one.

Issue: #683