### PR TITLE
Remove DXGI header from GPGMM D3D12 header.

### DIFF
--- a/include/gpgmm_d3d12.h
+++ b/include/gpgmm_d3d12.h
@@ -35,7 +35,6 @@
 
 #ifndef GPGMM_D3D12_HEADERS_ALREADY_INCLUDED
 #    include <d3d12.h>
-#    include <dxgi1_4.h>
 #endif  // defined(GPGMM_D3D12_HEADERS_ALREADY_INCLUDED)
 
 #ifndef GPGMM_WINDOWS_HEADERS_ALREADY_INCLUDED
@@ -690,12 +689,14 @@ namespace gpgmm::d3d12 {
 
     /** \brief  Create residency residency manager to manage memory.
 
+    Adapter requires DXGI 1.4 due to IDXGIAdapter3::QueryMemoryInfo. Use EnumAdapters to get the
+    IDXGIAdapter3.
+
     @param descriptor A reference to RESIDENCY_MANAGER_DESC structure that describes the residency
     manager.
     @param pDevice device used by this allocator. Required parameter. Use CreateDevice get the
     device.
-    @param pAdapter DXGI adapter used to create the device.  Requires DXGI 1.4 due to
-    IDXGIAdapter3::QueryMemoryInfo. Use EnumAdapters to get the adapter.
+    @param pAdapter Adapter used to create the device.
     @param[out] ppResidencyManagerOut Pointer to a memory block that receives a pointer to the
     residency manager. Pass NULL to test if residency Manager creation would succeed, but not
     actually create the residency Manager. If NULL is passed and residency manager creating
@@ -1449,14 +1450,12 @@ namespace gpgmm::d3d12 {
 
     /** \brief Create a resource allocator with residency.
 
-    Residency requires at-least DXGI version 1.4.
-
     @param allocatorDescriptor A reference to RESOURCE_ALLOCATOR_DESC structure that describes the
     allocator.
     @param pDevice device used by this allocator. Required parameter. Use CreateDevice get the
     device.
-    @param pAdapter DXGI adapter used to create the device. Used to detect for additional device
-    capabilities (by GPU vendor). Optional parameter. Use EnumAdapters to get the adapter.
+    @param pAdapter adapter used to create the device. Used to detect for additional device
+    capabilities (by vendor). Optional parameter.
     @param[out] ppResourceAllocatorOut Pointer to a memory block that receives a pointer to the
     resource allocator. Pass NULL to test if allocator creation would succeed, but not actually
     create the allocator.
@@ -1476,8 +1475,8 @@ namespace gpgmm::d3d12 {
     allocator.
     @param pDevice device used by this allocator. Required parameter. Use CreateDevice get the
     device.
-    @param pAdapter DXGI adapter used to create the device. Used to detect for additional device
-    capabilities (by GPU vendor). Optional parameter. Use EnumAdapters to get the adapter.
+    @param pAdapter adapter used to create the device. Used to detect for additional device
+    capabilities (by vendor). Optional parameter.
     @param pResidencyManager Pointer to a memory block that receives a pointer to the
     residency manager.
     @param[out] ppResourceAllocatorOut Pointer to a memory block that receives a pointer to the

--- a/src/fuzzers/D3D12Fuzzer.h
+++ b/src/fuzzers/D3D12Fuzzer.h
@@ -17,6 +17,7 @@
 
 #include <gpgmm_d3d12.h>
 
+#include <dxgi1_4.h>
 #include <wrl.h>
 #include <cstdint>
 

--- a/src/gpgmm/d3d12/CapsD3D12.cpp
+++ b/src/gpgmm/d3d12/CapsD3D12.cpp
@@ -21,6 +21,7 @@
 #include "gpgmm/utils/Utils.h"
 #include "gpgmm/utils/WindowsUtils.h"
 
+#include <dxgi.h>
 #include <memory>
 
 namespace gpgmm::d3d12 {

--- a/src/gpgmm/d3d12/D3D12Platform.h
+++ b/src/gpgmm/d3d12/D3D12Platform.h
@@ -17,7 +17,6 @@
 #define SRC_GPGMM_D3D12_D3D12PLATFORM_H_
 
 #include <d3d12.h>
-#include <dxgi1_4.h>
 #include <wrl.h>
 
 // Keep backwards compatibility when using D3D12 feature flags that are only defined in a newer

--- a/src/gpgmm/d3d12/ResidencyManagerD3D12.h
+++ b/src/gpgmm/d3d12/ResidencyManagerD3D12.h
@@ -21,6 +21,7 @@
 #include "gpgmm/utils/EnumFlags.h"
 #include "gpgmm/utils/LinkedList.h"
 
+#include <dxgi1_4.h>
 #include <gpgmm_d3d12.h>
 
 #include <memory>

--- a/src/tests/D3D12Test.h
+++ b/src/tests/D3D12Test.h
@@ -21,6 +21,7 @@
 #include <string>
 #include <vector>
 
+#include <dxgi1_4.h>
 #include <gpgmm_d3d12.h>
 
 #include "gpgmm/d3d12/D3D12Platform.h"


### PR DESCRIPTION
Allows use of GPGMM D3D12 API without DXGI adapter.

Issue: #683